### PR TITLE
fix(auditor): keep same-realpath skills from audit -y (#416)

### DIFF
--- a/src/auditor.test.ts
+++ b/src/auditor.test.ts
@@ -337,6 +337,142 @@ describe("detectDuplicates", () => {
     expect(report.duplicateGroups[0].reason).toBe("same-dirName");
     expect(report.duplicateGroups[0].instances).toHaveLength(2);
   });
+
+  it("treats two non-symlink rows with the same realPath as one installation", () => {
+    const shared = "/home/user/.agents/skills/code-review";
+    const skills = [
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: shared,
+        originalPath: shared,
+        realPath: shared,
+        location: "global-agents",
+        scope: "global",
+        provider: "agents",
+        isSymlink: false,
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: shared,
+        originalPath: shared,
+        realPath: shared,
+        location: "project-agents",
+        scope: "project",
+        provider: "agents",
+        isSymlink: false,
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(0);
+    expect(report.totalSkills).toBe(2);
+  });
+
+  it("does not report the same .agents/skills dir as global and project when cwd is home", () => {
+    const home = "/home/user";
+    const realPath = `${home}/.agents/skills/code-review`;
+    const skills = [
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: `${home}/.agents/skills/code-review`,
+        originalPath: `${home}/.agents/skills/code-review`,
+        realPath,
+        location: "global-agents",
+        scope: "global",
+        provider: "agents",
+        isSymlink: false,
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: `${home}/.agents/skills/code-review`,
+        originalPath: "./.agents/skills/code-review",
+        realPath,
+        location: "project-agents",
+        scope: "project",
+        provider: "agents",
+        isSymlink: false,
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(0);
+    expect(report.totalDuplicateInstances).toBe(0);
+  });
+
+  it("still groups genuinely separate global and project copies", () => {
+    const skills = [
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/home/user/.agents/skills/code-review",
+        realPath: "/home/user/.agents/skills/code-review",
+        location: "global-agents",
+        scope: "global",
+        provider: "agents",
+        isSymlink: false,
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/project/.agents/skills/code-review",
+        realPath: "/project/.agents/skills/code-review",
+        location: "project-agents",
+        scope: "project",
+        provider: "agents",
+        isSymlink: false,
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(1);
+    expect(report.duplicateGroups[0].reason).toBe("same-dirName");
+    expect(report.duplicateGroups[0].instances).toHaveLength(2);
+  });
+
+  it("prefers the global instance when collapsing same-realPath non-symlinks", () => {
+    const shared = "/home/user/.agents/skills/code-review";
+    const other = "/home/user/.codex/skills/code-review";
+    const skills = [
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: shared,
+        realPath: shared,
+        location: "project-agents",
+        scope: "project",
+        provider: "agents",
+        isSymlink: false,
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: shared,
+        realPath: shared,
+        location: "global-agents",
+        scope: "global",
+        provider: "agents",
+        isSymlink: false,
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: other,
+        realPath: other,
+        location: "global-codex",
+        scope: "global",
+        provider: "codex",
+        isSymlink: false,
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(1);
+    expect(report.duplicateGroups[0].instances).toHaveLength(2);
+    const scopes = report.duplicateGroups[0].instances.map((i) => i.location);
+    expect(scopes).toContain("global-agents");
+    expect(scopes).not.toContain("project-agents");
+    expect(scopes).toContain("global-codex");
+  });
 });
 
 describe("sortInstancesForKeep", () => {

--- a/src/auditor.ts
+++ b/src/auditor.ts
@@ -21,10 +21,12 @@ export function detectDuplicates(skills: SkillInfo[]): AuditReport {
         deduped[deduped.indexOf(existing)] = s;
         seenRealPaths.set(s.realPath, s);
       }
-      // Both non-symlinks with same realPath — keep both (different copies)
-      // This shouldn't normally happen but is safe
-      else {
-        deduped.push(s);
+      // Both non-symlinks with the same realPath — one physical install
+      // (e.g. cwd === $HOME so ~/.agents/skills and ./.agents/skills collide).
+      // Prefer global scope; otherwise keep the first seen instance.
+      else if (s.scope === "global" && existing.scope !== "global") {
+        deduped[deduped.indexOf(existing)] = s;
+        seenRealPaths.set(s.realPath, s);
       }
     } else {
       seenRealPaths.set(s.realPath, s);

--- a/src/uninstaller.test.ts
+++ b/src/uninstaller.test.ts
@@ -43,6 +43,7 @@ import {
   mkdtemp,
   mkdir,
   writeFile,
+  readFile,
   readlink,
   lstat,
   realpath,
@@ -413,6 +414,56 @@ describe("executeRemoval with symlinkTo", () => {
       } catch (err: any) {
         expect(err.code).toBe("ENOENT");
       }
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("does not delete a directory whose resolved path matches symlinkTo", async () => {
+    const base = await mkdtemp(join(tmpdir(), "asm-test-samepath-"));
+    try {
+      const keptDir = join(base, "skill");
+      await mkdir(keptDir, { recursive: true });
+      await writeFile(join(keptDir, "SKILL.md"), "kept");
+
+      const plan: RemovalPlan = {
+        directories: [{ path: keptDir, isSymlink: false }],
+        ruleFiles: [],
+        agentsBlocks: [],
+      };
+
+      const log = await executeRemoval(plan, keptDir);
+
+      const stats = await lstat(keptDir);
+      expect(stats.isDirectory()).toBe(true);
+      const content = await readFile(join(keptDir, "SKILL.md"), "utf-8");
+      expect(content).toBe("kept");
+      expect(log.some((l) => /skipped same-path/i.test(l))).toBe(true);
+      expect(log.some((l) => l.startsWith("Removed directory:"))).toBe(false);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("does not delete when symlinkTo is the same path via a different string", async () => {
+    const base = await mkdtemp(join(tmpdir(), "asm-test-samepath-resolve-"));
+    try {
+      const keptDir = join(base, "skill");
+      await mkdir(keptDir, { recursive: true });
+      await writeFile(join(keptDir, "SKILL.md"), "kept");
+
+      const aliased = join(base, ".", "skill");
+      const plan: RemovalPlan = {
+        directories: [{ path: aliased, isSymlink: false }],
+        ruleFiles: [],
+        agentsBlocks: [],
+      };
+
+      const log = await executeRemoval(plan, keptDir);
+
+      const stats = await lstat(keptDir);
+      expect(stats.isDirectory()).toBe(true);
+      expect(log.some((l) => /skipped same-path/i.test(l))).toBe(true);
     } finally {
       await rm(base, { recursive: true, force: true });
     }

--- a/src/uninstaller.ts
+++ b/src/uninstaller.ts
@@ -442,6 +442,11 @@ export async function executeRemoval(
         continue;
       }
 
+      if (symlinkTo && resolve(dir.path) === resolve(symlinkTo)) {
+        log.push(`Skipped same-path removal: ${dir.path}`);
+        continue;
+      }
+
       if (dir.isSymlink) {
         await rm(dir.path);
         log.push(`Removed symlink: ${dir.path}`);


### PR DESCRIPTION
Closes #416

## Summary

When `asm` is run from the user's home directory, Agents global (`~/.agents/skills`) and project (`./.agents/skills`) paths resolve to the same directory. `asm audit` listed that one install twice and `asm audit -y` deleted the directory marked `[keep]`. Duplicate detection now collapses non-symlink rows that share a `realPath`, and removal skips a path that resolves to the kept instance.

## Approach

Direct minimal plan (light profile): collapse same-`realPath` non-symlink rows in `detectDuplicates`, preferring global scope, and skip `executeRemoval` when `resolve(dir.path) === resolve(symlinkTo)`.

## Decision Record

- **Root cause:** `detectDuplicates` kept both non-symlink rows that shared a `realPath`. Rule 1 then grouped them as `same-dirName` (global-agents vs project-agents). `asm audit -y` passed the project path to `executeRemoval` with `symlinkTo` set to the keep path; those paths were the same physical directory, so `rm` deleted the kept skill.
- **Options considered:** Option 1 — collapse same-`realPath` rows in the auditor and skip same-path removal in the uninstaller
- **Options rejected:** n/a — trivial change, direct plan (light profile)
- **Selected option:** Option 1 — collapse same-`realPath` rows in the auditor and skip same-path removal in the uninstaller
- **Residual risk:** Genuine separate copies (different `realPath`) still dedupe as before. Other providers are only affected if they emit two non-symlink rows for the same physical path.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle
- **Reproduction:** `npx vitest run src/auditor.test.ts -t "same realPath"` confirmed red (duplicate group of 2) → fixed → `src/auditor.test.ts`; `npx vitest run src/uninstaller.test.ts -t "resolved path matches symlinkTo"` confirmed red (directory removed) → fixed → `src/uninstaller.test.ts`

Analyzed at: `origin/main @ dc5102b` (2026-08-17)

## Changes

| File | Change |
|------|--------|
| `src/auditor.ts` | Collapse two non-symlink rows with the same `realPath` into one install; prefer global |
| `src/uninstaller.ts` | Skip removal when `resolve(dir.path) === resolve(symlinkTo)` |
| `src/auditor.test.ts` | Same-`realPath`, cwd=home, genuine-copies, prefer-global cases |
| `src/uninstaller.test.ts` | Same-path and aliased-resolve keep-path cases |

## Test Results

- Unit tests: 86 passed (`src/auditor.test.ts` 31, `src/uninstaller.test.ts` 55)
- Broader `src/` suite excluding live-index snapshot: 1945 passed
- Full `npm test`: 1966 passed, 1 failed — pre-existing `src/skill-index.test.ts` emilkowalski `skillCount` 8 vs 9 (not introduced by this change; blocks local pre-commit hooks)
- Integration tests: skipped
- E2e tests: pre-push hook `e2e tests (node)` passed
- Build: typecheck passed; pre-push `build` passed
- QA cycles: 1 (review PASS, 0 findings)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Skills with identical resolved `realPath` values are treated as a single installation | pass | Verified red: `npx vitest run src/auditor.test.ts -t "same realPath"` → fixed → `src/auditor.test.ts` (`treats two non-symlink rows with the same realPath as one installation`) |
| Running `asm audit` from the user's home directory does not report the same `.agents/skills` directory as both a removable global and project duplicate | pass | Verified red: `npx vitest run src/auditor.test.ts -t "cwd is home"` → fixed → `src/auditor.test.ts` (`does not report the same .agents/skills dir as global and project when cwd is home`) |
| `asm audit -y` never deletes a directory when its resolved path matches the selected keep path | pass | Verified red: `npx vitest run src/uninstaller.test.ts -t "resolved path matches symlinkTo"` → fixed → `src/uninstaller.test.ts` (`does not delete a directory whose resolved path matches symlinkTo`) |
| Add a regression test for the case where the working directory equals the user's home directory | pass | `src/auditor.test.ts` (`does not report the same .agents/skills dir as global and project when cwd is home`) |
| Existing duplicate detection for genuinely separate global/project copies continues to work | pass | `src/auditor.test.ts` (`still groups genuinely separate global and project copies`) |
