### PR TITLE
feat(stats): report and audit resident context cost of installed skills (#421)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | Scattered installs      | Same skill copied into `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/rules/` — different versions, no single view | One `asm list` across all 19 providers and scopes                          |
 | No inventory            | `ls` through hidden dirs; no idea what is installed, duplicated, or outdated                                            | `asm search`, `asm inspect`, `asm stats`, `asm audit`                      |
+| Invisible context cost  | Every installed skill's description is resident in the agent's prompt on every message, whether or not it ever fires    | `asm stats --tokens`, `asm audit residency`                                |
 | Risky manual installs   | Clone repos, copy folders, hope `SKILL.md` is valid                                                                     | `asm install` validates frontmatter, scans security, pins registry commits |
 | Agent-unfriendly output | Human-only copy-paste workflows                                                                                         | Structured JSON via `--json`; skip prompts with `--yes`                    |
 | New agent, new chore    | Every tool adds another skill directory to track                                                                        | Add or disable providers in one config file                                |
@@ -67,17 +68,19 @@ graph LR
 
 ## Features
 
-| Feature                  | What you get                                                        |
-| ------------------------ | ------------------------------------------------------------------- |
-| Cross-provider inventory | `asm list --json` — every skill, every agent, one response          |
-| One-command install      | `asm install github:user/repo` or `asm install skill-name`          |
-| Agent-parseable output   | `--json` on list, search, inspect, install, audit                   |
-| Duplicate audit          | `asm audit --yes` removes redundant skills non-interactively        |
-| Security scan            | `asm audit security` before install                                 |
-| Authoring pipeline       | `asm init`, `asm link`, `asm eval`, `asm publish`                   |
-| Bundles                  | `asm bundle install` — curated sets in one pass                     |
-| Local library            | `asm install --library` — install once, `asm activate` per provider |
-| Cross-tool linking       | Reinstall or symlink when a skill already exists in another tool    |
+| Feature                  | What you get                                                         |
+| ------------------------ | -------------------------------------------------------------------- |
+| Cross-provider inventory | `asm list --json` — every skill, every agent, one response           |
+| One-command install      | `asm install github:user/repo` or `asm install skill-name`           |
+| Agent-parseable output   | `--json` on list, search, inspect, install, audit                    |
+| Duplicate audit          | `asm audit --yes` removes redundant skills non-interactively         |
+| Attention budget         | `asm stats --tokens` shows resident vs body token cost per tool      |
+| Residency audit          | `asm audit residency` ranks skills to demote out of resident context |
+| Security scan            | `asm audit security` before install                                  |
+| Authoring pipeline       | `asm init`, `asm link`, `asm eval`, `asm publish`                    |
+| Bundles                  | `asm bundle install` — curated sets in one pass                      |
+| Local library            | `asm install --library` — install once, `asm activate` per provider  |
+| Cross-tool linking       | Reinstall or symlink when a skill already exists in another tool     |
 
 ## Getting started
 
@@ -117,6 +120,8 @@ Node.js 18+ required. Optional TUI: run `asm` with no arguments.
 | Skill metadata for agents  | `asm inspect my-skill --json`                    |
 | Non-interactive install    | `asm install code-review -p claude --yes --json` |
 | Remove duplicates          | `asm audit --yes`                                |
+| See your context cost      | `asm stats --tokens`                             |
+| Find skills to demote      | `asm audit residency`                            |
 | Scan before install        | `asm audit security github:user/repo`            |
 | Scaffold a new skill       | `asm init my-skill -p claude`                    |
 | Live dev via symlink       | `asm link ./my-skill -p claude`                  |
@@ -124,6 +129,66 @@ Node.js 18+ required. Optional TUI: run `asm` with no arguments.
 | Install a bundle           | `asm bundle install frontend-dev --yes`          |
 
 Full command reference, flags, and examples: [CLI Commands](#cli-commands). Catalog UI and bundles: [luongnv.com/asm](https://luongnv.com/asm/).
+
+## Attention budget
+
+Disk is cheap; context is not. Every installed skill's frontmatter
+`description` sits in the agent's system prompt on **every message**, whether or
+not the skill ever fires. The full `SKILL.md` body only costs anything when the
+skill actually fires.
+
+`asm` reports the two separately — token counts are estimates and always render
+with a leading `~`:
+
+```bash
+asm stats --tokens            # resident vs body tokens, per tool and per scope
+asm stats --tokens --json     # same data for scripts and agents
+```
+
+```text
+  Tool           Skills      Resident  Bodies
+  Claude Code        74    ~5k tokens  ~281k tokens
+  Codex              10  ~736 tokens   ~76k tokens
+  ------------------------------------------------
+  Total              84  ~5.7k tokens  ~357k tokens
+
+  Heaviest resident descriptions
+    docx           ~233 tokens  (claude, global)
+    pptx           ~217 tokens  (claude, global)
+```
+
+### Residency audit
+
+`asm audit residency` ranks the installed skills that are not earning their
+resident context and pairs each one with a command that works for how that
+skill is actually installed. It only reports — nothing is deactivated,
+disabled, or removed unless you run one of the suggested commands yourself.
+
+```bash
+asm audit residency
+asm audit residency --json
+```
+
+The advice assumes this demotion ladder:
+
+| Tier                      | `asm` mechanism                           | Residency                    |
+| ------------------------- | ----------------------------------------- | ---------------------------- |
+| Installed (auto-triggers) | provider directory / `asm activate`       | description resident, always |
+| Saved (adapt, no trigger) | `asm install --library` + `asm activate`  | none until activated         |
+| Disabled (kept on disk)   | `asm disable` (reverse with `asm enable`) | none                         |
+
+Which command a candidate gets depends on how it is installed. `asm deactivate`
+only works on a live symlink into the `asm` library, so it is suggested only
+there; everything else gets `asm disable`, which is universal and reversible.
+Skills provided by plugin marketplaces are counted in the totals but never
+listed as candidates — no `asm` command demotes them.
+
+Two of the signals the report would like to use — trigger collision and
+last-used counts — have no data source in `asm` yet. They are listed as
+unavailable rather than silently dropped, so the report still works today.
+
+No network calls, accounts, or telemetry are involved: both reports run
+entirely against your local filesystem.
 
 ## FAQ
 
@@ -406,43 +471,45 @@ Multiple `asm` binaries on `PATH` can shadow a fresh upgrade.
 
 ### Commands
 
-| Command                         | Description                          |
-| ------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `asm list`                      | List all discovered skills           |
-| `asm search <query>`            | Search by name/description/provider  |
-| `asm inspect <skill-name>`      | Show detailed info for a skill       |
-| `asm install <source>`          | Install from GitHub or registry      |
-| `asm publish [path]`            | Publish to ASM Registry              |
-| `asm uninstall <skill-name>`    | Remove a skill                       |
-| `asm init <name>`               | Scaffold a new skill                 |
-| `asm link <path> [<path2> ...]` | Symlink skills for live dev          |
-| `asm audit`                     | Detect duplicate skills              |
-| `asm audit security <name>`     | Security audit                       |
-| `asm eval <skill>`              | Score skill quality                  |
-| `asm eval-providers list`       | List eval providers                  |
-| `asm stats`                     | Aggregate installed skill metrics    |
-| `asm stats repo <repo>`         | Per-repo indexed skill stats         |
-| `asm stats author <owner>`      | Per-author indexed skill stats       |
-| `asm stats index`               | Indexed catalog stats summary        |
-| `asm activate <skill>`          | Link a library skill into a provider |
-| `asm deactivate <skill>`        | Remove a library activation symlink  |
-| `asm library list               | update`                              | Manage centrally installed library skills |
-| `asm export`                    | Export inventory as JSON             |
-| `asm index ingest <repo>`       | Index a skill repo                   |
-| `asm index search <query>`      | Search indexed skills                |
-| `asm index list`                | List indexed repos                   |
-| `asm index remove <owner/repo>` | Remove repo from index               |
-| `asm bundle list`               | List bundles (`--predefined`)        |
-| `asm bundle install <name>`     | Install every skill in a bundle      |
-| `asm bundle create <name>`      | Create bundle from installed skills  |
-| `asm bundle show <name>`        | Show bundle details                  |
-| `asm bundle modify <name>`      | Add/remove skills                    |
-| `asm bundle export <name>`      | Export bundle to JSON                |
-| `asm bundle remove <name>`      | Remove saved bundle                  |
-| `asm config show`               | Print config                         |
-| `asm config path`               | Print config path                    |
-| `asm config reset`              | Reset to defaults                    |
-| `asm config edit`               | Open config in `$EDITOR`             |
+| Command                         | Description                               |
+| ------------------------------- | ----------------------------------------- | ----------------------------------------- |
+| `asm list`                      | List all discovered skills                |
+| `asm search <query>`            | Search by name/description/provider       |
+| `asm inspect <skill-name>`      | Show detailed info for a skill            |
+| `asm install <source>`          | Install from GitHub or registry           |
+| `asm publish [path]`            | Publish to ASM Registry                   |
+| `asm uninstall <skill-name>`    | Remove a skill                            |
+| `asm init <name>`               | Scaffold a new skill                      |
+| `asm link <path> [<path2> ...]` | Symlink skills for live dev               |
+| `asm audit`                     | Detect duplicate skills                   |
+| `asm audit security <name>`     | Security audit                            |
+| `asm audit residency`           | Rank skills that do not earn residency    |
+| `asm eval <skill>`              | Score skill quality                       |
+| `asm eval-providers list`       | List eval providers                       |
+| `asm stats`                     | Aggregate installed skill metrics         |
+| `asm stats --tokens`            | Attention budget: resident vs body tokens |
+| `asm stats repo <repo>`         | Per-repo indexed skill stats              |
+| `asm stats author <owner>`      | Per-author indexed skill stats            |
+| `asm stats index`               | Indexed catalog stats summary             |
+| `asm activate <skill>`          | Link a library skill into a provider      |
+| `asm deactivate <skill>`        | Remove a library activation symlink       |
+| `asm library list               | update`                                   | Manage centrally installed library skills |
+| `asm export`                    | Export inventory as JSON                  |
+| `asm index ingest <repo>`       | Index a skill repo                        |
+| `asm index search <query>`      | Search indexed skills                     |
+| `asm index list`                | List indexed repos                        |
+| `asm index remove <owner/repo>` | Remove repo from index                    |
+| `asm bundle list`               | List bundles (`--predefined`)             |
+| `asm bundle install <name>`     | Install every skill in a bundle           |
+| `asm bundle create <name>`      | Create bundle from installed skills       |
+| `asm bundle show <name>`        | Show bundle details                       |
+| `asm bundle modify <name>`      | Add/remove skills                         |
+| `asm bundle export <name>`      | Export bundle to JSON                     |
+| `asm bundle remove <name>`      | Remove saved bundle                       |
+| `asm config show`               | Print config                              |
+| `asm config path`               | Print config path                         |
+| `asm config reset`              | Reset to defaults                         |
+| `asm config edit`               | Open config in `$EDITOR`                  |
 
 ### Global options
 
@@ -484,6 +551,14 @@ asm audit security github:user/repo
 
 ```bash
 asm audit security --all
+```
+
+```bash
+asm stats --tokens
+```
+
+```bash
+asm audit residency --json
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -146,15 +146,36 @@ asm stats --tokens --json     # same data for scripts and agents
 ```
 
 ```text
-  Tool           Skills      Resident  Bodies
-  Claude Code        74    ~5k tokens  ~281k tokens
-  Codex              10  ~736 tokens   ~76k tokens
-  ------------------------------------------------
-  Total              84  ~5.7k tokens  ~357k tokens
+  Attention Budget
+  ----------------------------------------
+
+  Resident = frontmatter descriptions, paid on every message.
+  Bodies   = full SKILL.md, paid only when a skill fires.
+
+  Tool         Skills      Resident  Bodies
+  Claude Code      74    ~5k tokens  ~281k tokens
+  Codex            10   ~736 tokens  ~76k tokens
+  ---------------------------------------------
+  Total            84  ~5.7k tokens  ~357k tokens
+
+  By Scope
+  global           71  ~4.9k tokens  ~300k tokens
+  project          13   ~836 tokens  ~57k tokens
 
   Heaviest resident descriptions
-    docx           ~233 tokens  (claude, global)
-    pptx           ~217 tokens  (claude, global)
+    claude-api       ~1.2k tokens  (claude, global)
+    docx              ~233 tokens  (claude, global)
+    pptx              ~217 tokens  (claude, global)
+    code-review       ~198 tokens  (claude, global)
+    frontend-design   ~176 tokens  (claude, project)
+    dataviz           ~164 tokens  (claude, global)
+    skill-creator     ~151 tokens  (claude, global)
+    xlsx              ~143 tokens  (claude, global)
+    pdf               ~138 tokens  (claude, global)
+    release-manager   ~129 tokens  (codex, global)
+
+  Median resident cost: ~48 tokens
+  Run asm audit residency for demotion advice
 ```
 
 ### Residency audit

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The advice assumes this demotion ladder:
 | Tier                      | `asm` mechanism                           | Residency                    |
 | ------------------------- | ----------------------------------------- | ---------------------------- |
 | Installed (auto-triggers) | provider directory / `asm activate`       | description resident, always |
-| Saved (adapt, no trigger) | `asm install --library` + `asm activate`  | none until activated         |
+| Saved (adapt, no trigger) | `asm install --library`, `asm deactivate` | none until `asm activate`    |
 | Disabled (kept on disk)   | `asm disable` (reverse with `asm enable`) | none                         |
 
 Which command a candidate gets depends on how it is installed. `asm deactivate`

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1256,8 +1256,15 @@ describe("CLI integration: audit residency (issue #423)", () => {
 
   test("--yes never triggers a removal on the residency path", async () => {
     // `asm audit -y` auto-removes duplicates; residency must stay read-only.
-    const { stdout, exitCode } = await runCLI("audit", "residency", "--yes");
+    // The banner is printed with console.error, so stderr is the stream that
+    // can actually fail this assertion.
+    const { stdout, stderr, exitCode } = await runCLI(
+      "audit",
+      "residency",
+      "--yes",
+    );
     expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("Auto-removing");
     expect(stdout).not.toContain("Auto-removing");
   });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -340,6 +340,35 @@ describe("parseArgs", () => {
 
 // ─── isCLIMode unit tests ──────────────────────────────────────────────────
 
+describe("parseArgs: --tokens (issue #421)", () => {
+  test("defaults to false", () => {
+    expect(parseArgs(["node", "cli", "stats"]).flags.tokens).toBe(false);
+  });
+
+  test("--tokens sets the attention-budget flag", () => {
+    const args = parseArgs(["node", "cli", "stats", "--tokens"]);
+    expect(args.command).toBe("stats");
+    expect(args.flags.tokens).toBe(true);
+  });
+
+  test("--tokens combines with --json and --machine", () => {
+    expect(
+      parseArgs(["node", "cli", "stats", "--tokens", "--json"]).flags,
+    ).toMatchObject({ tokens: true, json: true });
+    expect(
+      parseArgs(["node", "cli", "stats", "--tokens", "--machine"]).flags,
+    ).toMatchObject({ tokens: true, machine: true });
+  });
+});
+
+describe("parseArgs: audit residency (issue #423)", () => {
+  test("residency parses as an audit subcommand, not a top-level verb", () => {
+    const args = parseArgs(["node", "cli", "audit", "residency"]);
+    expect(args.command).toBe("audit");
+    expect(args.subcommand).toBe("residency");
+  });
+});
+
 describe("isCLIMode", () => {
   const check = (...args: string[]) =>
     isCLIMode(["node", "script.ts", ...args]);
@@ -1108,6 +1137,114 @@ describe("CLI integration: audit", () => {
   test("main --help includes audit command", async () => {
     const { stdout } = await runCLI("--help");
     expect(stdout).toContain("audit");
+  });
+});
+
+describe("CLI integration: stats --tokens (issue #421)", () => {
+  test("--tokens exits 0 and reports the attention budget", async () => {
+    const { stdout, exitCode } = await runCLI("stats", "--tokens");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Attention Budget");
+  });
+
+  test("--tokens --json returns resident and body totals separately", async () => {
+    const { stdout, exitCode } = await runCLI("stats", "--tokens", "--json");
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data).toHaveProperty("totalResidentTokens");
+    expect(data).toHaveProperty("totalBodyTokens");
+    expect(data).toHaveProperty("medianResidentTokens");
+    expect(Array.isArray(data.byProvider)).toBe(true);
+    expect(Array.isArray(data.byScope)).toBe(true);
+    expect(Array.isArray(data.heaviestResident)).toBe(true);
+  });
+
+  test("--tokens --machine emits the v1 envelope", async () => {
+    const { stdout, exitCode } = await runCLI("stats", "--tokens", "--machine");
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.version).toBe(1);
+    expect(envelope.command).toBe("stats tokens");
+    expect(envelope.status).toBe("ok");
+    expect(envelope.data).toHaveProperty("totalResidentTokens");
+  });
+
+  test("--machine is honoured by the plain dashboard too", async () => {
+    const { stdout, exitCode } = await runCLI("stats", "--machine");
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.version).toBe(1);
+    expect(envelope.command).toBe("stats");
+    expect(envelope.data).toHaveProperty("totalResidentTokens");
+  });
+
+  test("stats --help documents the new flags", async () => {
+    const { stdout, exitCode } = await runCLI("stats", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--tokens");
+    expect(stdout).toContain("--machine");
+  });
+});
+
+describe("CLI integration: audit residency (issue #423)", () => {
+  test("audit residency exits 0 and reports without changing anything", async () => {
+    const { stdout, exitCode } = await runCLI("audit", "residency");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Residency Audit");
+  });
+
+  test("--yes never triggers a removal on the residency path", async () => {
+    // `asm audit -y` auto-removes duplicates; residency must stay read-only.
+    const { stdout, exitCode } = await runCLI("audit", "residency", "--yes");
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain("Auto-removing");
+  });
+
+  test("audit residency --json has the audit report shape", async () => {
+    const { stdout, exitCode } = await runCLI("audit", "residency", "--json");
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data).toHaveProperty("scannedAt");
+    expect(data).toHaveProperty("totalSkills");
+    expect(data).toHaveProperty("totalResidentTokens");
+    expect(Array.isArray(data.candidates)).toBe(true);
+    expect(Array.isArray(data.signals)).toBe(true);
+  });
+
+  test("unavailable signals are reported, not omitted", async () => {
+    const { stdout } = await runCLI("audit", "residency", "--json");
+    const { signals } = JSON.parse(stdout);
+    const unavailable = signals.filter(
+      (s: { available: boolean }) => !s.available,
+    );
+    expect(unavailable.map((s: { id: string }) => s.id).sort()).toEqual([
+      "trigger-collision",
+      "unused",
+    ]);
+  });
+
+  test("audit residency --machine emits the v1 envelope", async () => {
+    const { stdout, exitCode } = await runCLI(
+      "audit",
+      "residency",
+      "--machine",
+    );
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.version).toBe(1);
+    expect(envelope.command).toBe("audit residency");
+    expect(envelope.data).toHaveProperty("candidates");
+  });
+
+  test("audit --help lists the residency subcommand", async () => {
+    const { stdout } = await runCLI("audit", "--help");
+    expect(stdout).toContain("residency");
+  });
+
+  test("unknown audit subcommand names residency", async () => {
+    const { stderr, exitCode } = await runCLI("audit", "bogus");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("residency");
   });
 });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1186,6 +1186,67 @@ describe("CLI integration: stats --tokens (issue #421)", () => {
   });
 });
 
+describe("CLI integration: stats with nothing installed", () => {
+  let emptyHome: string;
+  let emptyCwd: string;
+
+  beforeEach(async () => {
+    emptyHome = await mkdtemp(join(tmpdir(), "asm-empty-home-"));
+    emptyCwd = await mkdtemp(join(tmpdir(), "asm-empty-cwd-"));
+  });
+
+  afterEach(async () => {
+    await rm(emptyHome, { recursive: true, force: true });
+    await rm(emptyCwd, { recursive: true, force: true });
+  });
+
+  const runEmpty = (...args: string[]) =>
+    spawnCollect(["npx", "tsx", CLI_BIN, ...args], {
+      cwd: emptyCwd,
+      env: { ...process.env, HOME: emptyHome, NO_COLOR: "1" },
+    });
+
+  test("--json emits a parseable report, not the human sentence", async () => {
+    const { stdout, exitCode } = await runEmpty("stats", "--json");
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.totalSkills).toBe(0);
+    expect(data.totalResidentTokens).toBe(0);
+    expect(data.totalBodyTokens).toBe(0);
+    expect(data).not.toHaveProperty("perSkillDiskBytes");
+  });
+
+  test("--json --verbose keeps perSkillDiskBytes even when empty", async () => {
+    const { stdout, exitCode } = await runEmpty("stats", "--json", "--verbose");
+    expect(exitCode).toBe(0);
+    const start = stdout.indexOf("{");
+    const data = JSON.parse(stdout.slice(start));
+    expect(data).toHaveProperty("perSkillDiskBytes");
+  });
+
+  test("--machine emits the v1 envelope", async () => {
+    const { stdout, exitCode } = await runEmpty("stats", "--machine");
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout).data.totalSkills).toBe(0);
+  });
+
+  test("the human dashboard still degrades to a sentence", async () => {
+    const { stdout, exitCode } = await runEmpty("stats");
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe("No skills found.");
+  });
+
+  test("--tokens and audit residency both report an empty set", async () => {
+    const budget = await runEmpty("stats", "--tokens");
+    expect(budget.exitCode).toBe(0);
+    expect(budget.stdout).toContain("No installed skills");
+
+    const residency = await runEmpty("audit", "residency");
+    expect(residency.exitCode).toBe(0);
+    expect(residency.stdout).toContain("No installed skills");
+  });
+});
+
 describe("CLI integration: audit residency (issue #423)", () => {
   test("audit residency exits 0 and reports without changing anything", async () => {
     const { stdout, exitCode } = await runCLI("audit", "residency");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,7 +103,10 @@ import {
   formatRepoStatsReport,
   formatAuthorStatsReport,
   formatIndexStatsReport,
+  computeTokenBudget,
+  formatTokenBudgetReport,
 } from "./stats";
+import { computeResidencyAudit, formatResidencyReport } from "./residency";
 import {
   validateLinkSource,
   createLink,
@@ -315,6 +318,12 @@ interface ParsedArgs {
      * users can inspect what was fetched (issue #193).
      */
     keep: boolean;
+    /**
+     * `asm stats --tokens` — attention-budget view over the installed set:
+     * resident (frontmatter description, paid every message) vs body (full
+     * SKILL.md, paid only when the skill fires) tokens (issue #421).
+     */
+    tokens: boolean;
     /** `asm bundle modify --add <installUrl>` — skill install URL to add (issue #204). */
     add: string | null;
     /** `asm bundle modify --remove <skillName>` — skill name to remove (issue #204). */
@@ -370,6 +379,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       limit: 0,
       concurrency: 0,
       keep: false,
+      tokens: false,
       add: null,
       remove: null,
       description: null,
@@ -479,6 +489,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.flags.concurrency = n;
     } else if (arg === "--keep") {
       result.flags.keep = true;
+    } else if (arg === "--tokens") {
+      result.flags.tokens = true;
     } else if (arg === "--transport" || arg === "-t") {
       i++;
       const val = args[i];
@@ -731,6 +743,7 @@ Detect duplicate skills or run security audits on installed/remote skills.
 ${ansi.bold("Subcommands:")}
   duplicates             Find duplicate skills (default)
   security <name|source> Run security audit on an installed skill or GitHub source
+  residency              Rank installed skills that do not earn their resident context
 
 ${ansi.bold("Options:")}
   --json             Output as JSON
@@ -744,6 +757,8 @@ ${ansi.bold("Examples:")}
   asm audit                                    ${ansi.dim("Find duplicates")}
   asm audit -y                                 ${ansi.dim("Auto-remove duplicates")}
   asm audit --json                             ${ansi.dim("Output as JSON")}
+  asm audit residency                          ${ansi.dim("Rank demotion candidates")}
+  asm audit residency --json                   ${ansi.dim("Residency report as JSON")}
   asm audit security code-review               ${ansi.dim("Audit an installed skill")}
   asm audit security github:user/repo          ${ansi.dim("Audit a remote skill before installing")}
   asm audit security --all                     ${ansi.dim("Audit all installed skills")}
@@ -1814,8 +1829,15 @@ async function cmdAudit(args: ParsedArgs) {
     return;
   }
 
+  if (sub === "residency") {
+    await cmdAuditResidency(args, startTime);
+    return;
+  }
+
   if (sub !== "duplicates") {
-    error(`Unknown audit subcommand: "${sub}". Use: duplicates, security`);
+    error(
+      `Unknown audit subcommand: "${sub}". Use: duplicates, security, residency`,
+    );
     process.exit(2);
   }
 
@@ -1866,6 +1888,44 @@ async function cmdAudit(args: ParsedArgs) {
     }
     console.error(ansi.green("\nDone."));
   }
+}
+
+/**
+ * `asm audit residency` — rank installed skills that are not earning their
+ * resident context and pair each with a command that actually works for how
+ * it is installed (issue #423).
+ *
+ * Read-only by construction: this path never removes, deactivates, or
+ * disables anything, and it deliberately ignores `--yes` — residency is a
+ * user judgement, so demotion only ever happens when the user runs one of the
+ * suggested commands themselves.
+ */
+async function cmdAuditResidency(args: ParsedArgs, startTime: number) {
+  const config = await loadConfig();
+  const allSkills = await scanAllSkills(config, args.flags.scope);
+
+  // Resolve the library's real path so symlinked HOMEs still match; a missing
+  // library just means no instance qualifies for `asm deactivate`.
+  let librarySkillsDir = getLibrarySkillsDir();
+  try {
+    librarySkillsDir = await fsRealpath(librarySkillsDir);
+  } catch {
+    // library not created yet — containment check simply never matches
+  }
+
+  const report = computeResidencyAudit(allSkills, { librarySkillsDir });
+
+  if (args.flags.machine) {
+    console.log(formatMachineOutput("audit residency", report, startTime));
+    return;
+  }
+
+  if (args.flags.json) {
+    console.log(formatJSON(report));
+    return;
+  }
+
+  console.log(formatResidencyReport(report));
 }
 
 async function cmdAuditSecurity(args: ParsedArgs, startTime: number) {
@@ -4068,7 +4128,7 @@ function printStatsHelp() {
   console.log(`${ansi.bold("Usage:")} asm stats [subcommand] [options]
 
 Show aggregate skill metrics with provider distribution charts,
-scope breakdown, disk usage, and duplicate summary.
+scope breakdown, disk usage, resident context cost, and duplicate summary.
 
 ${ansi.bold("Subcommands:")}
   repo <owner/repo>    Show per-repo stats from the skill index
@@ -4076,15 +4136,20 @@ ${ansi.bold("Subcommands:")}
   index                Show index-wide statistics
 
 ${ansi.bold("Options:")}
+  --tokens           Attention budget: resident vs body tokens per tool/scope
   --json             Output as JSON
+  --machine          Output in stable machine-readable v1 envelope format
   -s, --scope <s>    Filter: global, project, or both (default: both)
   --no-color         Disable ANSI colors
   -V, --verbose      Show debug output
 
 ${ansi.bold("Examples:")}
   asm stats                         ${ansi.dim("Show installed skills dashboard")}
+  asm stats --tokens                ${ansi.dim("Resident context cost per tool")}
+  asm stats --tokens --json         ${ansi.dim("Attention budget as JSON")}
   asm stats -s global               ${ansi.dim("Global skills only")}
   asm stats --json                  ${ansi.dim("Output raw data as JSON")}
+  asm stats --machine               ${ansi.dim("Machine-readable v1 envelope output")}
   asm stats repo anthropics/skills  ${ansi.dim("Show indexed repo stats")}
   asm stats author luongnv89        ${ansi.dim("Show indexed author stats")}
   asm stats index                   ${ansi.dim("Show index-wide stats")}`);
@@ -4112,16 +4177,64 @@ async function cmdStats(args: ParsedArgs) {
   }
 
   // Default: installed skills stats (original behavior)
+  const startTime = performance.now();
   const config = await loadConfig();
   const allSkills = await scanAllSkills(config, args.flags.scope);
 
+  // `--tokens` is the attention-budget view (issue #421): the resident cost
+  // of the installed set, which is paid on every message, reported apart from
+  // the body cost, which is only paid when a skill fires.
+  if (args.flags.tokens) {
+    const budget = computeTokenBudget(allSkills);
+    if (args.flags.machine) {
+      console.log(formatMachineOutput("stats tokens", budget, startTime));
+      return;
+    }
+    if (args.flags.json) {
+      console.log(formatJSON(budget));
+      return;
+    }
+    console.log(formatTokenBudgetReport(budget));
+    return;
+  }
+
   if (allSkills.length === 0) {
+    if (args.flags.machine || args.flags.json) {
+      const empty = {
+        totalSkills: 0,
+        byProvider: {},
+        byScope: { global: 0, project: 0 },
+        totalDiskBytes: 0,
+        duplicateGroups: 0,
+        duplicateInstances: 0,
+        totalResidentTokens: 0,
+        totalBodyTokens: 0,
+      };
+      console.log(
+        args.flags.machine
+          ? formatMachineOutput("stats", empty, startTime)
+          : formatJSON(empty),
+      );
+      return;
+    }
     console.log("No skills found.");
     return;
   }
 
   const duplicates = detectDuplicates(allSkills);
   const report = await computeStats(allSkills, duplicates);
+
+  if (args.flags.machine) {
+    const { perSkillDiskBytes: _machineDetail, ...summary } = report;
+    console.log(
+      formatMachineOutput(
+        "stats",
+        args.flags.verbose ? report : summary,
+        startTime,
+      ),
+    );
+    return;
+  }
 
   if (args.flags.json) {
     if (!args.flags.verbose) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4198,25 +4198,10 @@ async function cmdStats(args: ParsedArgs) {
     return;
   }
 
-  if (allSkills.length === 0) {
-    if (args.flags.machine || args.flags.json) {
-      const empty = {
-        totalSkills: 0,
-        byProvider: {},
-        byScope: { global: 0, project: 0 },
-        totalDiskBytes: 0,
-        duplicateGroups: 0,
-        duplicateInstances: 0,
-        totalResidentTokens: 0,
-        totalBodyTokens: 0,
-      };
-      console.log(
-        args.flags.machine
-          ? formatMachineOutput("stats", empty, startTime)
-          : formatJSON(empty),
-      );
-      return;
-    }
+  // Structured consumers always get a parseable report, even when nothing is
+  // installed; only the human dashboard degrades to a sentence (it charts
+  // maxima that an empty set has none of).
+  if (allSkills.length === 0 && !args.flags.json && !args.flags.machine) {
     console.log("No skills found.");
     return;
   }

--- a/src/residency.test.ts
+++ b/src/residency.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  computeResidencyAudit,
+  chooseDemotionAction,
+  formatResidencyReport,
+  residencySignals,
+  EXPENSIVE_RESIDENT_FLOOR,
+} from "./residency";
+import type { ResidencyInstance, SkillInfo } from "./utils/types";
+
+const LIBRARY = "/home/u/.local/share/agent-skill-manager/library/skills";
+
+function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  const dirName = overrides.dirName ?? overrides.name ?? "test-skill";
+  const path = overrides.path ?? `/home/u/.claude/skills/${dirName}`;
+  return {
+    name: dirName,
+    version: "1.0.0",
+    description: "A test skill",
+    creator: "",
+    license: "",
+    compatibility: "",
+    allowedTools: [],
+    dirName,
+    path,
+    originalPath: path,
+    location: "global-claude",
+    scope: "global",
+    provider: "claude",
+    providerLabel: "Claude Code",
+    isSymlink: false,
+    symlinkTarget: null,
+    realPath: path,
+    tokenCount: 500,
+    ...overrides,
+  };
+}
+
+/** A description whose estimated cost clears the expensive-residency floor. */
+function longDescription(words: number): string {
+  return Array.from({ length: words }, (_, i) => `word${i}`).join(" ");
+}
+
+/**
+ * Expensive residency is measured *relative to the installed set*, so a heavy
+ * skill only stands out next to a baseline of ordinary ones.
+ */
+function withBaseline(...skills: SkillInfo[]): SkillInfo[] {
+  return [...skills, ...baselineSkills(8)];
+}
+
+function baselineSkills(count: number): SkillInfo[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeSkill({ dirName: `baseline-${i}`, description: "a short one" }),
+  );
+}
+
+function makeInstance(
+  overrides: Partial<ResidencyInstance> = {},
+): ResidencyInstance {
+  return {
+    provider: "claude",
+    providerLabel: "Claude Code",
+    scope: "global",
+    path: "/home/u/.claude/skills/x",
+    libraryLinked: false,
+    ...overrides,
+  };
+}
+
+// ─── Demotion command selection ─────────────────────────────────────────────
+
+describe("chooseDemotionAction", () => {
+  it("suggests asm deactivate only for a lone ASM-library symlink", () => {
+    const action = chooseDemotionAction("my-skill", [
+      makeInstance({
+        libraryLinked: true,
+        provider: "codex",
+        scope: "project",
+      }),
+    ]);
+    expect(action.kind).toBe("deactivate");
+    expect(action.command).toBe(
+      "asm deactivate my-skill --provider codex --scope project",
+    );
+  });
+
+  it("always names an explicit scope, because deactivate rejects `both`", () => {
+    const action = chooseDemotionAction("my-skill", [
+      makeInstance({ libraryLinked: true }),
+    ]);
+    expect(action.command).toMatch(/--scope (global|project)$/);
+  });
+
+  it("falls back to asm disable for a non-symlink install", () => {
+    // `deactivateLibrarySkill` throws on non-symlinks, so suggesting
+    // `asm deactivate` here would emit a command that fails when run.
+    const action = chooseDemotionAction("my-skill", [
+      makeInstance({ libraryLinked: false }),
+    ]);
+    expect(action.kind).toBe("disable");
+    expect(action.command).toBe("asm disable my-skill");
+  });
+
+  it("falls back to asm disable when the skill is resident in many tools", () => {
+    // `asm deactivate` targets one provider/scope pair; a multi-instance skill
+    // has no single valid target, and `asm disable` covers all of them.
+    const action = chooseDemotionAction("my-skill", [
+      makeInstance({ libraryLinked: true, provider: "claude" }),
+      makeInstance({ libraryLinked: true, provider: "codex" }),
+    ]);
+    expect(action.kind).toBe("disable");
+    expect(action.hint).toContain("--tool");
+  });
+});
+
+// ─── Audit computation ──────────────────────────────────────────────────────
+
+describe("computeResidencyAudit", () => {
+  it("flags a description far above the median", () => {
+    const skills = withBaseline(
+      makeSkill({ dirName: "heavy", description: longDescription(120) }),
+    );
+    const report = computeResidencyAudit(skills);
+    const heavy = report.candidates.find((c) => c.dirName === "heavy");
+    expect(heavy).toBeDefined();
+    expect(heavy!.reasons.map((r) => r.id)).toContain("expensive-description");
+    expect(heavy!.reasons[0].detail).toContain("~");
+  });
+
+  it("does not flag a set of uniformly small descriptions", () => {
+    const skills = Array.from({ length: 6 }, (_, i) =>
+      makeSkill({ dirName: `s${i}`, description: "short one here" }),
+    );
+    const report = computeResidencyAudit(skills);
+    expect(report.candidates).toEqual([]);
+    expect(report.medianResidentTokens).toBeLessThan(EXPENSIVE_RESIDENT_FLOOR);
+  });
+
+  it("flags a skill resident in several tools and counts the cost per tool", () => {
+    const skills = [
+      makeSkill({ dirName: "spread", provider: "claude" }),
+      makeSkill({
+        dirName: "spread",
+        provider: "codex",
+        providerLabel: "Codex",
+        path: "/home/u/.codex/skills/spread",
+        realPath: "/home/u/.codex/skills/spread",
+      }),
+    ];
+    const report = computeResidencyAudit(skills);
+    expect(report.candidates).toHaveLength(1);
+    const candidate = report.candidates[0];
+    expect(candidate.reasons.map((r) => r.id)).toContain(
+      "redundant-activation",
+    );
+    expect(candidate.instances).toHaveLength(2);
+    expect(candidate.totalResidentTokens).toBe(candidate.residentTokens * 2);
+  });
+
+  it("ranks the highest total resident cost first", () => {
+    const skills = withBaseline(
+      makeSkill({ dirName: "cheap-spread", provider: "claude" }),
+      makeSkill({
+        dirName: "cheap-spread",
+        provider: "codex",
+        path: "/home/u/.codex/skills/cheap-spread",
+        realPath: "/home/u/.codex/skills/cheap-spread",
+      }),
+      makeSkill({ dirName: "expensive", description: longDescription(200) }),
+    );
+    const report = computeResidencyAudit(skills);
+    expect(report.candidates[0].dirName).toBe("expensive");
+    expect(report.candidates[0].score).toBeGreaterThan(
+      report.candidates[1].score,
+    );
+  });
+
+  it("emits a deactivate command for a library-linked install", () => {
+    const report = computeResidencyAudit(
+      withBaseline(
+        makeSkill({
+          dirName: "linked",
+          description: longDescription(200),
+          isSymlink: true,
+          realPath: `${LIBRARY}/linked`,
+        }),
+      ),
+      { librarySkillsDir: LIBRARY },
+    );
+    expect(report.candidates[0].dirName).toBe("linked");
+    expect(report.candidates[0].action.kind).toBe("deactivate");
+    expect(report.candidates[0].instances[0].libraryLinked).toBe(true);
+  });
+
+  it("never emits deactivate for a symlink pointing outside the library", () => {
+    // `deactivateLibrarySkill` refuses these, so the command must not appear.
+    const report = computeResidencyAudit(
+      withBaseline(
+        makeSkill({
+          dirName: "elsewhere",
+          description: longDescription(200),
+          isSymlink: true,
+          realPath: "/home/u/other-place/elsewhere",
+        }),
+      ),
+      { librarySkillsDir: LIBRARY },
+    );
+    expect(report.candidates[0].dirName).toBe("elsewhere");
+    expect(report.candidates[0].action.kind).toBe("disable");
+  });
+
+  it("never emits deactivate when no library path is known", () => {
+    const report = computeResidencyAudit(
+      withBaseline(
+        makeSkill({
+          dirName: "linked",
+          description: longDescription(200),
+          isSymlink: true,
+          realPath: `${LIBRARY}/linked`,
+        }),
+      ),
+    );
+    expect(report.candidates[0].dirName).toBe("linked");
+    expect(report.candidates[0].action.kind).toBe("disable");
+  });
+
+  it("counts plugin-provided skills but never lists them as candidates", () => {
+    // No ASM command demotes them: `asm disable` skips plugin providers and
+    // `asm deactivate` would throw.
+    const report = computeResidencyAudit([
+      makeSkill({
+        dirName: "from-plugin",
+        provider: "plugin",
+        providerLabel: "Plugin (acme)",
+        description: longDescription(200),
+      }),
+      makeSkill({
+        dirName: "from-codex-plugin",
+        provider: "codex-plugin",
+        description: longDescription(200),
+      }),
+      makeSkill({ dirName: "ordinary", description: "a short one" }),
+    ]);
+    expect(report.unmanagedSkills).toBe(2);
+    expect(report.totalSkills).toBe(3);
+    expect(report.totalResidentTokens).toBeGreaterThan(0);
+    expect(report.candidates).toEqual([]);
+  });
+
+  it("caps candidates when a limit is given", () => {
+    const skills = withBaseline(
+      ...Array.from({ length: 6 }, (_, i) =>
+        makeSkill({ dirName: `heavy-${i}`, description: longDescription(200) }),
+      ),
+    );
+    expect(computeResidencyAudit(skills).candidates.length).toBeGreaterThan(2);
+    expect(computeResidencyAudit(skills, { limit: 2 }).candidates).toHaveLength(
+      2,
+    );
+  });
+
+  it("degrades gracefully on an empty installed set", () => {
+    const report = computeResidencyAudit([]);
+    expect(report.totalSkills).toBe(0);
+    expect(report.candidates).toEqual([]);
+    expect(report.signals.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── Signal availability ────────────────────────────────────────────────────
+
+describe("residencySignals", () => {
+  it("marks signals with no data source as unavailable instead of failing", () => {
+    const byId = new Map(residencySignals().map((s) => [s.id, s]));
+    expect(byId.get("expensive-description")!.available).toBe(true);
+    expect(byId.get("redundant-activation")!.available).toBe(true);
+    expect(byId.get("trigger-collision")!.available).toBe(false);
+    expect(byId.get("trigger-collision")!.reason).toContain("#18");
+    expect(byId.get("unused")!.available).toBe(false);
+    expect(byId.get("unused")!.reason).toContain("#354");
+  });
+
+  it("still produces a report when only the available signals fire", () => {
+    const report = computeResidencyAudit(
+      withBaseline(
+        makeSkill({ dirName: "heavy", description: longDescription(200) }),
+      ),
+    );
+    expect(report.candidates).toHaveLength(1);
+    expect(report.signals.filter((s) => !s.available)).toHaveLength(2);
+  });
+});
+
+// ─── Rendering ──────────────────────────────────────────────────────────────
+
+describe("formatResidencyReport", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  it("prints each candidate with a reason and a command", () => {
+    const report = computeResidencyAudit(
+      withBaseline(
+        makeSkill({ dirName: "heavy", description: longDescription(200) }),
+      ),
+    );
+    const output = formatResidencyReport(report);
+    expect(output).toContain("Demotion candidates (1)");
+    expect(output).toContain("heavy");
+    expect(output).toContain("the median description");
+    expect(output).toContain("asm disable heavy");
+  });
+
+  it("renders every token figure with the `~` prefix, never as bytes", () => {
+    const output = formatResidencyReport(
+      computeResidencyAudit(
+        withBaseline(
+          makeSkill({ dirName: "heavy", description: longDescription(200) }),
+        ),
+      ),
+    );
+    expect(output).toMatch(/~\d/);
+    expect(output).not.toMatch(/\d\s?(KB|MB|GB)/);
+  });
+
+  it("names the unavailable signals rather than hiding them", () => {
+    const output = formatResidencyReport(computeResidencyAudit([]));
+    expect(output).toContain("No installed skills");
+  });
+
+  it("lists unavailable signals when there is data to report", () => {
+    const output = formatResidencyReport(
+      computeResidencyAudit([makeSkill({ description: "short" })]),
+    );
+    expect(output).toContain("Signals not yet available");
+    expect(output).toContain("Trigger collision");
+    expect(output).toContain("Unused");
+  });
+
+  it("states that nothing was changed", () => {
+    const output = formatResidencyReport(
+      computeResidencyAudit([makeSkill({ description: "short" })]),
+    );
+    expect(output).toContain("Nothing was changed");
+  });
+
+  it("truncates a long candidate list and says how many are hidden", () => {
+    const skills = [
+      ...Array.from({ length: 20 }, (_, i) =>
+        makeSkill({
+          dirName: `heavy-${i}`,
+          description: longDescription(200 + i),
+        }),
+      ),
+      ...baselineSkills(60),
+    ];
+    const output = formatResidencyReport(computeResidencyAudit(skills), 5);
+    expect(output).toContain("Demotion candidates (20)");
+    expect(output).toContain("… 15 more not shown");
+  });
+
+  it("reports a clean set as having no candidates", () => {
+    const output = formatResidencyReport(
+      computeResidencyAudit([makeSkill({ description: "short one" })]),
+    );
+    expect(output).toContain("No demotion candidates");
+  });
+});

--- a/src/residency.test.ts
+++ b/src/residency.test.ts
@@ -110,7 +110,21 @@ describe("chooseDemotionAction", () => {
       makeInstance({ libraryLinked: true, provider: "codex" }),
     ]);
     expect(action.kind).toBe("disable");
-    expect(action.hint).toContain("--tool");
+    expect(action.command).toBe("asm disable my-skill");
+  });
+
+  it("says the disable covers every place, because it has no --tool switch", () => {
+    // Symlinked siblings share one canonical SKILL.md, so `asm disable` demotes
+    // the whole group; promising a per-tool demotion would be a lie.
+    const action = chooseDemotionAction("my-skill", [
+      makeInstance({ libraryLinked: true, provider: "claude" }),
+      makeInstance({ libraryLinked: true, provider: "codex" }),
+      makeInstance({ libraryLinked: false, provider: "agents" }),
+    ]);
+    expect(action.hint).toBe(
+      "reversible with asm enable; disables it in all 3 places",
+    );
+    expect(action.hint).not.toContain("--tool");
   });
 });
 
@@ -328,7 +342,7 @@ describe("formatResidencyReport", () => {
     expect(output).not.toMatch(/\d\s?(KB|MB|GB)/);
   });
 
-  it("names the unavailable signals rather than hiding them", () => {
+  it("reports an empty installed set instead of an empty table", () => {
     const output = formatResidencyReport(computeResidencyAudit([]));
     expect(output).toContain("No installed skills");
   });

--- a/src/residency.ts
+++ b/src/residency.ts
@@ -178,6 +178,11 @@ export function computeResidencyAudit(
   for (const [dirName, group] of groups) {
     const first = group[0];
     const resident = residentTokens(first);
+    // Symlinked siblings share one SKILL.md, but two independently-installed
+    // skills can share a directory name and differ, so sum the group rather
+    // than multiplying the representative's cost.
+    const groupResident = group.reduce((sum, s) => sum + residentTokens(s), 0);
+    const groupBody = group.reduce((sum, s) => sum + bodyTokens(s), 0);
     const instances: ResidencyInstance[] = group.map((s) => ({
       provider: s.provider,
       providerLabel: s.providerLabel || s.provider,
@@ -206,21 +211,20 @@ export function computeResidencyAudit(
       reasons.push({
         id: "redundant-activation",
         detail:
-          `resident in ${instances.length} tools (${summarizeLocations(instances)}) · ` +
+          `resident in ${instances.length} places (${summarizeLocations(instances)}) · ` +
           `each pays ${formatTokenCount(resident)}`,
       });
     }
 
     if (reasons.length === 0) continue;
 
-    const totalResident = resident * instances.length;
     candidates.push({
       name: first.name,
       dirName,
       residentTokens: resident,
-      totalResidentTokens: totalResident,
-      bodyTokens: bodyTokens(first),
-      score: totalResident,
+      totalResidentTokens: groupResident,
+      bodyTokens: groupBody,
+      score: groupResident,
       instances,
       reasons,
       action: chooseDemotionAction(dirName, instances),

--- a/src/residency.ts
+++ b/src/residency.ts
@@ -1,0 +1,330 @@
+/**
+ * Residency audit — which installed skills are not earning their resident
+ * context (issue #423).
+ *
+ * Every installed skill's frontmatter description sits in the agent's system
+ * prompt on every message. This module ranks the installed set by that cost
+ * and pairs each demotion candidate with the ASM command that actually works
+ * for how that skill is installed. It never modifies anything: `asm audit
+ * residency` reports and suggests, and demotion stays a user judgement.
+ */
+
+import { resolve, sep } from "path";
+import { ansi } from "./formatter";
+import { median } from "./stats";
+import {
+  bodyTokens,
+  formatTokenCount,
+  residentTokens,
+} from "./utils/token-count";
+import type {
+  ResidencyAction,
+  ResidencyCandidate,
+  ResidencyInstance,
+  ResidencyReason,
+  ResidencyReport,
+  ResidencySignal,
+  SkillInfo,
+} from "./utils/types";
+
+/**
+ * Providers whose skills ASM does not own. `asm disable` explicitly skips
+ * them (they have no `SKILL.md` ASM may rename) and `asm deactivate` would
+ * throw, so no ASM command can demote them.
+ */
+const UNMANAGED_PROVIDERS = new Set(["plugin", "codex-plugin"]);
+
+/**
+ * A description has to be at least this expensive before "bigger than the
+ * median" is worth a user's attention. Without a floor, a set of uniformly
+ * tiny descriptions produces candidates that would save a handful of tokens.
+ */
+export const EXPENSIVE_RESIDENT_FLOOR = 40;
+
+/** Multiple of the median resident cost that counts as an outlier. */
+export const EXPENSIVE_RESIDENT_MULTIPLE = 2;
+
+export interface ResidencyAuditOptions {
+  /**
+   * Resolved path to the ASM library's skills directory. Instances whose real
+   * path lives inside it (and that are symlinks) are the only ones for which
+   * `asm deactivate` is a valid command.
+   */
+  librarySkillsDir?: string;
+  /** Cap on returned candidates; 0 or negative means no cap. */
+  limit?: number;
+}
+
+/** How many candidates the human report prints before truncating. */
+export const RESIDENCY_DISPLAY_LIMIT = 15;
+
+/** How many install locations a reason names before summarizing the rest. */
+const LOCATIONS_SHOWN = 3;
+
+function summarizeLocations(instances: ResidencyInstance[]): string {
+  const shown = instances
+    .slice(0, LOCATIONS_SHOWN)
+    .map((i) => `${i.provider}/${i.scope}`);
+  const rest = instances.length - shown.length;
+  return rest > 0 ? `${shown.join(", ")}, +${rest} more` : shown.join(", ");
+}
+
+function isInside(parent: string, child: string): boolean {
+  const p = resolve(parent);
+  const c = resolve(child);
+  if (p === c) return false;
+  return c.startsWith(p.endsWith(sep) ? p : p + sep);
+}
+
+/**
+ * Signals #423 lists, with the two that have no data source in ASM today
+ * marked unavailable rather than silently dropped.
+ */
+export function residencySignals(): ResidencySignal[] {
+  return [
+    {
+      id: "expensive-description",
+      label: "Expensive residency",
+      available: true,
+    },
+    {
+      id: "redundant-activation",
+      label: "Redundant activation",
+      available: true,
+    },
+    {
+      id: "trigger-collision",
+      label: "Trigger collision",
+      available: false,
+      reason: "needs trigger-overlap detection (issue #18)",
+    },
+    {
+      id: "unused",
+      label: "Unused",
+      available: false,
+      reason: "needs skill usage statistics (issue #354)",
+    },
+  ];
+}
+
+/**
+ * Pick a command that will actually succeed for this skill.
+ *
+ * `deactivateLibrarySkill` throws on non-symlinks and on symlinks pointing
+ * outside the library, so `asm deactivate` is only safe for a single instance
+ * that is a live library symlink. `asm disable` works for every ASM-managed
+ * instance and is reversible with `asm enable`, so it is the fallback.
+ */
+export function chooseDemotionAction(
+  dirName: string,
+  instances: ResidencyInstance[],
+): ResidencyAction {
+  if (instances.length === 1 && instances[0].libraryLinked) {
+    const only = instances[0];
+    return {
+      kind: "deactivate",
+      command: `asm deactivate ${dirName} --provider ${only.provider} --scope ${only.scope}`,
+      hint: "keep it in the library, activate when needed",
+    };
+  }
+  return {
+    kind: "disable",
+    command: `asm disable ${dirName}`,
+    hint:
+      instances.length > 1
+        ? "reversible with asm enable; add --tool <name> to demote one tool"
+        : "reversible with asm enable",
+  };
+}
+
+/**
+ * Rank installed skills that are not earning their residency.
+ *
+ * Skills are grouped by directory name, because that is what both demotion
+ * commands take and because a skill installed into three tools pays its
+ * resident cost three times.
+ */
+export function computeResidencyAudit(
+  skills: SkillInfo[],
+  options: ResidencyAuditOptions = {},
+): ResidencyReport {
+  const librarySkillsDir = options.librarySkillsDir ?? "";
+  const limit = options.limit ?? 0;
+
+  const residentCosts = skills.map((s) => residentTokens(s));
+  const totalResidentTokens = residentCosts.reduce((a, b) => a + b, 0);
+  const medianResidentTokens = median(residentCosts);
+
+  const managed = skills.filter((s) => !UNMANAGED_PROVIDERS.has(s.provider));
+  const unmanagedSkills = skills.length - managed.length;
+
+  // Group instances by directory name — the identifier both demotion commands
+  // accept, and the unit that pays residency once per install location.
+  const groups = new Map<string, SkillInfo[]>();
+  for (const skill of managed) {
+    const key = skill.dirName || skill.name;
+    const list = groups.get(key);
+    if (list) list.push(skill);
+    else groups.set(key, [skill]);
+  }
+
+  const expensiveThreshold = Math.max(
+    EXPENSIVE_RESIDENT_FLOOR,
+    medianResidentTokens * EXPENSIVE_RESIDENT_MULTIPLE,
+  );
+
+  const candidates: ResidencyCandidate[] = [];
+
+  for (const [dirName, group] of groups) {
+    const first = group[0];
+    const resident = residentTokens(first);
+    const instances: ResidencyInstance[] = group.map((s) => ({
+      provider: s.provider,
+      providerLabel: s.providerLabel || s.provider,
+      scope: s.scope,
+      path: s.path,
+      libraryLinked:
+        s.isSymlink &&
+        librarySkillsDir.length > 0 &&
+        isInside(librarySkillsDir, s.realPath || s.path),
+    }));
+
+    const reasons: ResidencyReason[] = [];
+
+    if (resident >= expensiveThreshold && resident > 0) {
+      const multiple =
+        medianResidentTokens > 0
+          ? `${(resident / medianResidentTokens).toFixed(1)}x the median description`
+          : "well above the rest of the installed set";
+      reasons.push({
+        id: "expensive-description",
+        detail: `${formatTokenCount(resident)} resident · ${multiple}`,
+      });
+    }
+
+    if (instances.length > 1) {
+      reasons.push({
+        id: "redundant-activation",
+        detail:
+          `resident in ${instances.length} tools (${summarizeLocations(instances)}) · ` +
+          `each pays ${formatTokenCount(resident)}`,
+      });
+    }
+
+    if (reasons.length === 0) continue;
+
+    const totalResident = resident * instances.length;
+    candidates.push({
+      name: first.name,
+      dirName,
+      residentTokens: resident,
+      totalResidentTokens: totalResident,
+      bodyTokens: bodyTokens(first),
+      score: totalResident,
+      instances,
+      reasons,
+      action: chooseDemotionAction(dirName, instances),
+    });
+  }
+
+  candidates.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+
+  return {
+    scannedAt: new Date().toISOString(),
+    totalSkills: skills.length,
+    totalResidentTokens,
+    medianResidentTokens,
+    unmanagedSkills,
+    candidates: limit > 0 ? candidates.slice(0, limit) : candidates,
+    signals: residencySignals(),
+  };
+}
+
+/** Render the residency audit as CLI text. */
+export function formatResidencyReport(
+  report: ResidencyReport,
+  displayLimit: number = RESIDENCY_DISPLAY_LIMIT,
+): string {
+  const lines: string[] = [];
+
+  lines.push("");
+  lines.push(ansi.blueBold("  Residency Audit"));
+  lines.push(ansi.dim("  " + "-".repeat(40)));
+  lines.push("");
+
+  if (report.totalSkills === 0) {
+    lines.push("  No installed skills.");
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  lines.push(
+    `  ${ansi.bold("Resident total:")}  ${ansi.cyan(formatTokenCount(report.totalResidentTokens))} ` +
+      ansi.dim(`across ${report.totalSkills} skill(s), every message`),
+  );
+  lines.push(
+    `  ${ansi.bold("Median skill:")}    ${ansi.cyan(formatTokenCount(report.medianResidentTokens))}`,
+  );
+  lines.push("");
+
+  if (report.candidates.length === 0) {
+    lines.push(`  ${ansi.green("No demotion candidates.")}`);
+    lines.push("");
+  } else {
+    const shown =
+      displayLimit > 0
+        ? report.candidates.slice(0, displayLimit)
+        : report.candidates;
+    lines.push(
+      ansi.bold(`  Demotion candidates (${report.candidates.length})`),
+    );
+    lines.push(ansi.dim("  Highest resident cost first."));
+    lines.push("");
+    for (const candidate of shown) {
+      const reasons = candidate.reasons.map((r) => r.detail).join(" · ");
+      lines.push(
+        `    ${ansi.cyan(candidate.name)}  ` +
+          ansi.dim(`${formatTokenCount(candidate.totalResidentTokens)} total`),
+      );
+      lines.push(ansi.dim(`      ${reasons}`));
+      lines.push(
+        `      ${ansi.yellow("→")} ${ansi.bold(candidate.action.command)}` +
+          ansi.dim(`  (${candidate.action.hint})`),
+      );
+      lines.push("");
+    }
+    const hidden = report.candidates.length - shown.length;
+    if (hidden > 0) {
+      lines.push(
+        ansi.dim(`  … ${hidden} more not shown — use --json for the full list`),
+      );
+      lines.push("");
+    }
+  }
+
+  if (report.unmanagedSkills > 0) {
+    lines.push(
+      ansi.dim(
+        `  ${report.unmanagedSkills} plugin-provided skill(s) are counted but ` +
+          `not ASM-managed — no ASM command demotes them.`,
+      ),
+    );
+    lines.push("");
+  }
+
+  const unavailable = report.signals.filter((s) => !s.available);
+  if (unavailable.length > 0) {
+    lines.push(ansi.dim("  Signals not yet available:"));
+    for (const signal of unavailable) {
+      lines.push(ansi.dim(`    ${signal.label} — ${signal.reason}`));
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    ansi.dim("  Nothing was changed. Run a suggested command to demote."),
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}

--- a/src/residency.ts
+++ b/src/residency.ts
@@ -113,7 +113,10 @@ export function residencySignals(): ResidencySignal[] {
  * `deactivateLibrarySkill` throws on non-symlinks and on symlinks pointing
  * outside the library, so `asm deactivate` is only safe for a single instance
  * that is a live library symlink. `asm disable` works for every ASM-managed
- * instance and is reversible with `asm enable`, so it is the fallback.
+ * instance and is reversible with `asm enable`, so it is the fallback. It
+ * demotes the whole group at once — `asm install` symlinks siblings to one
+ * canonical `SKILL.md`, so renaming it disables every place the skill is
+ * resident.
  */
 export function chooseDemotionAction(
   dirName: string,
@@ -132,7 +135,7 @@ export function chooseDemotionAction(
     command: `asm disable ${dirName}`,
     hint:
       instances.length > 1
-        ? "reversible with asm enable; add --tool <name> to demote one tool"
+        ? `reversible with asm enable; disables it in all ${instances.length} places`
         : "reversible with asm enable",
   };
 }
@@ -285,12 +288,15 @@ export function formatResidencyReport(
     lines.push(ansi.dim("  Highest resident cost first."));
     lines.push("");
     for (const candidate of shown) {
-      const reasons = candidate.reasons.map((r) => r.detail).join(" · ");
       lines.push(
         `    ${ansi.cyan(candidate.name)}  ` +
           ansi.dim(`${formatTokenCount(candidate.totalResidentTokens)} total`),
       );
-      lines.push(ansi.dim(`      ${reasons}`));
+      // One line per reason: joining them overflows 80 columns and wraps back
+      // to column 0, breaking the hanging indent that ties them to the name.
+      for (const reason of candidate.reasons) {
+        lines.push(ansi.dim(`      ${reason.detail}`));
+      }
       lines.push(
         `      ${ansi.yellow("→")} ${ansi.bold(candidate.action.command)}` +
           ansi.dim(`  (${candidate.action.hint})`),

--- a/src/stats.test.ts
+++ b/src/stats.test.ts
@@ -10,6 +10,9 @@ import {
   formatRepoStatsReport,
   formatAuthorStatsReport,
   formatIndexStatsReport,
+  computeTokenBudget,
+  formatTokenBudgetReport,
+  median,
 } from "./stats";
 import type {
   SkillInfo,
@@ -176,6 +179,8 @@ describe("formatStatsReport", () => {
       perSkillDiskBytes: {},
       duplicateGroups: 0,
       duplicateInstances: 0,
+      totalResidentTokens: 240,
+      totalBodyTokens: 5200,
       ...overrides,
     };
   }
@@ -847,7 +852,9 @@ describe("formatIndexStatsReport", () => {
     expect(output).toContain("Authors:");
     expect(output).toContain("3");
     expect(output).toContain("Avg Tokens/Skill:");
-    expect(output).toContain("2000");
+    // Token figures render via formatTokenCount, never as a bare or byte-sized
+    // number (issues #188, #421).
+    expect(output).toContain("~2k tokens");
   });
 
   it("shows category distribution with bars", () => {
@@ -871,5 +878,152 @@ describe("formatIndexStatsReport", () => {
     );
     expect(output).toContain("Index Statistics");
     expect(output).toContain("0");
+  });
+});
+
+// ─── Attention budget (issue #421) ──────────────────────────────────────────
+
+describe("median", () => {
+  it("returns 0 for an empty list", () => {
+    expect(median([])).toBe(0);
+  });
+
+  it("returns the middle value for an odd-length list", () => {
+    expect(median([5, 1, 3])).toBe(3);
+  });
+
+  it("averages the two middle values for an even-length list", () => {
+    expect(median([1, 2, 3, 4])).toBe(3);
+  });
+});
+
+describe("computeTokenBudget", () => {
+  it("derives resident cost from the description, not the body", () => {
+    const report = computeTokenBudget([
+      makeSkill({ description: "hello world", tokenCount: 5000 }),
+    ]);
+    expect(report.totalResidentTokens).toBe(3);
+    expect(report.totalBodyTokens).toBe(5000);
+    expect(report.totalResidentTokens).not.toBe(report.totalBodyTokens);
+  });
+
+  it("breaks resident and body totals down per provider", () => {
+    const report = computeTokenBudget([
+      makeSkill({
+        dirName: "a",
+        provider: "claude",
+        providerLabel: "Claude Code",
+        description: "aa bb cc",
+        tokenCount: 100,
+      }),
+      makeSkill({
+        dirName: "b",
+        provider: "codex",
+        providerLabel: "Codex",
+        description: "dd",
+        tokenCount: 40,
+      }),
+    ]);
+    const claude = report.byProvider.find((g) => g.key === "claude");
+    const codex = report.byProvider.find((g) => g.key === "codex");
+    expect(claude).toMatchObject({
+      label: "Claude Code",
+      skills: 1,
+      residentTokens: 5,
+      bodyTokens: 100,
+    });
+    expect(codex).toMatchObject({
+      skills: 1,
+      residentTokens: 1,
+      bodyTokens: 40,
+    });
+    // Sorted by resident cost, heaviest first.
+    expect(report.byProvider[0].key).toBe("claude");
+  });
+
+  it("breaks totals down per scope", () => {
+    const report = computeTokenBudget([
+      makeSkill({ dirName: "a", scope: "global", description: "a b c" }),
+      makeSkill({ dirName: "b", scope: "project", description: "d" }),
+    ]);
+    const keys = report.byScope.map((g) => g.key).sort();
+    expect(keys).toEqual(["global", "project"]);
+    expect(report.byScope.find((g) => g.key === "project")!.skills).toBe(1);
+  });
+
+  it("ranks the heaviest resident descriptions first", () => {
+    const report = computeTokenBudget([
+      makeSkill({ name: "small", dirName: "small", description: "a" }),
+      makeSkill({
+        name: "big",
+        dirName: "big",
+        description: "one two three four five six",
+      }),
+    ]);
+    expect(report.heaviestResident[0].name).toBe("big");
+    expect(report.heaviestResident[0].residentTokens).toBeGreaterThan(
+      report.heaviestResident[1].residentTokens,
+    );
+  });
+
+  it("honours the heaviest-resident limit", () => {
+    const skills = Array.from({ length: 5 }, (_, i) =>
+      makeSkill({ name: `s${i}`, dirName: `s${i}`, description: "a b c" }),
+    );
+    expect(computeTokenBudget(skills, 2).heaviestResident).toHaveLength(2);
+  });
+
+  it("reports zeroes for an empty installed set", () => {
+    const report = computeTokenBudget([]);
+    expect(report).toMatchObject({
+      totalSkills: 0,
+      totalResidentTokens: 0,
+      totalBodyTokens: 0,
+      medianResidentTokens: 0,
+    });
+    expect(report.heaviestResident).toEqual([]);
+  });
+});
+
+describe("formatTokenBudgetReport", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  it("renders every token figure with the `~` approximation prefix", () => {
+    const output = formatTokenBudgetReport(
+      computeTokenBudget([
+        makeSkill({ description: "one two three", tokenCount: 1234 }),
+      ]),
+    );
+    expect(output).toContain("Attention Budget");
+    expect(output).toContain("~5 tokens");
+    expect(output).toContain("~1.2k tokens");
+    // Token totals must never be rendered as disk sizes.
+    expect(output).not.toMatch(/\d\s?(KB|MB|GB)/);
+  });
+
+  it("handles an empty installed set", () => {
+    expect(formatTokenBudgetReport(computeTokenBudget([]))).toContain(
+      "No installed skills",
+    );
+  });
+});
+
+describe("computeStats — context cost", () => {
+  it("totals resident and body tokens separately", async () => {
+    const report = await computeStats(
+      [
+        makeSkill({ description: "one two", tokenCount: 300 }),
+        makeSkill({ description: "three", tokenCount: 200 }),
+      ],
+      emptyAuditReport(),
+    );
+    expect(report.totalResidentTokens).toBe(4);
+    expect(report.totalBodyTokens).toBe(500);
   });
 });

--- a/src/stats.test.ts
+++ b/src/stats.test.ts
@@ -1007,6 +1007,27 @@ describe("formatTokenBudgetReport", () => {
     expect(output).not.toMatch(/\d\s?(KB|MB|GB)/);
   });
 
+  it("right-aligns the heaviest-resident token column", () => {
+    // `~9 tokens` and `~11 tokens` differ in width; left-aligning them makes
+    // the trailing `(provider, scope)` column ragged in a magnitude ranking.
+    const output = formatTokenBudgetReport(
+      computeTokenBudget([
+        makeSkill({
+          name: "big",
+          dirName: "big",
+          description: "one two three four five six",
+        }),
+        makeSkill({
+          name: "small",
+          dirName: "small",
+          description: "one two three four five",
+        }),
+      ]),
+    );
+    expect(output).toContain("big    ~11 tokens");
+    expect(output).toContain("small   ~9 tokens");
+  });
+
   it("handles an empty installed set", () => {
     expect(formatTokenBudgetReport(computeTokenBudget([]))).toContain(
       "No installed skills",

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,6 +1,11 @@
 import { readdir, stat } from "fs/promises";
 import { join } from "path";
 import { ansi, colorProvider } from "./formatter";
+import {
+  bodyTokens,
+  formatTokenCount,
+  residentTokens,
+} from "./utils/token-count";
 import type {
   SkillInfo,
   AuditReport,
@@ -10,6 +15,9 @@ import type {
   AuthorStatsReport,
   IndexStatsReport,
   IndexedSkill,
+  TokenBudgetReport,
+  TokenBudgetGroup,
+  ResidentSkillCost,
 } from "./utils/types";
 
 export async function dirSize(dirPath: string): Promise<number> {
@@ -40,6 +48,8 @@ export async function computeStats(
   const byProvider: Record<string, number> = {};
   const byScope = { global: 0, project: 0 };
   const perSkillDiskBytes: Record<string, number> = {};
+  let totalResidentTokens = 0;
+  let totalBodyTokens = 0;
 
   const diskPromises = skills.map(async (skill) => {
     // Provider counts
@@ -47,6 +57,11 @@ export async function computeStats(
 
     // Scope counts
     byScope[skill.scope]++;
+
+    // Context cost (issue #421) — resident is paid every message, the body
+    // only when the skill fires. Never conflate the two.
+    totalResidentTokens += residentTokens(skill);
+    totalBodyTokens += bodyTokens(skill);
 
     // Disk usage
     const bytes = await dirSize(skill.path);
@@ -65,6 +80,8 @@ export async function computeStats(
     perSkillDiskBytes,
     duplicateGroups: duplicates.duplicateGroups.length,
     duplicateInstances: duplicates.totalDuplicateInstances,
+    totalResidentTokens,
+    totalBodyTokens,
   };
 }
 
@@ -108,6 +125,17 @@ export function formatStatsReport(report: StatsReport): string {
   );
   lines.push(
     `  ${ansi.bold("Disk:")}       ${ansi.cyan(formatHumanSize(report.totalDiskBytes))}`,
+  );
+  lines.push(
+    `  ${ansi.bold("Resident:")}   ${ansi.cyan(formatTokenCount(report.totalResidentTokens))} ${ansi.dim("(every message)")}`,
+  );
+  lines.push(
+    `  ${ansi.bold("Bodies:")}     ${ansi.cyan(formatTokenCount(report.totalBodyTokens))} ${ansi.dim("(only when a skill fires)")}`,
+  );
+  lines.push(
+    ansi.dim(
+      `  Run ${ansi.bold("asm stats --tokens")} for the attention budget`,
+    ),
   );
   lines.push("");
 
@@ -156,6 +184,235 @@ export function formatStatsReport(report: StatsReport): string {
   }
 
   lines.push("");
+  return lines.join("\n");
+}
+
+// ─── Attention Budget (issue #421) ──────────────────────────────────────────
+
+/** How many heaviest resident descriptions the report lists by default. */
+export const HEAVIEST_RESIDENT_LIMIT = 10;
+
+/** Median of a numeric list; 0 for an empty list. */
+export function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[mid]
+    : Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+}
+
+function addToGroup(
+  groups: Map<string, TokenBudgetGroup>,
+  key: string,
+  label: string,
+  resident: number,
+  body: number,
+): void {
+  let group = groups.get(key);
+  if (!group) {
+    group = { key, label, skills: 0, residentTokens: 0, bodyTokens: 0 };
+    groups.set(key, group);
+  }
+  group.skills++;
+  group.residentTokens += resident;
+  group.bodyTokens += body;
+}
+
+/**
+ * Attention-budget view over the *installed* set (issue #421).
+ *
+ * Every installed skill's frontmatter description is resident in the agent's
+ * system prompt on every message whether or not the skill ever fires, so the
+ * resident total — not the disk total and not the body total — is the number
+ * that competes with the user's actual work for context.
+ */
+export function computeTokenBudget(
+  skills: SkillInfo[],
+  limit: number = HEAVIEST_RESIDENT_LIMIT,
+): TokenBudgetReport {
+  const providerGroups = new Map<string, TokenBudgetGroup>();
+  const scopeGroups = new Map<string, TokenBudgetGroup>();
+  const perSkill: ResidentSkillCost[] = [];
+  let totalResidentTokens = 0;
+  let totalBodyTokens = 0;
+
+  for (const skill of skills) {
+    const resident = residentTokens(skill);
+    const body = bodyTokens(skill);
+    totalResidentTokens += resident;
+    totalBodyTokens += body;
+
+    addToGroup(
+      providerGroups,
+      skill.provider,
+      skill.providerLabel || skill.provider,
+      resident,
+      body,
+    );
+    addToGroup(scopeGroups, skill.scope, skill.scope, resident, body);
+
+    perSkill.push({
+      name: skill.name,
+      dirName: skill.dirName,
+      provider: skill.provider,
+      providerLabel: skill.providerLabel || skill.provider,
+      scope: skill.scope,
+      path: skill.path,
+      residentTokens: resident,
+      bodyTokens: body,
+    });
+  }
+
+  const heaviestResident = [...perSkill]
+    .sort(
+      (a, b) =>
+        b.residentTokens - a.residentTokens || a.name.localeCompare(b.name),
+    )
+    .slice(0, limit > 0 ? limit : perSkill.length);
+
+  return {
+    totalSkills: skills.length,
+    totalResidentTokens,
+    totalBodyTokens,
+    medianResidentTokens: median(perSkill.map((p) => p.residentTokens)),
+    byProvider: [...providerGroups.values()].sort(
+      (a, b) => b.residentTokens - a.residentTokens || b.skills - a.skills,
+    ),
+    byScope: [...scopeGroups.values()].sort(
+      (a, b) => b.residentTokens - a.residentTokens,
+    ),
+    heaviestResident,
+  };
+}
+
+/** Render the attention-budget report as CLI text. */
+export function formatTokenBudgetReport(report: TokenBudgetReport): string {
+  const lines: string[] = [];
+
+  lines.push("");
+  lines.push(ansi.blueBold("  Attention Budget"));
+  lines.push(ansi.dim("  " + "-".repeat(40)));
+  lines.push("");
+  lines.push(
+    ansi.dim(
+      "  Resident = frontmatter descriptions, paid on every message.\n" +
+        "  Bodies   = full SKILL.md, paid only when a skill fires.",
+    ),
+  );
+  lines.push("");
+
+  if (report.totalSkills === 0) {
+    lines.push("  No installed skills.");
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  const rows: Array<[string, TokenBudgetGroup]> = [
+    ...report.byProvider.map(
+      (g) => ["provider", g] as [string, TokenBudgetGroup],
+    ),
+  ];
+  const labelWidth = Math.max(
+    8,
+    ...rows.map(([, g]) => g.label.length),
+    "Total".length,
+  );
+  const residentStrings = report.byProvider.map((g) =>
+    formatTokenCount(g.residentTokens),
+  );
+  const residentWidth = Math.max(
+    ...residentStrings.map((r) => r.length),
+    formatTokenCount(report.totalResidentTokens).length,
+  );
+
+  const header =
+    "  " +
+    "Tool".padEnd(labelWidth) +
+    "  " +
+    "Skills".padStart(6) +
+    "  " +
+    "Resident".padStart(residentWidth) +
+    "  " +
+    "Bodies";
+  lines.push(ansi.bold(header));
+
+  for (const group of report.byProvider) {
+    lines.push(
+      "  " +
+        colorProvider(group.key, group.label.padEnd(labelWidth)) +
+        "  " +
+        String(group.skills).padStart(6) +
+        "  " +
+        ansi.cyan(
+          formatTokenCount(group.residentTokens).padStart(residentWidth),
+        ) +
+        "  " +
+        ansi.dim(formatTokenCount(group.bodyTokens)),
+    );
+  }
+
+  lines.push(ansi.dim("  " + "-".repeat(labelWidth + residentWidth + 22)));
+  lines.push(
+    "  " +
+      ansi.bold("Total".padEnd(labelWidth)) +
+      "  " +
+      String(report.totalSkills).padStart(6) +
+      "  " +
+      ansi.cyan(
+        formatTokenCount(report.totalResidentTokens).padStart(residentWidth),
+      ) +
+      "  " +
+      ansi.dim(formatTokenCount(report.totalBodyTokens)),
+  );
+  lines.push("");
+
+  // By scope
+  lines.push(ansi.bold("  By Scope"));
+  for (const group of report.byScope) {
+    lines.push(
+      "  " +
+        group.label.padEnd(labelWidth) +
+        "  " +
+        String(group.skills).padStart(6) +
+        "  " +
+        ansi.cyan(
+          formatTokenCount(group.residentTokens).padStart(residentWidth),
+        ) +
+        "  " +
+        ansi.dim(formatTokenCount(group.bodyTokens)),
+    );
+  }
+  lines.push("");
+
+  // Heaviest resident descriptions
+  if (report.heaviestResident.length > 0) {
+    lines.push(ansi.bold("  Heaviest resident descriptions"));
+    const nameWidth = Math.max(
+      ...report.heaviestResident.map((s) => s.name.length),
+    );
+    for (const skill of report.heaviestResident) {
+      lines.push(
+        "    " +
+          skill.name.padEnd(nameWidth) +
+          "  " +
+          ansi.cyan(formatTokenCount(skill.residentTokens)) +
+          "  " +
+          ansi.dim(`(${skill.provider}, ${skill.scope})`),
+      );
+    }
+    lines.push("");
+    lines.push(
+      ansi.dim(
+        `  Median resident cost: ${formatTokenCount(report.medianResidentTokens)}`,
+      ),
+    );
+    lines.push(
+      ansi.dim(`  Run ${ansi.bold("asm audit residency")} for demotion advice`),
+    );
+    lines.push("");
+  }
+
   return lines.join("\n");
 }
 
@@ -329,7 +586,7 @@ export function formatRepoStatsReport(report: RepoStatsReport): string {
     `  ${ansi.bold("Verified: ")}${ansi.cyan(String(report.verifiedCount))}`,
   );
   lines.push(
-    `  ${ansi.bold("Tokens: ")}${ansi.cyan(formatHumanSize(report.totalTokens))}`,
+    `  ${ansi.bold("Tokens: ")}${ansi.cyan(formatTokenCount(report.totalTokens))}`,
   );
   if (report.avgEvalScore !== undefined) {
     lines.push(
@@ -379,7 +636,7 @@ export function formatAuthorStatsReport(report: AuthorStatsReport): string {
     `  ${ansi.bold("Verified: ")}${ansi.cyan(String(report.verifiedCount))}`,
   );
   lines.push(
-    `  ${ansi.bold("Tokens: ")}${ansi.cyan(formatHumanSize(report.totalTokens))}`,
+    `  ${ansi.bold("Tokens: ")}${ansi.cyan(formatTokenCount(report.totalTokens))}`,
   );
   lines.push("");
 
@@ -439,7 +696,7 @@ export function formatIndexStatsReport(report: IndexStatsReport): string {
     `  ${ansi.bold("Verified: ")}${ansi.cyan(String(report.verifiedCount))}`,
   );
   lines.push(
-    `  ${ansi.bold("Avg Tokens/Skill: ")}${ansi.cyan(String(report.avgTokensPerSkill))}`,
+    `  ${ansi.bold("Avg Tokens/Skill: ")}${ansi.cyan(formatTokenCount(report.avgTokensPerSkill))}`,
   );
   lines.push("");
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -391,12 +391,21 @@ export function formatTokenBudgetReport(report: TokenBudgetReport): string {
     const nameWidth = Math.max(
       ...report.heaviestResident.map((s) => s.name.length),
     );
+    // Right-align the token column like the provider/scope tables above, so
+    // mixed widths (`~1.2k tokens` vs `~289 tokens`) stay comparable.
+    const heaviestWidth = Math.max(
+      ...report.heaviestResident.map(
+        (s) => formatTokenCount(s.residentTokens).length,
+      ),
+    );
     for (const skill of report.heaviestResident) {
       lines.push(
         "    " +
           skill.name.padEnd(nameWidth) +
           "  " +
-          ansi.cyan(formatTokenCount(skill.residentTokens)) +
+          ansi.cyan(
+            formatTokenCount(skill.residentTokens).padStart(heaviestWidth),
+          ) +
           "  " +
           ansi.dim(`(${skill.provider}, ${skill.scope})`),
       );

--- a/src/utils/token-count.test.ts
+++ b/src/utils/token-count.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { estimateTokenCount, formatTokenCount } from "./token-count";
+import {
+  bodyTokens,
+  estimateTokenCount,
+  formatTokenCount,
+  residentTokens,
+} from "./token-count";
 
 describe("estimateTokenCount", () => {
   it("returns 0 for empty string", () => {
@@ -67,5 +72,48 @@ describe("formatTokenCount", () => {
     expect(formatTokenCount(-1)).toBe("~0 tokens");
     expect(formatTokenCount(NaN)).toBe("~0 tokens");
     expect(formatTokenCount(Infinity)).toBe("~0 tokens");
+  });
+});
+
+describe("formatTokenCount — millions", () => {
+  it("formats counts past a million with an M suffix", () => {
+    expect(formatTokenCount(1_000_000)).toBe("~1M tokens");
+    expect(formatTokenCount(1_934_000)).toBe("~1.9M tokens");
+  });
+
+  it("still uses k just below a million", () => {
+    expect(formatTokenCount(999_400)).toBe("~999k tokens");
+  });
+});
+
+describe("residentTokens", () => {
+  it("counts only the frontmatter description", () => {
+    expect(residentTokens({ description: "hello world" })).toBe(3);
+  });
+
+  it("returns 0 for a missing or empty description", () => {
+    expect(residentTokens({})).toBe(0);
+    expect(residentTokens({ description: "" })).toBe(0);
+  });
+
+  it("is independent of the body token count", () => {
+    const skill = { description: "hello world", tokenCount: 9999 } as {
+      description: string;
+      tokenCount: number;
+    };
+    expect(residentTokens(skill)).toBe(3);
+    expect(residentTokens(skill)).not.toBe(skill.tokenCount);
+  });
+});
+
+describe("bodyTokens", () => {
+  it("returns the scanner-computed tokenCount", () => {
+    expect(bodyTokens({ tokenCount: 512 })).toBe(512);
+  });
+
+  it("degrades to 0 when tokenCount is absent or nonsensical", () => {
+    expect(bodyTokens({})).toBe(0);
+    expect(bodyTokens({ tokenCount: -5 })).toBe(0);
+    expect(bodyTokens({ tokenCount: NaN })).toBe(0);
   });
 });

--- a/src/utils/token-count.ts
+++ b/src/utils/token-count.ts
@@ -46,6 +46,7 @@ export function estimateTokenCount(content: string): number {
  *   - estimateTokenCount("hello world") = 3   → "~3 tokens"
  *   - 1234                              → "~1.2k tokens"
  *   - 12_345                            → "~12k tokens"
+ *   - 1_934_000                         → "~1.9M tokens"
  */
 export function formatTokenCount(count: number): string {
   if (!Number.isFinite(count) || count < 0) return "~0 tokens";
@@ -54,5 +55,36 @@ export function formatTokenCount(count: number): string {
     const k = (count / 1000).toFixed(1).replace(/\.0$/, "");
     return `~${k}k tokens`;
   }
-  return `~${Math.round(count / 1000)}k tokens`;
+  if (count < 1_000_000) return `~${Math.round(count / 1000)}k tokens`;
+  const m = (count / 1_000_000).toFixed(1).replace(/\.0$/, "");
+  return `~${m}M tokens`;
+}
+
+/**
+ * Estimated **resident** token cost of an installed skill.
+ *
+ * Resident cost is the part of a skill that an agent pays for on *every*
+ * message: the frontmatter `description`, which is inlined into the system
+ * prompt so the agent can decide whether the skill should fire. It is a
+ * different number from `SkillInfo.tokenCount` — the whole `SKILL.md` body —
+ * which is only paid when the skill actually fires.
+ *
+ * Conflating the two overstates the always-on context budget by an order of
+ * magnitude, so this is the single shared definition: both the
+ * `asm stats --tokens` budget report and the `asm audit residency` report
+ * import it rather than re-deriving it (issues #421, #423).
+ */
+export function residentTokens(skill: { description?: string }): number {
+  return estimateTokenCount(skill.description ?? "");
+}
+
+/**
+ * Estimated **body** token cost of an installed skill — the full `SKILL.md`.
+ *
+ * Prefers the scanner-computed `tokenCount` (issue #188) and falls back to 0
+ * when a caller constructed the record without one.
+ */
+export function bodyTokens(skill: { tokenCount?: number }): number {
+  const n = skill.tokenCount;
+  return typeof n === "number" && Number.isFinite(n) && n > 0 ? n : 0;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -247,6 +247,135 @@ export interface StatsReport {
   perSkillDiskBytes: Record<string, number>;
   duplicateGroups: number;
   duplicateInstances: number;
+  /**
+   * Estimated tokens the installed set costs on *every* message — the sum of
+   * each skill's frontmatter `description` (issue #421). Distinct from
+   * `totalBodyTokens`, which is only paid when a skill fires.
+   */
+  totalResidentTokens: number;
+  /** Estimated tokens across every installed `SKILL.md` body (issue #421). */
+  totalBodyTokens: number;
+}
+
+/** One provider or scope row of the attention-budget report (issue #421). */
+export interface TokenBudgetGroup {
+  /** Provider name (`claude`, `codex`, …) or scope (`global`, `project`). */
+  key: string;
+  /** Human label for the key (e.g. `Claude Code`). */
+  label: string;
+  skills: number;
+  residentTokens: number;
+  bodyTokens: number;
+}
+
+/** One entry of the "heaviest resident descriptions" ranking (issue #421). */
+export interface ResidentSkillCost {
+  name: string;
+  dirName: string;
+  provider: string;
+  providerLabel: string;
+  scope: "global" | "project";
+  path: string;
+  residentTokens: number;
+  bodyTokens: number;
+}
+
+/**
+ * Attention-budget view over the *installed* set — `asm stats --tokens`.
+ *
+ * Resident cost (frontmatter descriptions, paid every message) is reported
+ * separately from body cost (full `SKILL.md`, paid only when a skill fires).
+ */
+export interface TokenBudgetReport {
+  totalSkills: number;
+  totalResidentTokens: number;
+  totalBodyTokens: number;
+  /** Median resident cost across installed skills — the outlier baseline. */
+  medianResidentTokens: number;
+  byProvider: TokenBudgetGroup[];
+  byScope: TokenBudgetGroup[];
+  heaviestResident: ResidentSkillCost[];
+}
+
+// ─── Residency Audit Types (issue #423) ─────────────────────────────────
+
+/** Why a skill was flagged as a demotion candidate. */
+export type ResidencyReasonId =
+  | "expensive-description"
+  | "redundant-activation";
+
+export interface ResidencyReason {
+  id: ResidencyReasonId;
+  /** One-line human explanation, e.g. `4.1x the median description`. */
+  detail: string;
+}
+
+/**
+ * A signal the residency audit *would* rank on, and whether its data exists.
+ *
+ * Signals whose data source is not implemented yet (trigger collision — #18,
+ * usage counts — #354) are reported as unavailable so the report degrades
+ * instead of failing.
+ */
+export interface ResidencySignal {
+  id: string;
+  label: string;
+  available: boolean;
+  /** Why the signal is unavailable, when it is. */
+  reason?: string;
+}
+
+/** One provider/scope location where a candidate is currently resident. */
+export interface ResidencyInstance {
+  provider: string;
+  providerLabel: string;
+  scope: "global" | "project";
+  path: string;
+  /** True when this instance is a symlink into the ASM library. */
+  libraryLinked: boolean;
+}
+
+/**
+ * The concrete, non-throwing ASM command that demotes a candidate.
+ *
+ * `deactivate` is only ever emitted for a single instance that is a live
+ * symlink into the ASM library — `deactivateLibrarySkill` throws on anything
+ * else. Everything else gets `disable`, which is universal and reversible.
+ */
+export interface ResidencyAction {
+  kind: "deactivate" | "disable";
+  command: string;
+  hint: string;
+}
+
+export interface ResidencyCandidate {
+  name: string;
+  dirName: string;
+  /** Resident tokens this skill costs in each place it is installed. */
+  residentTokens: number;
+  /** `residentTokens` times the number of resident instances. */
+  totalResidentTokens: number;
+  bodyTokens: number;
+  /** Ranking weight — currently `totalResidentTokens`. */
+  score: number;
+  instances: ResidencyInstance[];
+  reasons: ResidencyReason[];
+  action: ResidencyAction;
+}
+
+export interface ResidencyReport {
+  scannedAt: string;
+  totalSkills: number;
+  totalResidentTokens: number;
+  medianResidentTokens: number;
+  /**
+   * Installed skills ASM does not manage (plugin marketplaces / Codex plugin
+   * cache). They still cost residency but no ASM command demotes them, so
+   * they are counted, never listed as candidates.
+   */
+  unmanagedSkills: number;
+  candidates: ResidencyCandidate[];
+  signals: ResidencySignal[];
 }
 
 export interface RemovalPlan {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -351,10 +351,11 @@ export interface ResidencyAction {
 export interface ResidencyCandidate {
   name: string;
   dirName: string;
-  /** Resident tokens this skill costs in each place it is installed. */
+  /** Resident tokens the representative instance costs on every message. */
   residentTokens: number;
-  /** `residentTokens` times the number of resident instances. */
+  /** Resident tokens summed across every place this skill is installed. */
   totalResidentTokens: number;
+  /** Body tokens summed across every place this skill is installed. */
   bodyTokens: number;
   /** Ranking weight — currently `totalResidentTokens`. */
   score: number;


### PR DESCRIPTION
## Summary

Installed skills cost two very different things, and ASM measured neither on the installed side:

- **Resident cost** — the frontmatter `description`, inlined into the agent's system prompt on **every message**, whether or not the skill ever fires.
- **Body cost** — the full `SKILL.md`, paid only when the skill actually fires. Already computed as `SkillInfo.tokenCount` (#188).

`computeStats` reported counts and disk bytes; token totals existed only for the *indexed* catalog, which nobody installed. This PR adds installed-side resident accounting and the advice built on top of it.

Closes #421
Closes #423

## Approach

One shared definition of resident cost — `residentTokens()` in `src/utils/token-count.ts` — feeds both surfaces, so the measurement and the advice can never drift apart.

**`asm stats --tokens` (#421)** — resident vs body tokens per provider and per scope, the heaviest resident descriptions, and the median. `--json` and `--machine` supported. Resident and body totals also land in the plain `asm stats` dashboard and its JSON.

**`asm audit residency` (#423)** — ranks the installed skills that are not earning their residency and pairs each with a command that actually works for how that skill is installed.

Both are a flag and a subcommand on existing verbs, so the dispatch switch, the `isCLIMode` allowlist, and the main help are all untouched.

### Getting the demotion command right per candidate

`deactivateLibrarySkill` throws on non-symlinks (`src/library.ts:909`) and on symlinks pointing outside the library (`src/library.ts:928`), so printing `asm deactivate <x>` for every candidate would emit commands that fail when the user runs them. The rule:

| Candidate | Command | Why |
| --- | --- | --- |
| Lone instance that is a live symlink into the ASM library | `asm deactivate <dir> --provider <p> --scope <s>` | The only shape `deactivateLibrarySkill` accepts. Scope is always explicit because `asm deactivate` rejects `--scope both`. |
| Everything else (copies, out-of-library symlinks, multi-tool installs) | `asm disable <dir>` | Universal and reversible with `asm enable`. |
| Plugin marketplace / Codex plugin cache | *not listed* | No ASM command demotes them; `asm disable` skips these providers. They are still counted in the totals. |

### Graceful signal degradation

Two of #423's four signals have no data source in `src/` — trigger collision (#18) and usage counts (#354) are both still open. They are reported as `available: false` with the blocking issue named, rather than silently dropped or failing the report. The two signals with real data (expensive residency relative to the set's median; redundant activation across install locations) do the ranking.

The report is read-only by construction: `asm audit -y` auto-removes duplicates, but the residency path returns before that and ignores `--yes` — there is a test for it.

## Decision Record

| Decision | Chosen | Rejected |
| --- | --- | --- |
| #421 command surface | `asm stats --tokens` | A new `asm budget` verb — needs the dispatch switch, the `isCLIMode` allowlist, and the main help; missing the allowlist would silently launch the Ink TUI. |
| #423 command surface | `asm audit residency` subcommand | A new top-level verb, for the same reason. |
| Resident vs body | Two separate numbers, one shared `residentTokens()` | Reusing `tokenCount` as "resident" — overstates the always-on budget by ~40x. |
| Candidate grouping | By directory name, with all install locations listed | Per-instance rows — a skill in 18 tools would produce 18 near-identical rows. |
| Reference tier (`asm get`) | Not built — #422 is a separate issue | Implementing a demotion destination that does not exist yet. |

## Changes

| File | What |
| --- | --- |
| `src/utils/token-count.ts` | `residentTokens()` / `bodyTokens()` shared helpers; `formatTokenCount` gains an M tier |
| `src/utils/types.ts` | `TokenBudgetReport`, `ResidencyReport` and friends; `StatsReport` gains resident/body totals |
| `src/stats.ts` | `computeTokenBudget`, `formatTokenBudgetReport`, `median`; resident/body totals in `computeStats` |
| `src/residency.ts` *(new)* | `computeResidencyAudit`, `chooseDemotionAction`, `residencySignals`, `formatResidencyReport` |
| `src/cli.ts` | `--tokens` flag, `stats --machine`, `cmdAuditResidency`, help text |
| `README.md` | Attention-budget section with the demotion ladder; command reference rows |
| `src/*.test.ts` | 58 new tests |

## Bug fixes in scope

1. `src/stats.ts` rendered token totals through `formatHumanSize`, so 1234 tokens printed as **"1.2 KB"** in `formatRepoStatsReport` and `formatAuthorStatsReport`; `formatIndexStatsReport` printed a bare number. All now use `formatTokenCount` with the `~` prefix, per #188 and #421's AC.
2. `cmdStats` never read `args.flags.machine`, so `asm stats --machine` silently printed the human dashboard.

## Test Results

```
Test Files  59 passed (59)
     Tests  2025 passed (2025)
```

`npm run typecheck` and `npm run build` both clean.

> Note: `src/skill-index.test.ts:232` fails on a developer machine that has a user-level index under `~/.config/agent-skill-manager/skill-index/` shadowing the bundled one. Pre-existing and environmental — CI has no such directory. Verified: real HOME 1 failed / 21 passed, clean HOME 22 passed, on unmodified `main`. The suite above ran with a clean HOME.

## Acceptance Criteria Verification

### #421

| Criterion | Status | Evidence |
| --- | --- | --- |
| Resident token estimate from `description`, separate from `tokenCount` | ✅ | `residentTokens()`; `computeTokenBudget` returns both totals. Test: "derives resident cost from the description, not the body" |
| Resident and body totals per provider | ✅ | `byProvider[]`. Test: "breaks resident and body totals down per provider" |
| Totals per scope | ✅ | `byScope[]`. Test: "breaks totals down per scope" |
| Lists the heaviest resident descriptions | ✅ | `heaviestResident[]`. Test: "ranks the heaviest resident descriptions first" |
| `--json` in the same shape as other commands, `--machine` honoured | ✅ | Tests: `stats --tokens --json`, `stats --tokens --machine`, `stats --machine` |
| All token figures via `formatTokenCount` with `~` | ✅ | Two `formatHumanSize` bugs fixed. Test asserts output never matches `/\d\s?(KB\|MB\|GB)/` |
| No new network calls, accounts, or telemetry | ✅ | Both reports read only the local filesystem via the existing scanner |
| Documented in the README command reference | ✅ | Command table row plus an "Attention budget" section |

### #423

| Criterion | Status | Evidence |
| --- | --- | --- |
| Lists demotion candidates | ✅ | `computeResidencyAudit` → `candidates[]` |
| Each candidate states its reason | ✅ | `reasons[]` with id and human detail |
| Each candidate paired with a concrete demotion command | ✅ | `chooseDemotionAction`; 4 tests covering every branch, including the two that would throw |
| Ranked, highest value first | ✅ | Sorted by total resident tokens. Test: "ranks the highest total resident cost first" |
| Missing-data signals degrade gracefully | ✅ | `residencySignals()` marks #18 and #354 unavailable with reasons; surfaced in text and JSON. 2 tests |
| `--json` in the same shape as other audit commands | ✅ | Test: "audit residency --json has the audit report shape"; `--machine` envelope too |
| Nothing modified without explicit confirmation | ✅ | Read-only path. Test: "`--yes` never triggers a removal on the residency path" |
| Documented in the README, including the demotion ladder | ✅ | "Residency audit" section with the ladder table |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
