### PR TITLE
feat(skills): add skill-install-improved for improve-then-install (#418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add the `skill-install-improved` bundled skill — installs an improved variant of one skill instead of the published one: resolves the target by local path, repo, or skill name, runs `skill-auto-improver` on a throwaway `mktemp -d` copy so the user's own files are never modified, installs the improved directory, and reports the before/after scores and the provenance it was improved from ([#418](https://github.com/luongnv89/asm/issues/418)) — @luongnv89
+
 ## v2.15.0 — 2026-07-22
 
 ### Features

--- a/skills/skill-install-improved/SKILL.md
+++ b/skills/skill-install-improved/SKILL.md
@@ -94,11 +94,11 @@ asm list --json    # probe: is this skill already installed for $TOOL / $SCOPE?
 ```
 
 - **Neither name matches** — install; nothing is touched.
-- **Frontmatter `name` matches for `$TOOL`** — the target directory is deleted and replaced. Name the existing entry's `path` and the source it came from, and get **explicit confirmation before running `asm install`**. There is no failure to fall back on once it is invoked.
+- **Frontmatter `name` matches for `$TOOL`** — force is set, even if that entry sits in another scope. What gets deleted is the **target** directory (`$SKILL_PATH`'s basename, or `alt`, under the install base for `$TOOL`/`$SCOPE`), which need not be the matched entry's `path`. Name that target path and whatever the probe shows there, and get **explicit confirmation before running `asm install`**. There is no failure to fall back on once it is invoked.
 - **Only the directory name matches** — no delete, but the copy still **merges into** the existing directory: colliding files are overwritten and the previous occupant's other files survive inside the installed skill. Confirm this one too.
-- **Opt-out** — `--name <alt>` installs side by side, on request only. Warn first: both then share one frontmatter `name` and identical triggers, the duplicate-trigger hazard the ASM auditor flags.
+- **Opt-out** — `--name <alt>` installs side by side, on request only. It does not suppress force, so anything already at `<base>/<alt>` is deleted and replaced; check `alt` against the probe. Warn first: both then share one frontmatter `name` and identical triggers, the duplicate-trigger hazard the ASM auditor flags.
 
-Two names decide the outcome and they can differ: ASM triggers the overwrite from the frontmatter `name` plus the selected tool (scope is not part of that match), but the directory it deletes is named after `$SKILL_PATH`'s basename. Check the probe output for both.
+Both names come out of the same probe: the frontmatter `name` plus `$TOOL` decides whether force is set, the target directory name decides what is destroyed.
 
 Only once the probe is read and any collision above is confirmed:
 
@@ -178,7 +178,7 @@ Use `√` for pass, `×` for fail, `—` for context. Checks per phase:
 - **Several `SKILL.md` files in a clone** — enumerate and ask. Never batch, never guess.
 - **`asm search` returns nothing, or several equally-plausible matches** — show the candidates and ask; never install the first hit.
 - **Target has no frontmatter** — `asm eval --fix` cannot add it. Report and stop; do not install an unimprovable skill as if it were improved.
-- **Collision is a same-named skill from another source** — the install would silently replace someone else's skill, with no error and no prompt. The probe is the only chance to catch it: name the path and its source, confirm, and offer `--name <alt>` — all before `asm install` runs.
+- **Collision is a same-named skill from another source** — the install would silently replace someone else's skill, with no error and no prompt. The probe is the only chance to catch it: name the target directory and whatever the probe shows there (`name`, `dirName`, `provider`, `scope`), confirm, and offer `--name <alt>` — all before `asm install` runs.
 - **Temp dir removed before harvesting** — the metrics are gone and the before/after criterion cannot be met. Harvest in Phase 2, always before cleanup.
 - **Clone or disk failure mid-resolve** — stop, remove `$WORK`, report. Never install a partial checkout.
 

--- a/skills/skill-install-improved/SKILL.md
+++ b/skills/skill-install-improved/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: skill-install-improved
+description: "Install an improved variant of one named skill: resolve it by local path, repo, or name, run skill-auto-improver on a throwaway copy, then install the improved result. Don't use for improving in place, upstream PRs, or plain asm install."
+license: MIT
+compatibility: "Claude Code; requires `asm` and `git` on PATH"
+allowed-tools: Bash Read Write Edit Grep Glob
+effort: high
+metadata:
+  version: 1.0.0
+  author: luongnv89
+---
+
+# Skill Install Improved
+
+You install an **improved** variant of one skill instead of the skill as published: resolve the target to a local directory → run `skill-auto-improver` on it → install the improved result → report what was improved and from what. The improvement is a step inside the install, not a separate errand. One skill per run.
+
+## When to Use
+
+- The user says "install `<skill>` but improve it first" or "install an improved version of `<skill>`"
+- The user points at a catalog skill below the 85/8 floor and wants the better version on their machine
+- The user has a local or cloned skill directory and wants the improved variant installed, not the raw one
+
+Do **not** trigger for: improving without installing (`skill-auto-improver`), contributing upstream (`skill-upstream-pr`), authoring from scratch (`skill-creator`), plain installs (`asm install <source>`), or bulk-improving many skills at once.
+
+## Prerequisites
+
+Verify each before resolving anything. Stop and tell the user if any fails.
+
+- `asm` and `git` on PATH
+- Python 3 and `~/.claude/skills/skill-creator/scripts/quick_validate.py` — `skill-auto-improver` requires it
+- Network access to GitHub, for the repo and name forms
+- Write access to the install target (`~/.claude/skills/` global, `.claude/skills/` project)
+
+### The user's own files are never modified (design decision)
+
+**Every input form is improved on a throwaway copy under `$(mktemp -d)` — local paths included.** Deliberate: an install that rewrites the user's working copy is a side effect they did not ask for, `skill-auto-improver` mandates `git fetch` + `git pull --rebase` before any edit (against a local path that rebases their branch), and copying makes all forms behave identically.
+
+**Trade-off:** the improvement lands only in the installed copy, not the user's tree. The copy has no `origin` and no history, so the improver's mandatory repo sync is **inapplicable** and is skipped — nothing to clobber, nothing pushed. Say so out loud when you skip it. To persist the change, point them at `skill-auto-improver` (their path) or `skill-upstream-pr` (the source repo).
+
+## Inputs
+
+The user identifies **one** target skill, in any of four forms — a local path (`skills/foo`), a local `SKILL.md` file path, a repo (`https://github.com/owner/repo`, `owner/repo`), or a skill name (`code-review`). Phase 0 normalizes all of them to one local directory, `$SKILL_PATH`.
+
+Optional: a `--name <alt>` intent and an install scope. Ask for the scope if the user did not state one; never guess.
+
+## Workflow
+
+Execute phases in order. Do not skip or reorder.
+
+### Phase 0 — Resolve the target to one local directory
+
+Full contract in `references/target-resolution.md`. In short, with `WORK="$(mktemp -d)"`:
+
+- **Local path** — `cp -R` into `$WORK`. A `SKILL.md` **file** path folds to its parent first; `skill-auto-improver` takes a directory, not a file.
+- **Repo** — plain `git clone` into `$WORK`. **Never `gh repo fork`** — this skill performs no public GitHub action.
+- **Skill name** — `asm search "<term>" --available --json`, then copy the string after `asm install ` from the chosen result's `installCommand` **verbatim**. Never hand-construct `github:owner/repo:path`. Clone what it names.
+
+Set `$SKILL_PATH` to the directory holding the chosen `SKILL.md`. If the checkout holds several and no subpath was given, enumerate them (`find "$WORK" -maxdepth 5 -name SKILL.md -type f`) and **ask which one. Never guess.**
+
+Record for the report: the supplied identifier, the resolved install or clone URL, and the upstream commit SHA.
+
+### Phase 1 — Delegate to skill-auto-improver
+
+This skill does not reimplement the improvement loop. Follow the workflow in `skills/skill-auto-improver/SKILL.md` with `$SKILL_PATH` as the target: Phase 0 (baseline), Phase 1 (`asm eval --fix` plus frontmatter normalization), Phases 2–4 (Gate 1 fixes, then the category loop against the 85/8 floor), Phases 5–7 (version bump, the 8-iteration cap, `.asm-improver/report.md`).
+
+Two adaptations, because the target is a throwaway copy:
+
+- Its "Repo Sync Before Edits" step is **inapplicable**. Log `— repo sync skipped (throwaway copy, no origin)` and continue.
+- `.asm-improver/` is written **relative to the current working directory**, so run the loop with cwd inside `$SKILL_PATH`, or Phase 2 has nothing to harvest.
+
+If the baseline already clears both gates the improver stops without editing — a valid outcome, see Edge Cases.
+
+### Phase 2 — Harvest artifacts, then clean up
+
+**Harvest before any cleanup.** Everything lives under `$SKILL_PATH/.asm-improver/` and dies with the temp dir. Read `baseline.json`, the highest-numbered `iter-N.json`, and `report.md`; extract the fields listed in `references/install-and-report.md`.
+
+Only once those values are captured, remove the two artifacts that must not ship — the `SKILL.md.bak` backup left by `asm eval --fix`, and `.asm-improver/`. `asm install` copies the source recursively, so leftovers land in the installed skill:
+
+```bash
+rm -f "$SKILL_PATH/SKILL.md.bak"
+rm -rf "$SKILL_PATH/.asm-improver"
+```
+
+Both deletions are confined to the `mktemp -d` copy — confirm `$SKILL_PATH` is still inside `$WORK` first. Never point either command at a user-supplied path.
+
+### Phase 3 — Install the improved directory
+
+`skill-auto-improver` never renames, so the improved variant keeps the original frontmatter `name` and collides with any existing install of the original. Flags and the full collision policy are in `references/install-and-report.md`.
+
+```bash
+asm install "$SKILL_PATH" --scope "$SCOPE" --json -y
+```
+
+- **No conflict** — it succeeds; done.
+- **Conflict** — ASM fails with `Skill already exists at: … Use --force to overwrite.` Default to overwriting so the improved variant is the one installed: name the path being replaced, confirm, then re-run with `-f`.
+- **Opt-out** — `--name <alt>` installs side by side, on request only. Warn first: both then share one frontmatter `name` and identical triggers, the duplicate-trigger hazard the ASM auditor flags.
+
+Install `$SKILL_PATH`, never the original source — that would install the unimproved skill.
+
+### Phase 4 — Report, then clean up
+
+Fill in the template in `references/install-and-report.md`. The output must state that an **improved variant** was installed rather than the published skill, the provenance (supplied identifier, resolved URL, upstream SHA), the before → after numbers, the collision path taken and what it replaced, and the installed path.
+
+Remove `$WORK` only after the report is complete.
+
+## Step Completion Reports (mandatory)
+
+Emit a compact status block after each phase:
+
+```
+◆ Phase N — [phase name] ([N of 5])
+··································································
+  [check 1]:         √ pass
+  [check 2]:         × fail — [reason]
+  Result:            PASS | FAIL | PARTIAL
+```
+
+Use `√` for pass, `×` for fail, `—` for context. Checks per phase:
+
+- **Phase 0** — `Form identified`, `Copied to temp`, `SKILL_PATH unambiguous`, `Provenance recorded`
+- **Phase 1** — `Baseline captured`, `Improver ran`, `Repo sync skipped`, `Gates cleared or stop reason known`
+- **Phase 2** — `Metrics harvested`, `.bak removed`, `.asm-improver removed`, `Deletions confined to temp`
+- **Phase 3** — `Conflict checked`, `Install path confirmed`, `Install succeeded`
+- **Phase 4** — `Report printed`, `Provenance shown`, `Temp dir removed`
+
+## Acceptance Criteria
+
+- Exactly one target resolved, from a local path, a repo, or a skill name
+- `$SKILL_PATH` is a directory containing `SKILL.md`, under a `mktemp -d` copy — the user's files unmodified
+- Name resolution copied `installCommand` verbatim; no hand-constructed `github:` URL
+- Repo resolution used plain `git clone`; no fork, no push, no public GitHub action
+- Several `SKILL.md` candidates and no supplied path → the user was asked, not guessed
+- `skill-auto-improver` ran on `$SKILL_PATH`; `baseline.json`, `iter-N.json`, and `report.md` read before cleanup
+- `SKILL.md.bak` and `.asm-improver/` removed before the install, both deletions confined to `$WORK`
+- `asm install` pointed at `$SKILL_PATH` — the improved directory — never the original source
+- On a conflict the run overwrote after confirmation, or used `--name <alt>` after warning; the report says which
+- The report names the installed path, says an improved variant was installed, and shows before → after plus provenance
+- `$WORK` removed only after the report is complete
+
+### Expected output
+
+- One skill installed under the chosen scope, containing the improved `SKILL.md`
+- A report per `references/install-and-report.md`, leading with "installed an improved variant of `<name>`" and the before → after numbers
+- No `.asm-improver/` and no `SKILL.md.bak` inside the installed skill
+- No change to the user's own skill directories, and no remote GitHub state touched
+
+### Example
+
+"Install code-review, improved" on a skill that starts at 71 ends like this:
+
+```
+◆ Installed an improved variant of `code-review`
+  Installed to:    ~/.claude/skills/code-review
+  Install path:    forced overwrite of ~/.claude/skills/code-review
+  Supplied as:     code-review
+  Resolved from:   github:owner/repo:skills/code-review @ a1b2c3d
+  Overall score:   71 (C) → 92 (A)   Min category: 5 → 8
+  Version:         1.0.0 → 1.3.0     Iterations: 3 of 8
+```
+
+## Edge Cases
+
+- **Baseline already passes both gates** — the improver stops without editing. Install the **original, unchanged**, and report plainly that no improvement was needed, naming the baseline score. Never imply a delta that did not happen.
+- **Improver ends in BLOCKER** (8 iterations, or stalled) — better than baseline but below the floor. Show the blocker list and ask whether to install the partial result or abort. Never install one silently.
+- **Local-path target** — improved on a copy, so the user's tree is untouched and the repo sync is skipped. Point them at `skill-auto-improver` or `skill-upstream-pr` to persist the change.
+- **Several `SKILL.md` files in a clone** — enumerate and ask. Never batch, never guess.
+- **`asm search` returns nothing, or several equally-plausible matches** — show the candidates and ask; never install the first hit.
+- **Target has no frontmatter** — `asm eval --fix` cannot add it. Report and stop; do not install an unimprovable skill as if it were improved.
+- **Conflict is a same-named skill from another source** — the overwrite replaces someone else's skill. Name the path and its source, confirm, and offer `--name <alt>`.
+- **Temp dir removed before harvesting** — the metrics are gone and the before/after criterion cannot be met. Harvest in Phase 2, always before cleanup.
+- **Clone or disk failure mid-resolve** — stop, remove `$WORK`, report. Never install a partial checkout.
+
+## References
+
+- `references/target-resolution.md` — the three input forms normalized to one local `$SKILL_PATH`
+- `references/install-and-report.md` — install flags, collision policy, harvested fields, report template
+- `skills/skill-auto-improver/SKILL.md` — the improvement loop this skill delegates to
+- `skills/skill-upstream-pr/SKILL.md` — the sibling path when the improvement should go back to the source repo
+- `asm install --help` and `asm search --help` — flag references

--- a/skills/skill-install-improved/SKILL.md
+++ b/skills/skill-install-improved/SKILL.md
@@ -91,7 +91,6 @@ Both deletions are confined to the `mktemp -d` copy — confirm `$SKILL_PATH` is
 
 ```bash
 asm list --json    # probe: is this skill already installed for $TOOL / $SCOPE?
-asm install "$SKILL_PATH" -p "$TOOL" --scope "$SCOPE" --json -y
 ```
 
 - **Neither name matches** — install; nothing is touched.
@@ -100,6 +99,12 @@ asm install "$SKILL_PATH" -p "$TOOL" --scope "$SCOPE" --json -y
 - **Opt-out** — `--name <alt>` installs side by side, on request only. Warn first: both then share one frontmatter `name` and identical triggers, the duplicate-trigger hazard the ASM auditor flags.
 
 Two names decide the outcome and they can differ: ASM triggers the overwrite from the frontmatter `name` plus the selected tool (scope is not part of that match), but the directory it deletes is named after `$SKILL_PATH`'s basename. Check the probe output for both.
+
+Only once the probe is read and any collision above is confirmed:
+
+```bash
+asm install "$SKILL_PATH" -p "$TOOL" --scope "$SCOPE" --json -y
+```
 
 Install `$SKILL_PATH`, never the original source — that would install the unimproved skill. Take the installed path from the install command's own `--json` output (`.path`); never assume `~/.claude/skills/`.
 
@@ -167,7 +172,7 @@ Use `√` for pass, `×` for fail, `—` for context. Checks per phase:
 
 ## Edge Cases
 
-- **Baseline already passes both gates** — the improver stops without editing. Install the **original, unchanged**, and report plainly that no improvement was needed, naming the baseline score. Never imply a delta that did not happen.
+- **Baseline already passes both gates** — the improver stops without editing. Phase 2's cleanup and Phase 3's probe still run: Phase 0 of the improver writes `.asm-improver/` before it decides no edits are needed, so clean up first, then probe for a collision. Install the **original, unchanged**, and report plainly that no improvement was needed, naming the baseline score. Never imply a delta that did not happen.
 - **Improver ends in BLOCKER** (8 iterations, or stalled) — better than baseline but below the floor. Show the blocker list and ask whether to install the partial result or abort. Never install one silently.
 - **Local-path target** — improved on a copy, so the user's tree is untouched and the repo sync is skipped. Point them at `skill-auto-improver` or `skill-upstream-pr` to persist the change.
 - **Several `SKILL.md` files in a clone** — enumerate and ask. Never batch, never guess.

--- a/skills/skill-install-improved/SKILL.md
+++ b/skills/skill-install-improved/SKILL.md
@@ -29,7 +29,7 @@ Verify each before resolving anything. Stop and tell the user if any fails.
 - `asm` and `git` on PATH
 - Python 3 and `~/.claude/skills/skill-creator/scripts/quick_validate.py` — `skill-auto-improver` requires it
 - Network access to GitHub, for the repo and name forms
-- Write access to the install target (`~/.claude/skills/` global, `.claude/skills/` project)
+- Write access to the install target — the directory for the chosen tool and scope (for `claude`: `~/.claude/skills/` global, `.claude/skills/` project). Other tools install elsewhere; take the real path from `asm list --json` or the install output.
 
 ### The user's own files are never modified (design decision)
 
@@ -41,7 +41,9 @@ Verify each before resolving anything. Stop and tell the user if any fails.
 
 The user identifies **one** target skill, in any of four forms — a local path (`skills/foo`), a local `SKILL.md` file path, a repo (`https://github.com/owner/repo`, `owner/repo`), or a skill name (`code-review`). Phase 0 normalizes all of them to one local directory, `$SKILL_PATH`.
 
-Optional: a `--name <alt>` intent and an install scope. Ask for the scope if the user did not state one; never guess.
+Also needed before Phase 3: the install **scope** (`global` or `project`) and the target **tool** (`-p/--tool` — `claude`, `codex`, `agents`, …). Ask for either one the user did not state; never guess. `asm install` hard-fails without `--tool` in a non-interactive run, and `-y` does not cover it.
+
+Optional: a `--name <alt>` intent.
 
 ## Workflow
 
@@ -85,17 +87,21 @@ Both deletions are confined to the `mktemp -d` copy — confirm `$SKILL_PATH` is
 
 ### Phase 3 — Install the improved directory
 
-`skill-auto-improver` never renames, so the improved variant keeps the original frontmatter `name` and collides with any existing install of the original. Flags and the full collision policy are in `references/install-and-report.md`.
+`skill-auto-improver` never renames, so the improved variant keeps the original frontmatter `name` and collides with any existing install of the original. **`asm install` never refuses on a collision** — it plans the force overwrite itself, and with `-y` it deletes and replaces the target directory with no prompt. `-f` changes nothing here. So probe **before** invoking it. Flags and the full policy are in `references/install-and-report.md`.
 
 ```bash
-asm install "$SKILL_PATH" --scope "$SCOPE" --json -y
+asm list --json    # probe: is this skill already installed for $TOOL / $SCOPE?
+asm install "$SKILL_PATH" -p "$TOOL" --scope "$SCOPE" --json -y
 ```
 
-- **No conflict** — it succeeds; done.
-- **Conflict** — ASM fails with `Skill already exists at: … Use --force to overwrite.` Default to overwriting so the improved variant is the one installed: name the path being replaced, confirm, then re-run with `-f`.
+- **Neither name matches** — install; nothing is touched.
+- **Frontmatter `name` matches for `$TOOL`** — the target directory is deleted and replaced. Name the existing entry's `path` and the source it came from, and get **explicit confirmation before running `asm install`**. There is no failure to fall back on once it is invoked.
+- **Only the directory name matches** — no delete, but the copy still **merges into** the existing directory: colliding files are overwritten and the previous occupant's other files survive inside the installed skill. Confirm this one too.
 - **Opt-out** — `--name <alt>` installs side by side, on request only. Warn first: both then share one frontmatter `name` and identical triggers, the duplicate-trigger hazard the ASM auditor flags.
 
-Install `$SKILL_PATH`, never the original source — that would install the unimproved skill.
+Two names decide the outcome and they can differ: ASM triggers the overwrite from the frontmatter `name` plus the selected tool (scope is not part of that match), but the directory it deletes is named after `$SKILL_PATH`'s basename. Check the probe output for both.
+
+Install `$SKILL_PATH`, never the original source — that would install the unimproved skill. Take the installed path from the install command's own `--json` output (`.path`); never assume `~/.claude/skills/`.
 
 ### Phase 4 — Report, then clean up
 
@@ -120,7 +126,7 @@ Use `√` for pass, `×` for fail, `—` for context. Checks per phase:
 - **Phase 0** — `Form identified`, `Copied to temp`, `SKILL_PATH unambiguous`, `Provenance recorded`
 - **Phase 1** — `Baseline captured`, `Improver ran`, `Repo sync skipped`, `Gates cleared or stop reason known`
 - **Phase 2** — `Metrics harvested`, `.bak removed`, `.asm-improver removed`, `Deletions confined to temp`
-- **Phase 3** — `Conflict checked`, `Install path confirmed`, `Install succeeded`
+- **Phase 3** — `Collision probed before install`, `Overwrite confirmed (if any)`, `Tool and scope supplied`, `Install succeeded`
 - **Phase 4** — `Report printed`, `Provenance shown`, `Temp dir removed`
 
 ## Acceptance Criteria
@@ -132,8 +138,8 @@ Use `√` for pass, `×` for fail, `—` for context. Checks per phase:
 - Several `SKILL.md` candidates and no supplied path → the user was asked, not guessed
 - `skill-auto-improver` ran on `$SKILL_PATH`; `baseline.json`, `iter-N.json`, and `report.md` read before cleanup
 - `SKILL.md.bak` and `.asm-improver/` removed before the install, both deletions confined to `$WORK`
-- `asm install` pointed at `$SKILL_PATH` — the improved directory — never the original source
-- On a conflict the run overwrote after confirmation, or used `--name <alt>` after warning; the report says which
+- `asm install` pointed at `$SKILL_PATH` — the improved directory — never the original source — with both `-p/--tool` and `--scope` supplied
+- A collision was probed for **before** `asm install` ran; on a match the run overwrote only after explicit confirmation, or used `--name <alt>` after warning; the report says which
 - The report names the installed path, says an improved variant was installed, and shows before → after plus provenance
 - `$WORK` removed only after the report is complete
 
@@ -150,8 +156,9 @@ Use `√` for pass, `×` for fail, `—` for context. Checks per phase:
 
 ```
 ◆ Installed an improved variant of `code-review`
-  Installed to:    ~/.claude/skills/code-review
-  Install path:    forced overwrite of ~/.claude/skills/code-review
+  Installed to:    ~/.claude/skills/code-review   (read from install --json .path)
+  Install path:    confirmed overwrite of the previous install at that path
+  Tool / scope:    claude / global
   Supplied as:     code-review
   Resolved from:   github:owner/repo:skills/code-review @ a1b2c3d
   Overall score:   71 (C) → 92 (A)   Min category: 5 → 8
@@ -166,7 +173,7 @@ Use `√` for pass, `×` for fail, `—` for context. Checks per phase:
 - **Several `SKILL.md` files in a clone** — enumerate and ask. Never batch, never guess.
 - **`asm search` returns nothing, or several equally-plausible matches** — show the candidates and ask; never install the first hit.
 - **Target has no frontmatter** — `asm eval --fix` cannot add it. Report and stop; do not install an unimprovable skill as if it were improved.
-- **Conflict is a same-named skill from another source** — the overwrite replaces someone else's skill. Name the path and its source, confirm, and offer `--name <alt>`.
+- **Collision is a same-named skill from another source** — the install would silently replace someone else's skill, with no error and no prompt. The probe is the only chance to catch it: name the path and its source, confirm, and offer `--name <alt>` — all before `asm install` runs.
 - **Temp dir removed before harvesting** — the metrics are gone and the before/after criterion cannot be met. Harvest in Phase 2, always before cleanup.
 - **Clone or disk failure mid-resolve** — stop, remove `$WORK`, report. Never install a partial checkout.
 

--- a/skills/skill-install-improved/docs/README.md
+++ b/skills/skill-install-improved/docs/README.md
@@ -1,0 +1,82 @@
+<!--
+  DO NOT READ THIS FILE — This README.md is for human catalog browsing only.
+  It ships inside the .skill package but is NEVER auto-loaded into agent context.
+  The runtime loader only reads SKILL.md + references/ + scripts/ + agents/ when the skill triggers.
+  If you're an AI agent, read the SKILL.md file instead for skill instructions.
+-->
+
+# Skill Install Improved
+
+> Installs an **improved** variant of one skill instead of the published one. Resolves the target by local path, repo, or skill name; runs `skill-auto-improver` on a throwaway copy; installs the improved result; and reports what was installed and what it was improved from.
+
+## Highlights
+
+- **Three ways to name the target.** A local path, the repo it lives in, or just the skill name (resolved through `asm search --available`).
+- **Your files are never touched.** Every input form — local paths included — is improved on a `mktemp -d` copy. An install should not rewrite your working tree or rebase your branch.
+- **The improved copy is what gets installed**, not the original. `asm install` is pointed at the improved directory.
+- **Provenance in the output.** The report names the identifier you supplied, the resolved install URL or clone URL, and the upstream commit SHA.
+- **Before/after numbers.** Baseline vs final `overallScore` and grade, minimum category score, `metadata.version`, iterations taken, and files changed.
+- **Honest about no-ops.** If the skill already clears the 85/8 floor, it installs the original unchanged and says so instead of faking a delta.
+- **Collision policy is explicit.** Default is a forced overwrite (so the improved variant is the one installed); `--name <alt>` is the documented opt-out, with a warning about duplicate triggers.
+
+## When to Use
+
+| Say this...                                        | Skill will...                                                    |
+| -------------------------------------------------- | ---------------------------------------------------------------- |
+| "Install code-review but improve it first"         | Resolve by name, improve on a copy, install the improved variant |
+| "Install an improved version of this repo's skill" | Clone, improve, install                                          |
+| "Install skills/foo, but level it up"              | Copy the local dir, improve the copy, install                    |
+| "Improve skills/foo"                               | **Not this skill** — use `/skill-auto-improver`                  |
+| "Send the improvement upstream as a PR"            | **Not this skill** — use `/skill-upstream-pr`                    |
+| "Install code-review"                              | **Not this skill** — just run `asm install code-review`          |
+
+## Usage
+
+```
+/skill-install-improved code-review
+/skill-install-improved https://github.com/owner/repo
+/skill-install-improved skills/my-skill
+```
+
+## How It Works
+
+```mermaid
+graph TD
+    A["Phase 0: resolve target<br/>path | repo | name → mktemp copy"] --> B["Phase 1: delegate to<br/>skill-auto-improver"]
+    B --> C{"Baseline already<br/>passes 85/8?"}
+    C -- yes --> D["Install original unchanged,<br/>report 'no improvement needed'"]
+    C -- no --> E["Phase 2: harvest .asm-improver/<br/>baseline + iter-N + report.md"]
+    E --> F["Remove SKILL.md.bak<br/>and .asm-improver/"]
+    F --> G{"Name already<br/>installed?"}
+    G -- no --> H["asm install $SKILL_PATH"]
+    G -- yes --> I["asm install -f<br/>(or --name alt, on request)"]
+    H --> J["Phase 4: report + cleanup"]
+    I --> J
+    style A fill:#4CAF50,color:#fff
+    style J fill:#2196F3,color:#fff
+```
+
+## What the Report Shows
+
+| Field           | Example                                            |
+| --------------- | -------------------------------------------------- |
+| Installed to    | `~/.claude/skills/code-review`                     |
+| Install path    | forced overwrite of `~/.claude/skills/code-review` |
+| Supplied as     | `code-review`                                      |
+| Resolved from   | `github:owner/repo:skills/code-review`             |
+| Upstream commit | `a1b2c3d`                                          |
+| Overall score   | `71 (C) → 92 (A)`                                  |
+| Min category    | `5 → 8`                                            |
+| Version         | `1.0.0 → 1.3.0`                                    |
+| Iterations      | `3 of 8`                                           |
+| Files changed   | `SKILL.md`, `references/playbook.md`               |
+
+## Resources
+
+| Path                                                                    | Description                                               |
+| ----------------------------------------------------------------------- | --------------------------------------------------------- |
+| [SKILL.md](../SKILL.md)                                                 | The agent workflow                                        |
+| [references/target-resolution.md](../references/target-resolution.md)   | The three input forms normalized to one local directory   |
+| [references/install-and-report.md](../references/install-and-report.md) | Install flags, collision policy, harvest fields, template |
+| `skills/skill-auto-improver/`                                           | The improvement loop this skill delegates to              |
+| `skills/skill-upstream-pr/`                                             | The sibling path for sending improvements upstream        |

--- a/skills/skill-install-improved/docs/README.md
+++ b/skills/skill-install-improved/docs/README.md
@@ -44,9 +44,10 @@
 graph TD
     A["Phase 0: resolve target<br/>path | repo | name → mktemp copy"] --> B["Phase 1: delegate to<br/>skill-auto-improver"]
     B --> C{"Baseline already<br/>passes 85/8?"}
-    C -- yes --> D["Install original unchanged,<br/>report 'no improvement needed'"]
+    C -- yes --> D["No edits needed —<br/>keep SKILL.md as published"]
     C -- no --> E["Phase 2: harvest .asm-improver/<br/>baseline + iter-N + report.md"]
     E --> F["Remove SKILL.md.bak<br/>and .asm-improver/"]
+    D --> F
     F --> G{"Probe asm list --json:<br/>name already installed?"}
     G -- no --> H["asm install $SKILL_PATH<br/>-p TOOL --scope SCOPE"]
     G -- yes --> I["Name the path, confirm the<br/>overwrite (or --name alt), then install"]

--- a/skills/skill-install-improved/docs/README.md
+++ b/skills/skill-install-improved/docs/README.md
@@ -17,7 +17,7 @@
 - **Provenance in the output.** The report names the identifier you supplied, the resolved install URL or clone URL, and the upstream commit SHA.
 - **Before/after numbers.** Baseline vs final `overallScore` and grade, minimum category score, `metadata.version`, iterations taken, and files changed.
 - **Honest about no-ops.** If the skill already clears the 85/8 floor, it installs the original unchanged and says so instead of faking a delta.
-- **Collision policy is explicit.** Default is a forced overwrite (so the improved variant is the one installed); `--name <alt>` is the documented opt-out, with a warning about duplicate triggers.
+- **Collisions are caught before they happen.** `asm install` overwrites an existing same-named skill unconditionally and without a prompt, so the skill probes `asm list --json` first, names the path that would be replaced, and asks. `--name <alt>` is the documented opt-out, with a warning about duplicate triggers.
 
 ## When to Use
 
@@ -47,9 +47,9 @@ graph TD
     C -- yes --> D["Install original unchanged,<br/>report 'no improvement needed'"]
     C -- no --> E["Phase 2: harvest .asm-improver/<br/>baseline + iter-N + report.md"]
     E --> F["Remove SKILL.md.bak<br/>and .asm-improver/"]
-    F --> G{"Name already<br/>installed?"}
-    G -- no --> H["asm install $SKILL_PATH"]
-    G -- yes --> I["asm install -f<br/>(or --name alt, on request)"]
+    F --> G{"Probe asm list --json:<br/>name already installed?"}
+    G -- no --> H["asm install $SKILL_PATH<br/>-p TOOL --scope SCOPE"]
+    G -- yes --> I["Name the path, confirm the<br/>overwrite (or --name alt), then install"]
     H --> J["Phase 4: report + cleanup"]
     I --> J
     style A fill:#4CAF50,color:#fff
@@ -58,18 +58,19 @@ graph TD
 
 ## What the Report Shows
 
-| Field           | Example                                            |
-| --------------- | -------------------------------------------------- |
-| Installed to    | `~/.claude/skills/code-review`                     |
-| Install path    | forced overwrite of `~/.claude/skills/code-review` |
-| Supplied as     | `code-review`                                      |
-| Resolved from   | `github:owner/repo:skills/code-review`             |
-| Upstream commit | `a1b2c3d`                                          |
-| Overall score   | `71 (C) → 92 (A)`                                  |
-| Min category    | `5 → 8`                                            |
-| Version         | `1.0.0 → 1.3.0`                                    |
-| Iterations      | `3 of 8`                                           |
-| Files changed   | `SKILL.md`, `references/playbook.md`               |
+| Field           | Example                                                        |
+| --------------- | -------------------------------------------------------------- |
+| Installed to    | `~/.claude/skills/code-review` (from install `--json` `.path`) |
+| Tool / scope    | `claude` / `global`                                            |
+| Install path    | confirmed overwrite of `~/.claude/skills/code-review`          |
+| Supplied as     | `code-review`                                                  |
+| Resolved from   | `github:owner/repo:skills/code-review`                         |
+| Upstream commit | `a1b2c3d`                                                      |
+| Overall score   | `71 (C) → 92 (A)`                                              |
+| Min category    | `5 → 8`                                                        |
+| Version         | `1.0.0 → 1.3.0`                                                |
+| Iterations      | `3 of 8`                                                       |
+| Files changed   | `SKILL.md`, `references/playbook.md`                           |
 
 ## Resources
 

--- a/skills/skill-install-improved/references/install-and-report.md
+++ b/skills/skill-install-improved/references/install-and-report.md
@@ -30,33 +30,45 @@ rm -rf "$SKILL_PATH/.asm-improver"   # iteration artifacts
 ## Install flags
 
 ```bash
-asm install "$SKILL_PATH" --scope "$SCOPE" --json -y
+asm install "$SKILL_PATH" -p "$TOOL" --scope "$SCOPE" --json -y
 ```
 
-| Flag            | Why                                                                            |
-| --------------- | ------------------------------------------------------------------------------ |
-| `"$SKILL_PATH"` | A **local directory** — the improved copy. Never the remote source.            |
-| `--scope`       | `global` or `project`. Ask if the user did not say; do not guess.              |
-| `--json`        | Machine-readable result, so the outcome is parsed, not scraped.                |
-| `-y`            | The user already approved the install; the improvement was the decision point. |
-| `-f`            | Only on a conflict, per the policy below.                                      |
-| `--name <alt>`  | Only when the user explicitly opts out of overwriting.                         |
+| Flag            | Why                                                                                                                                                       |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"$SKILL_PATH"` | A **local directory** — the improved copy. Never the remote source.                                                                                       |
+| `-p/--tool`     | `claude`, `codex`, `agents`, … **Required** — without it ASM aborts with `--tool (or --provider) is required in non-interactive mode`. Ask; do not guess. |
+| `--scope`       | `global` or `project`. Ask if the user did not say; do not guess.                                                                                         |
+| `--json`        | Machine-readable result, so the outcome is parsed, not scraped — including `.path`.                                                                       |
+| `-y`            | The user already approved the install; the improvement was the decision point.                                                                            |
+| `--name <alt>`  | Only when the user explicitly opts out of overwriting.                                                                                                    |
+
+`-y` skips the confirmation prompt as well as the install prompt, so nothing in the command asks before replacing an existing skill. `-f` is **not** part of this flow: `asm install` sets force itself whenever the name already exists.
 
 ## Collision policy
 
 `skill-auto-improver` never renames a skill, so the improved variant keeps the original frontmatter `name`. If the original is already installed, the names collide.
 
-1. **Probe.** Run the install without `-f`. No conflict → it succeeds and you are done.
-2. **Conflict.** ASM fails with `Skill already exists at: <path>` / `Use --force to overwrite.` Name that path, and the source the existing install came from, in the output.
-3. **Default: overwrite.** Re-run with `-f`. This is the default because the request was to install the improved variant — leaving the original in place would not satisfy it.
+**`asm install` never refuses on a collision.** When a skill with the same frontmatter `name` is already installed for the selected tool, it plans a force overwrite on the very first invocation: the existing target directory is removed and replaced. With `-y` there is no prompt, no error, and no `Skill already exists` message — that failure only comes from the bundle/import path, never from `asm install`. So the safety gate has to run _before_ the command, not after it.
+
+Two different names are in play and they can disagree:
+
+- The **overwrite decision** matches the frontmatter `name` plus the selected tool. Scope is not part of that match.
+- The **directory deleted** is named after `$SKILL_PATH`'s basename (or `--name <alt>`).
+
+1. **Probe first.** Before invoking `asm install`, list what is already installed and look for both names:
 
    ```bash
-   asm install "$SKILL_PATH" --scope "$SCOPE" --json -y -f
+   asm list --json    # each entry carries name, dirName, path, provider, scope
    ```
 
-4. **Opt-out: `--name <alt>`.** Side-by-side install under a different directory name. Warn before doing it: **both skills then carry the same frontmatter `name` and the same triggers**, so the runtime has two indistinguishable candidates — the duplicate-trigger hazard the ASM auditor reports. Take this path only when the user asks for it.
+   `asm inspect "<dirName>" --json` gives the same detail for a single entry, but it matches on the **directory** name only — use `asm list --json` when you need to match the frontmatter `name`.
 
-The report always states which of the three paths was taken and what, if anything, was replaced.
+2. **Neither name matches.** Nothing is touched. Install and report a clean install.
+3. **Frontmatter `name` matches for the selected tool — confirm, then overwrite.** Name the existing entry's `path` and the source it came from, and get explicit confirmation. Overwriting is the expected outcome (the request was to install the improved variant), but it is destructive and unconditional, so it must be an informed choice made before the command runs.
+4. **Only the directory name matches.** No force is planned, so nothing is deleted — but the recursive copy still **merges into** the existing directory: colliding files are overwritten in place and the previous occupant's other files stay behind inside the installed skill. There is no clean-install guarantee anywhere in `asm install`. Confirm this case as well, and check the result for strays.
+5. **Opt-out: `--name <alt>`.** Side-by-side install under a different directory name — check `alt` against the probe too, or it merges into whatever already sits there. Warn before doing it: **both skills then carry the same frontmatter `name` and the same triggers**, so the runtime has two indistinguishable candidates — the duplicate-trigger hazard the ASM auditor reports. Take this path only when the user asks for it.
+
+The report always states which of these paths was taken and what, if anything, was replaced or merged into.
 
 ## Report template
 
@@ -65,8 +77,9 @@ Print this to the user at the end of Phase 4, before removing `$WORK`.
 ```
 ◆ Installed an improved variant of `<skill-name>`
 ··································································
-  Installed to:      ~/.claude/skills/<dir>
-  Install path:      clean install | forced overwrite of <path> | side-by-side as <alt>
+  Installed to:      <.path from the install --json output — never assumed>
+  Tool / scope:      <tool> / <scope>
+  Install path:      clean install | confirmed overwrite of <path> | side-by-side as <alt>
 
   Improved from
     Supplied as:     <what the user typed>

--- a/skills/skill-install-improved/references/install-and-report.md
+++ b/skills/skill-install-improved/references/install-and-report.md
@@ -52,8 +52,8 @@ asm install "$SKILL_PATH" -p "$TOOL" --scope "$SCOPE" --json -y
 
 Two different names are in play and they can disagree:
 
-- The **overwrite decision** matches the frontmatter `name` plus the selected tool. Scope is not part of that match.
-- The **directory deleted** is named after `$SKILL_PATH`'s basename (or `--name <alt>`).
+- The **overwrite decision** matches the frontmatter `name` plus the selected tool. Scope is not part of that match, and `--name` does not suppress it.
+- The **directory deleted** is the _target_ directory: `$SKILL_PATH`'s basename (or `alt`) under the install base for `$TOOL`/`$SCOPE`. That is not necessarily the matched entry's `path`.
 
 1. **Probe first.** Before invoking `asm install`, list what is already installed and look for both names:
 
@@ -64,9 +64,9 @@ Two different names are in play and they can disagree:
    `asm inspect "<dirName>" --json` gives the same detail for a single entry, but it matches on the **directory** name only — use `asm list --json` when you need to match the frontmatter `name`.
 
 2. **Neither name matches.** Nothing is touched. Install and report a clean install.
-3. **Frontmatter `name` matches for the selected tool — confirm, then overwrite.** Name the existing entry's `path` and the source it came from, and get explicit confirmation. Overwriting is the expected outcome (the request was to install the improved variant), but it is destructive and unconditional, so it must be an informed choice made before the command runs.
+3. **Frontmatter `name` matches for the selected tool — confirm, then overwrite.** The matched entry is only the _trigger_; it may sit in a different scope. Confirm the **target** directory instead — derive its base from the `path` of probe entries sharing the same `provider` and `scope`, and state what the probe shows occupying it (`name`, `dirName`, `provider`, `scope`) or that it is free. Name the matched entry separately, as the reason force is set. Overwriting is the expected outcome (the request was to install the improved variant), but it is destructive and unconditional, so it must be an informed choice made before the command runs.
 4. **Only the directory name matches.** No force is planned, so nothing is deleted — but the recursive copy still **merges into** the existing directory: colliding files are overwritten in place and the previous occupant's other files stay behind inside the installed skill. There is no clean-install guarantee anywhere in `asm install`. Confirm this case as well, and check the result for strays.
-5. **Opt-out: `--name <alt>`.** Side-by-side install under a different directory name — check `alt` against the probe too, or it merges into whatever already sits there. Warn before doing it: **both skills then carry the same frontmatter `name` and the same triggers**, so the runtime has two indistinguishable candidates — the duplicate-trigger hazard the ASM auditor reports. Take this path only when the user asks for it.
+5. **Opt-out: `--name <alt>`.** Side-by-side install under directory name `alt`. `--name` does not suppress force, so when the frontmatter `name` already matches, anything occupying `<base>/<alt>` is deleted and replaced, not merged — check `alt` against the probe first. Warn before doing it: **both skills then carry the same frontmatter `name` and the same triggers**, so the runtime has two indistinguishable candidates — the duplicate-trigger hazard the ASM auditor reports. Take this path only when the user asks for it.
 
 The report always states which of these paths was taken and what, if anything, was replaced or merged into.
 
@@ -79,7 +79,7 @@ Print this to the user at the end of Phase 4, before removing `$WORK`.
 ··································································
   Installed to:      <.path from the install --json output — never assumed>
   Tool / scope:      <tool> / <scope>
-  Install path:      clean install | confirmed overwrite of <path> | side-by-side as <alt>
+  Install path:      clean install | confirmed overwrite of <target path> | side-by-side as <alt>
 
   Improved from
     Supplied as:     <what the user typed>

--- a/skills/skill-install-improved/references/install-and-report.md
+++ b/skills/skill-install-improved/references/install-and-report.md
@@ -1,0 +1,100 @@
+# Install and Report
+
+Phases 2–4 in detail: what to harvest, how to install, and what the user must be able to read off the output.
+
+## Harvest before cleanup
+
+`skill-auto-improver` writes `.asm-improver/` **relative to the current working directory**, so the loop must run with cwd inside `$SKILL_PATH`. Everything below lives in a temp directory and is gone the moment `$WORK` is removed — read it first.
+
+| File                                    | What to take from it                                |
+| --------------------------------------- | --------------------------------------------------- |
+| `.asm-improver/baseline.json`           | `overallScore`, `grade`, all 7 `categories[].score` |
+| `.asm-improver/iter-N.json` (highest N) | the same fields, after                              |
+| `.asm-improver/report.md`               | files changed, key fixes, blocker list if any       |
+
+Derived fields:
+
+- `minCategory` before and after — the minimum of the 7 category scores
+- `iterations` — N of 8
+- `versionBefore` → `versionAfter` — the target's frontmatter `metadata.version`
+
+Then clean the checkout, so nothing extraneous ships:
+
+```bash
+rm -f "$SKILL_PATH/SKILL.md.bak"     # left behind by `asm eval --fix`
+rm -rf "$SKILL_PATH/.asm-improver"   # iteration artifacts
+```
+
+`asm install` copies the source directory recursively; anything still in `$SKILL_PATH` lands in the installed skill.
+
+## Install flags
+
+```bash
+asm install "$SKILL_PATH" --scope "$SCOPE" --json -y
+```
+
+| Flag            | Why                                                                            |
+| --------------- | ------------------------------------------------------------------------------ |
+| `"$SKILL_PATH"` | A **local directory** — the improved copy. Never the remote source.            |
+| `--scope`       | `global` or `project`. Ask if the user did not say; do not guess.              |
+| `--json`        | Machine-readable result, so the outcome is parsed, not scraped.                |
+| `-y`            | The user already approved the install; the improvement was the decision point. |
+| `-f`            | Only on a conflict, per the policy below.                                      |
+| `--name <alt>`  | Only when the user explicitly opts out of overwriting.                         |
+
+## Collision policy
+
+`skill-auto-improver` never renames a skill, so the improved variant keeps the original frontmatter `name`. If the original is already installed, the names collide.
+
+1. **Probe.** Run the install without `-f`. No conflict → it succeeds and you are done.
+2. **Conflict.** ASM fails with `Skill already exists at: <path>` / `Use --force to overwrite.` Name that path, and the source the existing install came from, in the output.
+3. **Default: overwrite.** Re-run with `-f`. This is the default because the request was to install the improved variant — leaving the original in place would not satisfy it.
+
+   ```bash
+   asm install "$SKILL_PATH" --scope "$SCOPE" --json -y -f
+   ```
+
+4. **Opt-out: `--name <alt>`.** Side-by-side install under a different directory name. Warn before doing it: **both skills then carry the same frontmatter `name` and the same triggers**, so the runtime has two indistinguishable candidates — the duplicate-trigger hazard the ASM auditor reports. Take this path only when the user asks for it.
+
+The report always states which of the three paths was taken and what, if anything, was replaced.
+
+## Report template
+
+Print this to the user at the end of Phase 4, before removing `$WORK`.
+
+```
+◆ Installed an improved variant of `<skill-name>`
+··································································
+  Installed to:      ~/.claude/skills/<dir>
+  Install path:      clean install | forced overwrite of <path> | side-by-side as <alt>
+
+  Improved from
+    Supplied as:     <what the user typed>
+    Resolved from:   <installUrl | clone URL | local path>
+    Upstream commit: <sha | n/a>
+
+  Improvement
+    Overall score:   <before> (<grade>) → <after> (<grade>)
+    Min category:    <before> → <after>
+    Version:         <x.y.z> → <x.y.z>
+    Iterations:      <N> of 8
+    Files changed:   <list>
+
+  Note: the installed copy is the improved one. The original source
+        was not modified.
+```
+
+### When no improvement was needed
+
+If the baseline already cleared both gates, `skill-auto-improver` stops without editing and the original is installed unchanged. Say that plainly rather than printing a zero delta:
+
+```
+◆ Installed `<skill-name>` unchanged — no improvement needed
+··································································
+  Baseline already clears both gates: <score> (<grade>), min category <n>.
+  skill-auto-improver made no edits. The published skill was installed as-is.
+```
+
+### When the improver ended in BLOCKER
+
+Show the blocker list from `.asm-improver/report.md` and the partial before → after numbers, then **ask** whether to install the partially-improved variant or abort. Never install a blocker result silently, and never describe it as improved-to-standard when it is not.

--- a/skills/skill-install-improved/references/target-resolution.md
+++ b/skills/skill-install-improved/references/target-resolution.md
@@ -1,0 +1,103 @@
+# Target Resolution
+
+The contract for Phase 0: turn whatever the user typed into exactly one local directory, `$SKILL_PATH`, that contains a `SKILL.md`.
+
+Two invariants hold for every input form:
+
+1. **`$SKILL_PATH` is a directory, never a file.** `skill-auto-improver` takes a directory (`skills/skill-auto-improver/SKILL.md` — "Inputs"). A `SKILL.md` file path folds to its parent.
+2. **`$SKILL_PATH` lives under `$(mktemp -d)`.** Including local-path targets. See SKILL.md → Prerequisites for why, and for the trade-off.
+
+```bash
+WORK="$(mktemp -d)"
+```
+
+## Deciding which form the user gave
+
+Check in this order — the first match wins:
+
+| Test                                                 | Form       |
+| ---------------------------------------------------- | ---------- |
+| Path exists on disk (after `~` expansion)            | Local path |
+| Looks like a GitHub URL, `github:…`, or `owner/repo` | Repo       |
+| Anything else                                        | Skill name |
+
+An input that looks path-shaped but does not exist is **not** a local path — say so and ask, rather than falling through to a catalog search for a typo'd path.
+
+## Form 1 — Local path
+
+```bash
+SRC="<path the user gave>"
+# A SKILL.md file path folds to its parent directory
+[ -f "$SRC" ] && SRC="$(dirname "$SRC")"
+
+cp -R "$SRC" "$WORK/target"
+SKILL_PATH="$WORK/target"
+```
+
+The copy has no `origin` remote and no history. `skill-auto-improver`'s mandatory repo sync is inapplicable — log the skip and continue.
+
+Provenance to record: the literal path the user supplied; `installUrl` = `n/a (local path)`; upstream SHA = `n/a` unless the source directory happened to sit in a git repo, in which case record `git -C "$SRC" rev-parse HEAD` for traceability.
+
+## Form 2 — Repo
+
+Use a plain clone. **Never `gh repo fork`** — this skill performs no public GitHub action, opens no PR, and creates nothing under the user's GitHub account.
+
+```bash
+git clone --depth 1 "https://github.com/$OWNER/$REPO" "$WORK/repo"
+# If the user named a ref:
+git -C "$WORK/repo" fetch --depth 1 origin "$REF" && git -C "$WORK/repo" checkout "$REF"
+SKILL_PATH="$WORK/repo/<subpath>"     # or the repo root when the skill is at top level
+```
+
+If the user gave a subpath, use it. If not, run the multi-candidate check below.
+
+Provenance to record: the clone URL, the ref, and `git -C "$WORK/repo" rev-parse HEAD`.
+
+## Form 3 — Skill name
+
+Query the catalog, then trust its own install string:
+
+```bash
+asm search "<term>" --available --json
+```
+
+Each result carries an `installCommand` such as:
+
+```
+asm install github:alirezarezvani/claude-skills:.codex/skills/marketing-ideas
+```
+
+**Copy the string after `asm install ` verbatim** as `$INSTALL_URL`. Never hand-construct `github:owner/repo:path` — the contract is stated in `skills/find-me-skills/references/catalog-discovery.md`, and reconstructed URLs silently resolve to the wrong subpath.
+
+Then materialize `$INSTALL_URL` locally: split it into its repo, optional `#ref`, and optional `:path` components, clone as in Form 2, and set `$SKILL_PATH` to the cloned subpath.
+
+Selection rules:
+
+- **No results** — report the search terms and stop. Do not broaden the query and install something adjacent.
+- **Exactly one result** — use it, and name it in the report so the user can see what was matched.
+- **Several results** — list name, repo, and description; ask the user to pick. Never install the first hit on a tie.
+
+Provenance to record: the term the user supplied, the chosen `installUrl`, and the clone's HEAD SHA.
+
+## Multiple `SKILL.md` candidates
+
+Whenever a checkout could hold more than one skill and the user gave no subpath:
+
+```bash
+find "$WORK" -maxdepth 5 -name "SKILL.md" -type f
+```
+
+- One match → use its parent directory.
+- More than one → list every candidate with its parent directory and frontmatter `name`, and **ask the user which one**. Never guess. Installing the wrong skill is worse than one extra question, and unlike a wrong PR it lands on the user's machine.
+
+## Provenance record
+
+Carry these fields forward to the Phase 4 report:
+
+| Field          | Source                                                    |
+| -------------- | --------------------------------------------------------- |
+| `suppliedAs`   | The identifier the user typed, verbatim                   |
+| `resolvedFrom` | `installUrl` (name form), clone URL (repo form), or `n/a` |
+| `upstreamSha`  | `git -C "$SKILL_PATH" rev-parse HEAD`, or `n/a`           |
+| `skillName`    | Frontmatter `name` of the resolved `SKILL.md`             |
+| `skillPath`    | `$SKILL_PATH`                                             |

--- a/skills/skill-install-improved/references/target-resolution.md
+++ b/skills/skill-install-improved/references/target-resolution.md
@@ -30,9 +30,12 @@ SRC="<path the user gave>"
 # A SKILL.md file path folds to its parent directory
 [ -f "$SRC" ] && SRC="$(dirname "$SRC")"
 
-cp -R "$SRC" "$WORK/target"
-SKILL_PATH="$WORK/target"
+# Keep the original directory name — it becomes the installed directory name
+cp -R "$SRC" "$WORK/$(basename "$SRC")"
+SKILL_PATH="$WORK/$(basename "$SRC")"
 ```
+
+`asm install` names the installed directory after `$SKILL_PATH`'s basename, so a generic temp name like `$WORK/target` would install as `target`. Preserve the source directory name for every form.
 
 The copy has no `origin` remote and no history. `skill-auto-improver`'s mandatory repo sync is inapplicable — log the skip and continue.
 
@@ -50,6 +53,8 @@ SKILL_PATH="$WORK/repo/<subpath>"     # or the repo root when the skill is at to
 ```
 
 If the user gave a subpath, use it. If not, run the multi-candidate check below.
+
+**Top-level skill:** `$SKILL_PATH` would then be `$WORK/repo`, and `asm install` would name the installed directory `repo`. Copy the checkout's skill files into `$WORK/<frontmatter name>` and point `$SKILL_PATH` there instead.
 
 Provenance to record: the clone URL, the ref, and `git -C "$WORK/repo" rev-parse HEAD`.
 

--- a/skills/skill-install-improved/references/target-resolution.md
+++ b/skills/skill-install-improved/references/target-resolution.md
@@ -99,10 +99,10 @@ find "$WORK" -maxdepth 5 -name "SKILL.md" -type f
 
 Carry these fields forward to the Phase 4 report:
 
-| Field          | Source                                                    |
-| -------------- | --------------------------------------------------------- |
-| `suppliedAs`   | The identifier the user typed, verbatim                   |
-| `resolvedFrom` | `installUrl` (name form), clone URL (repo form), or `n/a` |
-| `upstreamSha`  | `git -C "$SKILL_PATH" rev-parse HEAD`, or `n/a`           |
-| `skillName`    | Frontmatter `name` of the resolved `SKILL.md`             |
-| `skillPath`    | `$SKILL_PATH`                                             |
+| Field          | Source                                                                                                                                               |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `suppliedAs`   | The identifier the user typed, verbatim                                                                                                              |
+| `resolvedFrom` | `installUrl` (name form), clone URL (repo form), or `n/a`                                                                                            |
+| `upstreamSha`  | Repo and name forms: `git -C "$WORK/repo" rev-parse HEAD`. Local path: `git -C "$SRC" rev-parse HEAD` when the source sits in a git repo, else `n/a` |
+| `skillName`    | Frontmatter `name` of the resolved `SKILL.md`                                                                                                        |
+| `skillPath`    | `$SKILL_PATH`                                                                                                                                        |


### PR DESCRIPTION
Closes #418

## Summary

Adds a new bundled skill, `skill-install-improved`, that installs an *improved* variant of one named skill instead of the skill as published. The user identifies one target — by local path, by repo, or by skill name — and the skill resolves it to a local directory, runs the existing `skill-auto-improver` against it, and installs the improved result, reporting what was improved and from what.

The deliverable is markdown only: four files under `skills/skill-install-improved/` plus a CHANGELOG entry. No `src/` change and no new CLI flag — issue #418 explicitly carves that work out to #245 ("Add 'better' install mode for improved skill variants"), which remains open. This skill *calls* the existing `asm` CLI rather than extending it.

## Approach

**Option 2 — Balanced: SKILL.md + references/ + per-skill docs/README.md.** Mirrors the layout of `skill-upstream-pr` (commit `ee34d77`), the closest prior art: resolve a possibly-remote target, prose-delegate the improvement loop to `skills/skill-auto-improver/SKILL.md`, harvest the loop's `.asm-improver/` artifacts for reporting, then perform a terminal action — here a local install rather than an upstream PR.

Three design decisions are documented explicitly in the skill:

- **Every input form is improved on a throwaway `mktemp -d` copy, local paths included.** An install that rewrites the user's working copy is a side effect they did not ask for, and `skill-auto-improver` mandates `git fetch` + `git pull --rebase` before any edit — against a local path that would rebase the user's branch. The trade-off (the improvement lands only in the installed copy; the copy has no `origin`, so the improver's repo sync is inapplicable) is stated in Prerequisites and Edge Cases.
- **Repo targets use a plain `git clone`, never `gh repo fork`** — the skill performs no public GitHub action.
- **Metrics are harvested before cleanup.** `.asm-improver/` is written relative to cwd and dies with the temp dir, so `baseline.json`, the latest `iter-N.json`, and `report.md` are read before anything is removed. This is what makes the "what it was improved from" reporting possible.

## Decision Record

- **Root cause:** Not a defect — a capability gap. #209 (closed) delivered `skill-auto-improver`, which improves a skill in place but deliberately stops short of installing it; #244 (closed) delivered `skill-upstream-pr`, which improves then opens an upstream PR. Neither covers improve-then-install-locally, which is what a user asking to "install a better version of X" actually wants.
- **Options considered:** Option 1 — Minimal, single self-contained SKILL.md; Option 2 — Balanced, SKILL.md + references/ + docs/README.md; Option 3 — Comprehensive, Balanced plus catalog publication and a persisted provenance record.
- **Options rejected:** Option 1 — fits three resolution paths, delegation, harvesting and edge cases into one body against a <500-line convention, and skips the dominant per-skill `docs/README.md` convention, leaving AC 8 thinly served; Option 3 — bolts catalog publication and a persisted provenance side effect onto an M-band issue, converting a zero-blast-radius additive PR into one that must reconcile an already-stale hand-maintained index against five assertions and rebuild the website catalog.
- **Selected option:** Option 2 — Balanced.
- **Residual risk:** The skill is a procedure, not code, so its correctness rests on the `asm` CLI behaving as documented. Two rounds of review verified every documented command and flag against source. Two known limitations are stated in the skill itself: (1) `asm install` overwrites unconditionally once invoked — it never calls `checkConflict` and `-y` suppresses the final prompt — so the skill probes with `asm list --json` and confirms *before* invoking; (2) the overwrite decision keys on frontmatter `name` + selected tool while the directory deleted is named after the source basename, two names that can disagree. `asm eval` scores the new skill 96/100 (A) with zero error findings, against 97/100 for the existing `skill-upstream-pr` used as calibration. One `asm eval` advisory remains: context efficiency 7/10 (body ~1650 words vs a 1500-word ideal window), left deliberately — closing it would cost load-bearing content.

Analyzed at: `feat/418-add-skill-to-auto-improve-a-skill @ db981f5` (2026-08-17)

## Changes

| File | Change |
|------|--------|
| `skills/skill-install-improved/SKILL.md` | New. Workflow spine: Phase 0 resolve → 1 delegate → 2 harvest → 3 install → 4 report, plus Prerequisites, Step Completion Reports, Acceptance Criteria, Expected output, Edge Cases, References. 191 lines. |
| `skills/skill-install-improved/references/target-resolution.md` | New. Normalizes the three input forms to one local `$SKILL_PATH`, preserving the real skill directory name; `asm search --available --json` with the verbatim-`installCommand` rule; the multi-`SKILL.md` ask-never-guess policy. |
| `skills/skill-install-improved/references/install-and-report.md` | New. Install flags, the collision policy written against real `asm install` behavior, the harvested field list, and the report templates (normal / no-op / blocker). |
| `skills/skill-install-improved/docs/README.md` | New. Human catalog page with the mandatory AI-skip block, highlights, trigger table, and a mermaid flow. |
| `CHANGELOG.md` | Added an `Unreleased → Features` entry naming the skill and #418. |

## Test Results

- Unit tests: 1960 passed, 1 local-environment failure (see below); CI green 13/13
- Integration tests: skipped — none apply to a markdown-only change
- E2e tests: skipped — none apply to a markdown-only change
- Build: passed (`npx tsc --noEmit` exit 0)
- QA cycles: 2

**Validator gates** (these stand in for specs — bundled skills have no vitest coverage in this repo, and no test enumerates or globs the repo-root `skills/` dir; `ee34d77` added `skill-upstream-pr` as four markdown files and nothing else):

| Gate | Result |
|------|--------|
| `asm eval skills/skill-install-improved` | 96/100 (A), zero error findings |
| `asm eval skills/skill-upstream-pr` (calibration) | 97/100 (A) |
| `quick_validate.py` | valid |
| prettier | clean |
| `gi-secscan.py --range origin/main` | clean, 11 files scanned |

> **Local-environment test failure — not a repo defect, and not introduced by this PR.** `src/skill-index.test.ts:232` fails with `expected 9 to be 8` on the author's machine only. Cause: `loadAllIndices()` (`src/skill-index.ts:97-108`) merges the bundled index with a user-level one under `~/.config/agent-skill-manager/skill-index/`, and user entries override bundled ones for the same `owner/repo`. The committed `data/skill-index/emilkowalski_skills.json` still pins 8 skills; the local override carries 9 (it adds `animate`). CI has no such directory, so all three `unit-tests` jobs are green on this head. **The repo needs no catalog refresh for this** — the earlier "pinned count has drifted" reading was wrong. Unrelated to #418 and left untouched. (The underlying non-hermeticity — a unit test whose result depends on the developer's `~/.config` state — is a separate pre-existing concern.)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| A new bundled skill exists whose purpose is to install an improved version of one named skill | pass | `skills/skill-install-improved/SKILL.md` — title paragraph, "One skill per run" |
| The target skill can be identified by a local path | pass | SKILL.md Inputs + Phase 0 "Local path"; `references/target-resolution.md` Form 1. Copied to `mktemp -d` first, so the user's tree is never modified — decision and trade-off documented in Prerequisites and Edge Cases |
| The target skill can be identified by the repo it belongs to | pass | SKILL.md Phase 0 "Repo"; `references/target-resolution.md` Form 2 — plain `git clone`, never `gh repo fork` |
| The target skill can be identified by skill name | pass | SKILL.md Phase 0 "Skill name"; `references/target-resolution.md` Form 3 — `asm search --available --json`, `installCommand` copied verbatim per `skills/find-me-skills/references/catalog-discovery.md:28` |
| The original skill is run through `skill-auto-improver` before installation | pass | SKILL.md Phase 1 "Delegate to skill-auto-improver", naming the repo-relative path in the `skill-upstream-pr:91-98` idiom; restated as an Acceptance Criterion inside the skill |
| The improved skill — not the original — is what ends up installed | pass | SKILL.md Phase 3 — `asm install "$SKILL_PATH"` (the improved directory) with an explicit "never the original source" rule, preceded by the `asm list --json` collision probe and confirmation |
| The user can tell from the run's output that an improved variant was installed and what it was improved from | pass | SKILL.md Phase 4 + `references/install-and-report.md` report template: provenance (supplied identifier, resolved URL, upstream SHA) and baseline → final score, grade, min category, version, iterations. The no-improvement-needed and BLOCKER variants keep the report truthful rather than implying a delta that did not occur |
| The new skill is documented alongside the other bundled skills | pass | `skills/skill-install-improved/docs/README.md`, matching `skill-auto-improver` and `skill-upstream-pr`, plus a `CHANGELOG.md` entry. Verified no other roster exists: grepping the six bundled skill names across `README.md`, `README.backup.md`, `docs/*.md`, `CONTRIBUTING.md` and `.github/` returns zero hits, and `ee34d77` likewise added only its own `docs/README.md` |

<!-- gitissue:qa v1 head=db981f5622e4a4ad477ffb4f8727f36a3dcadeaa profile=full cycles=2 review=clean tests=1960@db981f5622e4a4ad477ffb4f8727f36a3dcadeaa ui=none -->

