### PR TITLE
feat(catalog): add skilldrop to the skill index

### DIFF
--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -504,6 +504,15 @@
       "description": "end to end app store screenshot creation using AI",
       "maintainer": "@ParthJadhav",
       "enabled": true
+    },
+    {
+      "source": "github:sananthanarayan/skilldrop",
+      "url": "https://github.com/sananthanarayan/skilldrop",
+      "owner": "sananthanarayan",
+      "repo": "skilldrop",
+      "description": "51 curated skills for the deliverables knowledge workers ship — ADRs, design docs, PRDs, runbooks, decks, threat models, journey maps, adversarial reviews — plus 3 reviewer subagents and 6 role-based packs. Conforms to the Agent Skills standard; every skill is machine-validated (name/description sync, reference + link integrity, model tier).",
+      "maintainer": "@sananthanarayan",
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
Adds [**skilldrop**](https://github.com/sananthanarayan/skilldrop) as a catalog source — one entry appended to `data/skill-index-resources.json` (purely additive; no other lines touched).

### What it is
A curated catalog of **51 skills** for the deliverables knowledge workers ship — ADRs, design docs, PRDs, runbooks, decks, threat models, journey maps, OKR cascades, adversarial code/doc reviews — plus **3 reviewer subagents** (`devils-advocate`, `security-reviewer`, `code-quality`) and **6 role-based packs**. It leans toward *knowledge-work* artifacts rather than code-only skills, so it should complement what's already indexed.

### Compatibility with the indexer
- **Layout:** canonical `skills/<name>/SKILL.md` — discovered by `scanner.ts` with no special handling.
- **Frontmatter:** every skill has the required `name` + `description`; conforms to the Agent Skills standard.
- **Quality:** all 51 are machine-validated in CI (`validate.py`) — name triple-match across folder/frontmatter/manifest, description sync, reference + link integrity, model tier, and pack membership. Judgment-heavy skills additionally ship a worked-example oracle.
- **Safety:** MIT, zero runtime dependencies, no telemetry. Only 3 skills ship executable scripts (each with a pinned `requirements.txt`); the rest are prose.

Happy to adjust the description or set `enabled: false` initially if you'd rather stage it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)