### PR TITLE
feat(cli): add asm get for zero-residency skill delivery (#422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add `asm get <skill>` — a zero-residency reference tier that resolves a skill through the installed / library / index / registry ladder (plus any `asm install` shorthand) and writes its `SKILL.md` body to stdout without installing anything; remote fetches run the same pre-install security scan, reported on stderr and under `--json` ([#422](https://github.com/luongnv89/asm/issues/422)) — @luongnv89
 - Add the `skill-install-improved` bundled skill — installs an improved variant of one skill instead of the published one: resolves the target by local path, repo, or skill name, runs `skill-auto-improver` on a throwaway `mktemp -d` copy so the user's own files are never modified, installs the improved directory, and reports the before/after scores and the provenance it was improved from ([#418](https://github.com/luongnv89/asm/issues/418)) — @luongnv89
 
 ## v2.15.0 — 2026-07-22

--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@
 
 ## Problems `asm` solves
 
-| Pain                    | Without `asm`                                                                                                           | With `asm`                                                                 |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| Scattered installs      | Same skill copied into `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/rules/` — different versions, no single view | One `asm list` across all 19 providers and scopes                          |
-| No inventory            | `ls` through hidden dirs; no idea what is installed, duplicated, or outdated                                            | `asm search`, `asm inspect`, `asm stats`, `asm audit`                      |
-| Invisible context cost  | Every installed skill's description is resident in the agent's prompt on every message, whether or not it ever fires    | `asm stats --tokens`, `asm audit residency`                                |
-| Risky manual installs   | Clone repos, copy folders, hope `SKILL.md` is valid                                                                     | `asm install` validates frontmatter, scans security, pins registry commits |
-| Agent-unfriendly output | Human-only copy-paste workflows                                                                                         | Structured JSON via `--json`; skip prompts with `--yes`                    |
-| New agent, new chore    | Every tool adds another skill directory to track                                                                        | Add or disable providers in one config file                                |
+| Pain                      | Without `asm`                                                                                                           | With `asm`                                                                 |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Scattered installs        | Same skill copied into `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/rules/` — different versions, no single view | One `asm list` across all 19 providers and scopes                          |
+| No inventory              | `ls` through hidden dirs; no idea what is installed, duplicated, or outdated                                            | `asm search`, `asm inspect`, `asm stats`, `asm audit`                      |
+| Invisible context cost    | Every installed skill's description is resident in the agent's prompt on every message, whether or not it ever fires    | `asm stats --tokens`, `asm audit residency`                                |
+| Install just to read once | Installing is the only way to get a skill in front of an agent — and it stays resident forever afterwards               | `asm get <skill>` prints the body and installs nothing                     |
+| Risky manual installs     | Clone repos, copy folders, hope `SKILL.md` is valid                                                                     | `asm install` validates frontmatter, scans security, pins registry commits |
+| Agent-unfriendly output   | Human-only copy-paste workflows                                                                                         | Structured JSON via `--json`; skip prompts with `--yes`                    |
+| New agent, new chore      | Every tool adds another skill directory to track                                                                        | Add or disable providers in one config file                                |
 
 ## At a glance
 
@@ -76,6 +77,7 @@ graph LR
 | Duplicate audit          | `asm audit --yes` removes redundant skills non-interactively         |
 | Attention budget         | `asm stats --tokens` shows resident vs body token cost per tool      |
 | Residency audit          | `asm audit residency` ranks skills to demote out of resident context |
+| Reference tier           | `asm get <skill>` delivers a body once, at zero residency            |
 | Security scan            | `asm audit security` before install                                  |
 | Authoring pipeline       | `asm init`, `asm link`, `asm eval`, `asm publish`                    |
 | Bundles                  | `asm bundle install` — curated sets in one pass                      |
@@ -114,19 +116,20 @@ Node.js 18+ required. Optional TUI: run `asm` with no arguments.
 
 ## Common tasks
 
-| Task                       | Command                                          |
-| -------------------------- | ------------------------------------------------ |
-| Machine-readable inventory | `asm list --json`                                |
-| Skill metadata for agents  | `asm inspect my-skill --json`                    |
-| Non-interactive install    | `asm install code-review -p claude --yes --json` |
-| Remove duplicates          | `asm audit --yes`                                |
-| See your context cost      | `asm stats --tokens`                             |
-| Find skills to demote      | `asm audit residency`                            |
-| Scan before install        | `asm audit security github:user/repo`            |
-| Scaffold a new skill       | `asm init my-skill -p claude`                    |
-| Live dev via symlink       | `asm link ./my-skill -p claude`                  |
-| Publish to registry        | `asm publish ./my-skill --yes`                   |
-| Install a bundle           | `asm bundle install frontend-dev --yes`          |
+| Task                          | Command                                          |
+| ----------------------------- | ------------------------------------------------ |
+| Machine-readable inventory    | `asm list --json`                                |
+| Skill metadata for agents     | `asm inspect my-skill --json`                    |
+| Non-interactive install       | `asm install code-review -p claude --yes --json` |
+| Remove duplicates             | `asm audit --yes`                                |
+| See your context cost         | `asm stats --tokens`                             |
+| Find skills to demote         | `asm audit residency`                            |
+| Use a skill without residency | `asm get code-review`                            |
+| Scan before install           | `asm audit security github:user/repo`            |
+| Scaffold a new skill          | `asm init my-skill -p claude`                    |
+| Live dev via symlink          | `asm link ./my-skill -p claude`                  |
+| Publish to registry           | `asm publish ./my-skill --yes`                   |
+| Install a bundle              | `asm bundle install frontend-dev --yes`          |
 
 Full command reference, flags, and examples: [CLI Commands](#cli-commands). Catalog UI and bundles: [luongnv.com/asm](https://luongnv.com/asm/).
 
@@ -197,6 +200,7 @@ The advice assumes this demotion ladder:
 | Installed (auto-triggers) | provider directory / `asm activate`       | description resident, always |
 | Saved (adapt, no trigger) | `asm install --library`, `asm deactivate` | none until `asm activate`    |
 | Disabled (kept on disk)   | `asm disable` (reverse with `asm enable`) | none                         |
+| Reference (read on use)   | `asm get` — nothing on disk at all        | none                         |
 
 Which command a candidate gets depends on how it is installed. `asm deactivate`
 only works on a live symlink into the `asm` library, so it is suggested only
@@ -210,6 +214,53 @@ unavailable rather than silently dropped, so the report still works today.
 
 No network calls, accounts, or telemetry are involved: both reports run
 entirely against your local filesystem.
+
+### Reference tier: use a skill without installing it
+
+Demoting a skill does not mean losing it. `asm get <skill>` resolves a skill and
+writes its `SKILL.md` body to **stdout** — no provider directory, no library
+entry, no residency. The skill is paid for once, at the point of use, and costs
+nothing afterwards.
+
+```bash
+asm get code-review                       # body to stdout
+asm get code-review > /tmp/SKILL.md       # save it without installing
+asm get github:owner/repo:skills/review   # any `asm install` shorthand
+asm get code-review --json                # name, description, tier, source, tokenCount, security, content
+```
+
+That makes `asm` usable as delivery infrastructure, not only as an installer.
+An agent can pull a skill in for a single task and drop it again:
+
+```bash
+asm get code-review | your-agent --system-prompt-file -
+```
+
+`<skill>` walks a resolution ladder, and the rung that answered is reported as
+the `tier` so provenance is always visible:
+
+| Order | Tier        | Resolves                                              |
+| ----- | ----------- | ----------------------------------------------------- |
+| 1     | `installed` | a skill already installed in one of your agents       |
+| 2     | `library`   | a library skill, **including deactivated ones**       |
+| 3     | `index`     | an indexed catalog skill, matched by exact name       |
+| 4     | `registry`  | the ASM registry — same route as `asm install <name>` |
+
+An explicit `github:owner/repo[#ref][:path]` shorthand, a GitHub URL, or a local
+path skips the ladder. A name that matches more than one indexed repo or
+registry author is never guessed: `asm get` exits non-zero and lists the
+qualified candidates.
+
+The catalog stores metadata, not bodies, so an `index`, `registry` or remote
+`asm get` costs a shallow clone into a temp directory, which is deleted before
+the command returns. Those fetches run the **same pre-install security scan
+`asm install` runs**; the verdict goes to stderr and into `--json` under
+`security`. It reports rather than blocks — `asm get` writes nothing — and
+`--audit` prints the full `asm audit security` report for the fetched skill.
+
+Output discipline: stdout carries the body (or, with `--json`, a single JSON
+object) and nothing else, so piping and redirecting are safe. Provenance,
+progress, and the security verdict go to stderr.
 
 ## FAQ
 
@@ -497,6 +548,7 @@ Multiple `asm` binaries on `PATH` can shadow a fresh upgrade.
 | `asm list`                      | List all discovered skills                |
 | `asm search <query>`            | Search by name/description/provider       |
 | `asm inspect <skill-name>`      | Show detailed info for a skill            |
+| `asm get <skill>`               | Print a skill's body, install nothing     |
 | `asm install <source>`          | Install from GitHub or registry           |
 | `asm publish [path]`            | Publish to ASM Registry                   |
 | `asm uninstall <skill-name>`    | Remove a skill                            |

--- a/README.md
+++ b/README.md
@@ -205,10 +205,11 @@ The advice assumes this demotion ladder:
 Which command a candidate gets depends on how it is installed. `asm deactivate`
 only works on a live symlink into the `asm` library, so it is suggested only
 there; everything else gets `asm disable`, which is universal and reversible.
-Library skills additionally get `asm get <skill>` as a second destination — the
-body is still one command away after demotion. Skills that are not in the
-library do not, because `asm disable` hides `SKILL.md` from the scanner and
-there would be no local copy left for `asm get` to read.
+The `asm deactivate` path additionally gets `asm get <skill>` as a second
+destination: deactivating removes the provider symlink but leaves the library
+copy, so the body is still one command away. The `asm disable` path does not,
+because disabling renames the canonical `SKILL.md` — for a library-linked skill
+that is the library copy itself — leaving nothing for `asm get` to read.
 Skills provided by plugin marketplaces are counted in the totals but never
 listed as candidates — no `asm` command demotes them.
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ The advice assumes this demotion ladder:
 Which command a candidate gets depends on how it is installed. `asm deactivate`
 only works on a live symlink into the `asm` library, so it is suggested only
 there; everything else gets `asm disable`, which is universal and reversible.
+Library skills additionally get `asm get <skill>` as a second destination — the
+body is still one command away after demotion. Skills that are not in the
+library do not, because `asm disable` hides `SKILL.md` from the scanner and
+there would be no local copy left for `asm get` to read.
 Skills provided by plugin marketplaces are counted in the totals but never
 listed as candidates — no `asm` command demotes them.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -5941,6 +5941,10 @@ One line of body text.
 
     await runGet(skillDir);
     await runGet(skillDir, "--json");
+    // Walk the whole ladder — installed, library, index — and fall off the end.
+    // The name is deliberately not a valid bare/scoped registry name, so the
+    // registry rung is never reached and no network call happens.
+    await runGet("NotARealSkill_422");
 
     // Provider directories for the most common agents.
     for (const dir of [

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -6012,6 +6012,29 @@ One line of body text.
     expect(stderr).toContain("escapes the repository");
   });
 
+  test("refuses a `..` hidden in the ref, which resolveSubpath would split out", async () => {
+    // `parseSource` reports subpath: null here — the `..` lives in the ref, and
+    // `resolveSubpath` would later split "main/../../etc" into ref "main" plus
+    // subpath "../../etc", which is then joined onto the temp clone.
+    const { stderr, exitCode } = await runGet(
+      "github:acme/skills#main/../../etc",
+    );
+    expect(exitCode).toBe(1);
+    // Rejected before any network access — neither ls-remote nor clone runs.
+    expect(stderr).not.toContain("Fetching");
+    expect(stderr).toContain("escapes the repository");
+  });
+
+  test("--audit prints the audit report on stderr for a local tier", async () => {
+    // The flag used to be a silent no-op for skills that were never fetched;
+    // it now runs against whatever directory the ladder resolved.
+    const { stdout, stderr, exitCode } = await runGet(skillDir, "--audit");
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("Security Audit");
+    // The body still owns stdout, byte for byte.
+    expect(stdout).toBe(BODY);
+  });
+
   test("a missing argument exits 2", async () => {
     const { exitCode, stderr } = await runGet();
     expect(exitCode).toBe(2);

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -5880,6 +5880,101 @@ One line of body text.
     expect(stderr).toContain("(installed)");
   });
 
+  test("resolves a deactivated library skill the scanner cannot see", async () => {
+    // Tier 2 lives outside every provider directory, so `scanAllSkills` finds
+    // nothing — this rung is the only way `asm get` reaches it, and it is the
+    // population `asm audit residency` points at the reference tier.
+    const libraryDir = join(home, ".config", "agent-skill-manager", "library");
+    const libSkill = join(libraryDir, "skills", "lib-only");
+    await mkdir(libSkill, { recursive: true });
+    await writeFile(join(libSkill, "SKILL.md"), BODY, "utf-8");
+    await writeFile(
+      join(libraryDir, "library-lock.json"),
+      JSON.stringify({
+        version: 1,
+        skills: {
+          "lib-only": {
+            name: "lib-only",
+            version: "1.0.0",
+            source: "github:acme/skills",
+            commitHash: "0123456789abcdef0123456789abcdef01234567",
+            ref: null,
+            skillPath: "lib-only",
+            libraryPath: libSkill,
+            installedAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const { stdout, stderr, exitCode } = await runGet("lib-only", "--json");
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("Fetching");
+    const payload = JSON.parse(stdout);
+    expect(payload.tier).toBe("library");
+    expect(payload.source).toBe(libSkill);
+    expect(payload.commit).toBe("0123456789abcdef0123456789abcdef01234567");
+    expect(payload.content).toBe(BODY);
+  });
+
+  test("refuses to guess when two indexed repos publish the same name", async () => {
+    const indexDir = join(
+      home,
+      ".config",
+      "agent-skill-manager",
+      "skill-index",
+    );
+    await mkdir(indexDir, { recursive: true });
+    const entry = (owner: string, repo: string) => ({
+      repoUrl: `https://github.com/${owner}/${repo}`,
+      owner,
+      repo,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      skillCount: 1,
+      skills: [
+        {
+          name: "collide-422",
+          description: "A name published by two repos.",
+          version: "1.0.0",
+          license: "MIT",
+          creator: "",
+          compatibility: "",
+          allowedTools: [],
+          installUrl: `github:${owner}/${repo}:skills/collide-422`,
+          relPath: "skills/collide-422",
+          tokenCount: 10,
+        },
+      ],
+      bundles: [],
+    });
+    await writeFile(
+      join(indexDir, "acme_skills.json"),
+      JSON.stringify(entry("acme", "skills")),
+      "utf-8",
+    );
+    await writeFile(
+      join(indexDir, "other_pack.json"),
+      JSON.stringify(entry("other", "pack")),
+      "utf-8",
+    );
+
+    const { stderr, exitCode } = await runGet("collide-422");
+    expect(exitCode).toBe(1);
+    // Never a clone: an ambiguous name is reported, not resolved.
+    expect(stderr).not.toContain("Fetching");
+    expect(stderr).toContain("matches 2 indexed skills");
+    expect(stderr).toContain("github:acme/skills:skills/collide-422");
+    expect(stderr).toContain("github:other/pack:skills/collide-422");
+
+    const machine = await runGet("collide-422", "--machine");
+    expect(machine.exitCode).toBe(1);
+    const envelope = JSON.parse(machine.stdout);
+    expect(envelope.status).toBe("error");
+    expect(envelope.error.code).toBe("INVALID_ARGUMENT");
+    expect(envelope.error.details.candidates).toHaveLength(2);
+  });
+
   test("--json emits one object with source, token count and body", async () => {
     const { stdout, exitCode } = await runGet(skillDir, "--json");
     expect(exitCode).toBe(0);
@@ -5905,6 +6000,16 @@ One line of body text.
     expect(envelope.command).toBe("get");
     expect(envelope.status).toBe("ok");
     expect(envelope.data.content).toBe(BODY);
+  });
+
+  test("refuses a subpath that climbs out of the clone", async () => {
+    const { stderr, exitCode } = await runGet(
+      "github:acme/skills:../../../etc",
+    );
+    expect(exitCode).toBe(1);
+    // Rejected before any network access — the clone never starts.
+    expect(stderr).not.toContain("Fetching");
+    expect(stderr).toContain("escapes the repository");
   });
 
   test("a missing argument exits 2", async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -5774,3 +5774,188 @@ version: 1.0.0
     }
   });
 });
+
+// ─── asm get: zero-residency reference tier (issue #422) ────────────────────
+
+describe("parseArgs: --audit (issue #422)", () => {
+  const parse = (...args: string[]) =>
+    parseArgs(["node", "script.ts", ...args]);
+
+  test("defaults to false", () => {
+    expect(parse("get", "code-review").flags.audit).toBe(false);
+  });
+
+  test("--audit sets the escalation flag", () => {
+    const args = parse("get", "code-review", "--audit");
+    expect(args.command).toBe("get");
+    expect(args.subcommand).toBe("code-review");
+    expect(args.flags.audit).toBe(true);
+  });
+
+  test("--audit combines with --json and --machine", () => {
+    expect(parse("get", "x", "--audit", "--json").flags).toMatchObject({
+      audit: true,
+      json: true,
+    });
+    expect(parse("get", "x", "--audit", "--machine").flags).toMatchObject({
+      audit: true,
+      machine: true,
+    });
+  });
+});
+
+describe("isCLIMode: get (issue #422)", () => {
+  test("get is a known command, not an unrecognised first arg", () => {
+    expect(isCLIMode(["node", "script.ts", "get"])).toBe(true);
+    expect(isCLIMode(["node", "script.ts", "get", "code-review"])).toBe(true);
+  });
+});
+
+describe("asm get (issue #422)", () => {
+  let home: string;
+  let skillDir: string;
+  const BODY = `---
+name: get-fixture
+description: A fixture skill used by the asm get tests.
+---
+
+# Get fixture
+
+One line of body text.
+`;
+
+  // Every spawn runs against a throwaway HOME so the command can never read —
+  // or write — the developer's real skill directories.
+  async function runGet(
+    ...args: string[]
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const res = await spawnCollect(["npx", "tsx", CLI_BIN, "get", ...args], {
+      env: { ...process.env, HOME: home, NO_COLOR: "1" },
+    });
+    return {
+      stdout: res.stdout,
+      stderr: res.stderr,
+      exitCode: res.exitCode,
+    };
+  }
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "asm-get-home-"));
+    skillDir = join(
+      await mkdtemp(join(tmpdir(), "asm-get-src-")),
+      "get-fixture",
+    );
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), BODY, "utf-8");
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+    await rm(dirname(skillDir), { recursive: true, force: true });
+  });
+
+  test("writes the SKILL.md body to stdout and nothing else", async () => {
+    const { stdout, exitCode } = await runGet(skillDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe(BODY);
+  });
+
+  test("reports provenance on stderr, never on stdout", async () => {
+    const { stdout, stderr } = await runGet(skillDir);
+    expect(stderr).toContain("get-fixture");
+    expect(stderr).toContain(skillDir);
+    expect(stderr).toContain("residency");
+    expect(stdout).not.toContain("residency");
+    expect(stdout).not.toContain("source:");
+  });
+
+  test("resolves an installed skill by name and reports the installed tier", async () => {
+    const installed = join(home, ".claude", "skills", "get-fixture");
+    await mkdir(installed, { recursive: true });
+    await writeFile(join(installed, "SKILL.md"), BODY, "utf-8");
+
+    const { stdout, stderr, exitCode } = await runGet("get-fixture");
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe(BODY);
+    expect(stderr).toContain("(installed)");
+  });
+
+  test("--json emits one object with source, token count and body", async () => {
+    const { stdout, exitCode } = await runGet(skillDir, "--json");
+    expect(exitCode).toBe(0);
+    const payload = JSON.parse(stdout);
+    expect(payload.name).toBe("get-fixture");
+    expect(payload.description).toBe(
+      "A fixture skill used by the asm get tests.",
+    );
+    expect(payload.tier).toBe("local");
+    expect(payload.source).toBe(skillDir);
+    expect(typeof payload.tokenCount).toBe("number");
+    expect(payload.tokenCount).toBeGreaterThan(0);
+    expect(payload.content).toBe(BODY);
+    // Assembled field by field — the scanner's private cache must never leak.
+    expect(payload).not.toHaveProperty("_skillMdContent");
+  });
+
+  test("--machine wraps the same data in the v1 envelope", async () => {
+    const { stdout, exitCode } = await runGet(skillDir, "--machine");
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.version).toBe(1);
+    expect(envelope.command).toBe("get");
+    expect(envelope.status).toBe("ok");
+    expect(envelope.data.content).toBe(BODY);
+  });
+
+  test("a missing argument exits 2", async () => {
+    const { exitCode, stderr } = await runGet();
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Missing required argument");
+  });
+
+  test("an unresolvable name exits 1 with a search hint", async () => {
+    // Deliberately not a valid bare/scoped registry name, so the ladder ends
+    // locally and the test never touches the network.
+    const { exitCode, stderr } = await runGet("NotARealSkill_422");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("not found");
+    expect(stderr).toContain("asm search");
+  });
+
+  test("--help exits 0 and documents the zero-residency guarantee", async () => {
+    const { stdout, exitCode } = await runGet("--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("asm get <skill>");
+    expect(stdout).toContain("Nothing is installed");
+  });
+
+  test("installs nothing: no provider directory and no library are created", async () => {
+    const exists = async (p: string) => {
+      try {
+        await lstat(p);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    await runGet(skillDir);
+    await runGet(skillDir, "--json");
+
+    // Provider directories for the most common agents.
+    for (const dir of [
+      join(home, ".claude", "skills"),
+      join(home, ".codex", "skills"),
+      join(home, ".cursor", "rules"),
+    ]) {
+      expect(await exists(dir)).toBe(false);
+    }
+    // The `asm` library — tier 2 — must be untouched as well.
+    expect(
+      await exists(join(home, ".config", "agent-skill-manager", "library")),
+    ).toBe(false);
+    // The registry metadata cache is deliberately NOT asserted on: it is
+    // resolution metadata, not an installed skill, and the local path used
+    // here never reaches the registry rung anyway.
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1588,10 +1588,10 @@ async function cmdGet(args: ParsedArgs) {
         );
       }
     }
-    if (cleanup) await cleanup();
-    cleanup = null;
-    restoreConsole();
-    process.exit(1);
+    // `process.exitCode` rather than `process.exit()`: under `--machine` the
+    // error envelope has just been written to stdout, and an immediate exit can
+    // truncate a pipe before it flushes. The `finally` below still cleans up.
+    process.exitCode = 1;
   } finally {
     if (cleanup) await cleanup();
     restoreConsole();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -750,7 +750,8 @@ ${ansi.bold("Options:")}
   --json             Output {name, description, tier, source, commit,
                      tokenCount, security, content} as a JSON object
   --machine          Stable machine-readable v1 envelope
-  --audit            Also print the full security audit report (stderr)
+  --audit            Also print the full security audit report (stderr),
+                     for any resolved skill, not only fetched ones
   -s, --scope <s>    Filter installed lookup: global, project, or both
   --transport <t>    Clone transport for remote sources: auto, https, ssh
   --no-cache         Bypass the registry cache when resolving a name
@@ -1244,6 +1245,11 @@ async function cmdInspect(args: ParsedArgs) {
 interface GetResolution {
   result: GetResult;
   cleanup: (() => Promise<void>) | null;
+  /** Directory the body was read from — still on disk until `cleanup` runs. */
+  dir: string;
+  /** GitHub coordinates, when the body came from a remote source. */
+  owner?: string;
+  repo?: string;
 }
 
 /** A name that resolves to more than one skill — never guessed, always listed. */
@@ -1326,6 +1332,16 @@ async function fetchGetFromRemote(
   sourceInput: string,
   tier: GetTier,
 ): Promise<GetResolution> {
+  // The subpath can arrive from catalog data as well as from the command line,
+  // and it is joined onto a temp directory — refuse anything that climbs out of
+  // it rather than reading a file outside the clone.
+  const preParsed = parseSource(sourceInput);
+  if (preParsed.subpath?.split(/[/\\]/).includes("..")) {
+    throw new Error(
+      `Invalid source: the subpath in "${sourceInput}" escapes the repository.`,
+    );
+  }
+
   process.stderr.write(ansi.dim(`Fetching ${sourceInput}…\n`));
   const remote = await fetchRemoteSkillDir(
     sourceInput,
@@ -1334,7 +1350,11 @@ async function fetchGetFromRemote(
   );
   try {
     const parsed = parseSource(sourceInput);
-    const hintBase = `github:${parsed.owner}/${parsed.repo}`;
+    // Keep any explicit ref in the hint — dropping it would suggest commands
+    // that silently resolve against the default branch instead.
+    const hintBase = `github:${parsed.owner}/${parsed.repo}${
+      parsed.ref ? `#${parsed.ref}` : ""
+    }`;
     const { name, description } = await validateSkillForGet(
       remote.rootDir,
       hintBase,
@@ -1351,16 +1371,6 @@ async function fetchGetFromRemote(
       categories: Array.from(new Set(warnings.map((w) => w.category))).sort(),
     };
 
-    if (args.flags.audit) {
-      const report = await auditSkillSecurity(
-        remote.rootDir,
-        name,
-        parsed.owner,
-        parsed.repo,
-      );
-      process.stderr.write(formatSecurityReport(report) + "\n");
-    }
-
     return {
       result: {
         name,
@@ -1373,6 +1383,9 @@ async function fetchGetFromRemote(
         content,
       },
       cleanup: remote.cleanup,
+      dir: remote.rootDir,
+      owner: parsed.owner,
+      repo: parsed.repo,
     };
   } catch (err) {
     await remote.cleanup();
@@ -1435,6 +1448,7 @@ async function resolveGetTarget(
     return {
       result: localGetResult(content, "local", localPath),
       cleanup: null,
+      dir: localPath,
     };
   }
 
@@ -1457,6 +1471,7 @@ async function resolveGetTarget(
         tokenCount: match.tokenCount,
       }),
       cleanup: null,
+      dir: match.path,
     };
   }
 
@@ -1475,6 +1490,7 @@ async function resolveGetTarget(
         commit: libMatch.commitHash || null,
       }),
       cleanup: null,
+      dir: libMatch.libraryPath,
     };
   }
 
@@ -1548,6 +1564,19 @@ async function cmdGet(args: ParsedArgs) {
     const resolution = await resolveGetTarget(args, target);
     cleanup = resolution.cleanup;
     const result = resolution.result;
+
+    // `--audit` applies to whatever was resolved: a temp clone is still on disk
+    // at this point, and installed/library/local tiers have a real directory
+    // too, so the flag never silently does nothing.
+    if (args.flags.audit) {
+      const report = await auditSkillSecurity(
+        resolution.dir,
+        result.name,
+        resolution.owner,
+        resolution.repo,
+      );
+      process.stderr.write(formatSecurityReport(report) + "\n");
+    }
 
     if (args.flags.machine) {
       process.stdout.write(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,7 @@ import {
   validateSkill,
   discoverSkills,
   scanForWarnings,
+  classifyWarningRisk,
   executeInstall,
   executeInstallAllProviders,
   cleanupTemp,
@@ -187,7 +188,9 @@ import {
   getTotalSkillCount,
   getMissingMetadataFields,
   loadAllIndices,
+  resolveIndexedSkillByName,
 } from "./skill-index";
+import { estimateTokenCount, formatTokenCount } from "./utils/token-count";
 import type { SearchFilters } from "./skill-index";
 import { getVersionString } from "./utils/version";
 import { buildShadowingReport } from "./utils/path-shadowing";
@@ -213,6 +216,9 @@ import type {
   RepoStatsReport,
   AuthorStatsReport,
   IndexStatsReport,
+  GetResult,
+  GetSecurityVerdict,
+  GetTier,
 } from "./utils/types";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -336,6 +342,8 @@ interface ParsedArgs {
     tags: string | null;
     /** `asm bundle list --predefined` — show pre-defined bundles shipped with ASM (issue #206). */
     predefined: boolean;
+    /** `asm get --audit` — print the full security audit report for a fetched skill (issue #422). */
+    audit: boolean;
   };
 }
 
@@ -386,6 +394,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       author: null,
       tags: null,
       predefined: false,
+      audit: false,
     },
   };
 
@@ -546,6 +555,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.flags.tags = args[i] || null;
     } else if (arg === "--predefined") {
       result.flags.predefined = true;
+    } else if (arg === "--audit") {
+      result.flags.audit = true;
     } else if (arg.startsWith("-")) {
       error(`Unknown option: ${arg}`);
       console.error(`Run "asm --help" for usage.`);
@@ -588,6 +599,7 @@ ${ansi.bold("Commands:")}
   list                   List all discovered skills
   search <query>         Search skills by name/description/tool
   inspect <skill-name>   Show detailed info for a skill
+  get <skill>            Print a skill's SKILL.md body (installs nothing)
   uninstall <skill-name> Remove a skill (with confirmation)
   disable <target>       Disable skill(s) without uninstalling
   enable <target>        Re-enable disabled skill(s)
@@ -713,6 +725,44 @@ ${ansi.bold("Examples:")}
   asm inspect code-review           ${ansi.dim("Show details for code-review")}
   asm inspect code-review --json    ${ansi.dim("Output as JSON")}
   asm inspect code-review -s global ${ansi.dim("Global installations only")}`);
+}
+
+function printGetHelp() {
+  console.log(`${ansi.bold("Usage:")} asm get <skill> [options]
+
+Resolve a skill and write its SKILL.md body to stdout. Nothing is installed:
+no provider directory, no library entry, no residency in any system prompt.
+Use it to pull a skill in for a single task and pay nothing afterwards.
+
+<skill> is resolved in this order, and the rung that answered is reported:
+  1. installed        a skill already present in one of your agents
+  2. library          a library skill, including deactivated ones
+  3. index            an indexed catalog skill (resolved by exact name)
+  4. registry         the ASM registry, same route as \`asm install <name>\`
+An explicit \`github:owner/repo[#ref][:path]\` shorthand, a GitHub URL, or a
+local path skips the ladder and is fetched directly.
+
+Index, registry and remote sources are fetched into a temp clone, scanned with
+the same pre-install security scan \`asm install\` runs, and deleted. The body
+goes to stdout; provenance and the security verdict go to stderr.
+
+${ansi.bold("Options:")}
+  --json             Output {name, description, tier, source, commit,
+                     tokenCount, security, content} as a JSON object
+  --machine          Stable machine-readable v1 envelope
+  --audit            Also print the full security audit report (stderr)
+  -s, --scope <s>    Filter installed lookup: global, project, or both
+  --transport <t>    Clone transport for remote sources: auto, https, ssh
+  --no-cache         Bypass the registry cache when resolving a name
+  --no-color         Disable ANSI colors
+  -V, --verbose      Show debug output
+
+${ansi.bold("Examples:")}
+  asm get code-review                      ${ansi.dim("Print the body to stdout")}
+  asm get code-review > SKILL.md           ${ansi.dim("Save it without installing")}
+  asm get github:owner/repo:skills/review  ${ansi.dim("Fetch a remote skill")}
+  asm get owner/review --audit             ${ansi.dim("Show the full security audit")}
+  asm get code-review --json               ${ansi.dim("Structured output")}`);
 }
 
 function printUninstallHelp() {
@@ -1179,6 +1229,372 @@ async function cmdInspect(args: ParsedArgs) {
     console.log(formatJSON(matches.length === 1 ? matches[0] : matches));
   } else {
     console.log(await formatSkillInspect(matches));
+  }
+}
+
+// ─── Get: zero-residency reference tier (issue #422) ────────────────────────
+//
+// `asm get` is deliberately the install path minus the write: it resolves a
+// skill through the same ladder `asm install` uses, prints the SKILL.md body
+// to stdout, and touches no provider directory and no library. The body is
+// paid for once, at the point of use, instead of sitting resident in every
+// system prompt.
+
+/** Resolution outcome plus the cleanup hook for any temp clone it created. */
+interface GetResolution {
+  result: GetResult;
+  cleanup: (() => Promise<void>) | null;
+}
+
+/** A name that resolves to more than one skill — never guessed, always listed. */
+class AmbiguousGetError extends Error {
+  candidates: string[];
+  constructor(message: string, candidates: string[]) {
+    super(message);
+    this.name = "AmbiguousGetError";
+    this.candidates = candidates;
+  }
+}
+
+/** Human-readable risk label, matching the `asm install` preview wording. */
+function getRiskLabel(risk: "high" | "medium" | "safe"): string {
+  if (risk === "high") return ansi.red("[!] High Risk");
+  if (risk === "medium") return ansi.yellow("[~] Medium Risk");
+  return ansi.green("[ok] Safe");
+}
+
+/**
+ * Provenance block for the plain (non-JSON) path. Always stderr: stdout
+ * carries the body and nothing else, so `asm get x > SKILL.md` and
+ * `asm get x | agent` both stay clean.
+ */
+function writeGetProvenance(result: GetResult): void {
+  const lines: string[] = [
+    `  ${ansi.bold(result.name)}  ${ansi.dim(formatTokenCount(result.tokenCount))}`,
+    `  ${ansi.dim("source:")} ${result.source}${
+      result.commit ? ` @ ${result.commit.slice(0, 7)}` : ""
+    } ${ansi.dim(`(${result.tier})`)}`,
+  ];
+  if (result.security) {
+    const { risk, warnings, categories } = result.security;
+    const detail = warnings
+      ? ansi.dim(
+          ` (${warnings} warning${warnings === 1 ? "" : "s"}: ${categories.join(", ")})`,
+        )
+      : "";
+    lines.push(`  ${ansi.dim("security:")} ${getRiskLabel(risk)}${detail}`);
+  }
+  lines.push(
+    `  ${ansi.dim("residency:")} ${ansi.dim("none — nothing was installed")}`,
+  );
+  process.stderr.write(lines.join("\n") + "\n\n");
+}
+
+/**
+ * Validate a cloned directory as a single skill, turning the "this repo is a
+ * collection" case into an actionable list of subpaths instead of a bare
+ * "SKILL.md not found".
+ */
+async function validateSkillForGet(
+  rootDir: string,
+  hintBase: string,
+): Promise<{ name: string; description: string }> {
+  try {
+    const { name, description } = await validateSkill(rootDir);
+    return { name, description };
+  } catch (err) {
+    const nested = (await discoverSkills(rootDir)).filter((s) => s.relPath);
+    if (nested.length > 0) {
+      const shown = nested.slice(0, 5);
+      throw new Error(
+        `"${hintBase}" holds ${nested.length} skills, not one. Pick a skill:\n` +
+          shown.map((s) => `    asm get ${hintBase}:${s.relPath}`).join("\n"),
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * Clone a remote source into a temp dir, read its body, and run the same
+ * pre-install security scan `asm install` runs. The verdict is *reported*, not
+ * enforced — `asm get` writes nothing, so there is no install to block; the
+ * user sees the risk before they feed the text to an agent.
+ */
+async function fetchGetFromRemote(
+  args: ParsedArgs,
+  sourceInput: string,
+  tier: GetTier,
+): Promise<GetResolution> {
+  process.stderr.write(ansi.dim(`Fetching ${sourceInput}…\n`));
+  const remote = await fetchRemoteSkillDir(
+    sourceInput,
+    args.flags.transport,
+    false,
+  );
+  try {
+    const parsed = parseSource(sourceInput);
+    const hintBase = `github:${parsed.owner}/${parsed.repo}`;
+    const { name, description } = await validateSkillForGet(
+      remote.rootDir,
+      hintBase,
+    );
+    const content = await fsReadFile(
+      joinPath(remote.rootDir, "SKILL.md"),
+      "utf-8",
+    );
+
+    const warnings = await scanForWarnings(remote.rootDir);
+    const security: GetSecurityVerdict = {
+      risk: classifyWarningRisk(warnings),
+      warnings: warnings.length,
+      categories: Array.from(new Set(warnings.map((w) => w.category))).sort(),
+    };
+
+    if (args.flags.audit) {
+      const report = await auditSkillSecurity(
+        remote.rootDir,
+        name,
+        parsed.owner,
+        parsed.repo,
+      );
+      process.stderr.write(formatSecurityReport(report) + "\n");
+    }
+
+    return {
+      result: {
+        name,
+        description,
+        tier,
+        source: remote.sourceRef,
+        commit: remote.commitSha,
+        tokenCount: estimateTokenCount(content),
+        security,
+        content,
+      },
+      cleanup: remote.cleanup,
+    };
+  } catch (err) {
+    await remote.cleanup();
+    throw err;
+  }
+}
+
+/** Build a `GetResult` from a SKILL.md that already sits on this machine. */
+function localGetResult(
+  content: string,
+  tier: GetTier,
+  source: string,
+  overrides: {
+    name?: string;
+    description?: string;
+    commit?: string | null;
+    tokenCount?: number;
+  } = {},
+): GetResult {
+  const fm = parseFrontmatter(content);
+  return {
+    name: overrides.name || fm.name || source.split(/[/\\]/).pop() || source,
+    description:
+      overrides.description ??
+      (fm.description || "").replace(/\s*\n\s*/g, " ").trim(),
+    tier,
+    source,
+    commit: overrides.commit ?? null,
+    tokenCount: overrides.tokenCount ?? estimateTokenCount(content),
+    security: null,
+    content,
+  };
+}
+
+/**
+ * The resolution ladder: explicit sources short-circuit, bare names walk
+ * installed → library → index → registry. Cheapest and most local wins, and
+ * whichever rung answered is reported as the `tier` so provenance is visible.
+ */
+async function resolveGetTarget(
+  args: ParsedArgs,
+  target: string,
+): Promise<GetResolution> {
+  // Explicit GitHub shorthand / URL — straight to the remote rung.
+  if (looksLikeGithubInput(target)) {
+    return fetchGetFromRemote(args, target, "remote");
+  }
+
+  // Explicit local path (or a path-shaped input that exists on disk).
+  if (isLocalPath(target) || (await isExistingLocalDir(target))) {
+    const localPath = parseSource(
+      isLocalPath(target) ? target : `./${target}`,
+    ).localPath!;
+    let content: string;
+    try {
+      content = await fsReadFile(joinPath(localPath, "SKILL.md"), "utf-8");
+    } catch {
+      throw new Error(`No SKILL.md found in "${localPath}".`);
+    }
+    return {
+      result: localGetResult(content, "local", localPath),
+      cleanup: null,
+    };
+  }
+
+  // Rung 1 — installed skills. The scanner already retained the body, so a
+  // hit here costs no IO at all.
+  const config = await loadConfig();
+  const installed = await scanAllSkills(config, args.flags.scope);
+  const match =
+    installed.find((s) => s.dirName === target) ??
+    installed.find((s) => s.name === target);
+  if (match) {
+    const content =
+      match._skillMdContent !== undefined
+        ? match._skillMdContent
+        : await fsReadFile(joinPath(match.path, "SKILL.md"), "utf-8");
+    return {
+      result: localGetResult(content, "installed", match.path, {
+        name: match.name,
+        description: match.description,
+        tokenCount: match.tokenCount,
+      }),
+      cleanup: null,
+    };
+  }
+
+  // Rung 2 — the local library. Deactivated library skills are invisible to
+  // the scanner, and they are exactly the population `asm audit residency`
+  // points at the reference tier.
+  const libMatch = findLibrarySkill(await listLibrarySkills(), target);
+  if (libMatch && !libMatch.missing) {
+    const content = await fsReadFile(
+      joinPath(libMatch.libraryPath, "SKILL.md"),
+      "utf-8",
+    );
+    return {
+      result: localGetResult(content, "library", libMatch.libraryPath, {
+        name: libMatch.name,
+        commit: libMatch.commitHash || null,
+      }),
+      cleanup: null,
+    };
+  }
+
+  // Rung 3 — the indexed catalog. `IndexedSkill` carries no body, so a hit
+  // here necessarily degrades into a temp clone.
+  const indexed = await resolveIndexedSkillByName(target);
+  if (indexed.status === "ambiguous") {
+    throw new AmbiguousGetError(
+      `"${target}" matches ${indexed.matches.length} indexed skills.`,
+      indexed.matches.map(
+        (m) => `${m.repo.owner}/${m.repo.repo} — asm get ${m.skill.installUrl}`,
+      ),
+    );
+  }
+  if (indexed.status === "found") {
+    return fetchGetFromRemote(args, indexed.match.skill.installUrl, "index");
+  }
+
+  // Rung 4 — the ASM registry, the same route `asm install <name>` takes.
+  if (isBareOrScopedName(target)) {
+    const { resolved, multipleMatches, suggestions } =
+      await resolveFromRegistry(target, { noCache: args.flags.noCache });
+    if (resolved) {
+      const m = resolved.manifest;
+      const repoPath = m.repository.replace("https://github.com/", "");
+      const ref = m.skill_path
+        ? `github:${repoPath}#${m.commit}:${m.skill_path}`
+        : `github:${repoPath}#${m.commit}`;
+      return fetchGetFromRemote(args, ref, "registry");
+    }
+    if (multipleMatches.length > 0) {
+      throw new AmbiguousGetError(
+        `"${target}" is published by ${multipleMatches.length} authors.`,
+        multipleMatches
+          .slice(0, 5)
+          .map((m) => `${m.author}/${m.name} — asm get ${m.author}/${m.name}`),
+      );
+    }
+    if (suggestions.length > 0) {
+      throw new Error(
+        `Skill "${target}" not found. Did you mean: ${suggestions.join(", ")}?`,
+      );
+    }
+  }
+
+  throw new Error(
+    `Skill "${target}" not found installed, in the library, in the index, or in the registry.`,
+  );
+}
+
+async function cmdGet(args: ParsedArgs) {
+  if (args.flags.help) {
+    printGetHelp();
+    return;
+  }
+
+  const startTime = performance.now();
+  const target = args.subcommand;
+  if (!target) {
+    error("Missing required argument: <skill>");
+    console.error(`Run "asm get --help" for usage.`);
+    process.exit(2);
+  }
+
+  // stdout carries the body (or the JSON object) and nothing else. Redirecting
+  // console output up front means no dependency can leak a line into a piped
+  // body.
+  const restoreConsole = redirectConsoleToStderr();
+  let cleanup: (() => Promise<void>) | null = null;
+  try {
+    const resolution = await resolveGetTarget(args, target);
+    cleanup = resolution.cleanup;
+    const result = resolution.result;
+
+    if (args.flags.machine) {
+      process.stdout.write(
+        formatMachineOutput("get", result, startTime) + "\n",
+      );
+    } else if (args.flags.json) {
+      process.stdout.write(formatJSON(result) + "\n");
+    } else {
+      writeGetProvenance(result);
+      process.stdout.write(result.content);
+      if (!result.content.endsWith("\n")) process.stdout.write("\n");
+    }
+  } catch (err: any) {
+    const message = err?.message || String(err);
+    const candidates =
+      err instanceof AmbiguousGetError ? err.candidates : undefined;
+    if (args.flags.machine) {
+      process.stdout.write(
+        formatMachineError(
+          "get",
+          candidates ? ErrorCodes.INVALID_ARGUMENT : ErrorCodes.SKILL_NOT_FOUND,
+          message,
+          startTime,
+          candidates ? { candidates } : undefined,
+        ) + "\n",
+      );
+    } else {
+      error(message);
+      if (candidates) {
+        for (const c of candidates) {
+          process.stderr.write(`    ${ansi.cyan("•")} ${c}\n`);
+        }
+      } else {
+        process.stderr.write(
+          ansi.dim(
+            `Try ${ansi.bold("asm list")} or ${ansi.bold(`asm search "${target}"`)}.\n`,
+          ),
+        );
+      }
+    }
+    if (cleanup) await cleanup();
+    cleanup = null;
+    restoreConsole();
+    process.exit(1);
+  } finally {
+    if (cleanup) await cleanup();
+    restoreConsole();
   }
 }
 
@@ -2629,18 +3045,13 @@ async function inspectSkillForInstall(
     scope,
   );
 
-  const hasHighRisk = warnings.some((w) =>
-    ["Shell commands", "Code execution", "Credentials"].includes(w.category),
-  );
-  const hasMedRisk = warnings.some((w) =>
-    ["External URLs"].includes(w.category),
-  );
-  const riskLevel = hasHighRisk ? "high" : hasMedRisk ? "medium" : "safe";
-  const riskLabel = hasHighRisk
-    ? ansi.red("[!] High Risk")
-    : hasMedRisk
-      ? ansi.yellow("[~] Medium Risk")
-      : ansi.green("[ok] Safe");
+  const riskLevel = classifyWarningRisk(warnings);
+  const riskLabel =
+    riskLevel === "high"
+      ? ansi.red("[!] High Risk")
+      : riskLevel === "medium"
+        ? ansi.yellow("[~] Medium Risk")
+        : ansi.green("[ok] Safe");
 
   return {
     metadata,
@@ -4499,11 +4910,12 @@ function unwrapRunnerErrorOrThrow(result: {
 }
 
 /**
- * Default fetchRemote adapter used by `cmdEval` — clones a GitHub shorthand or
- * URL into a temp dir via the installer pipeline, resolves any subpath, then
- * hands the root back with a cleanup hook.
+ * Shared remote-acquisition primitive — clones a GitHub shorthand or URL into
+ * a temp dir via the installer pipeline, resolves any subpath, then hands the
+ * root back with a cleanup hook and the provenance (`sourceRef`, `commitSha`)
+ * its callers report. Used by `cmdEval` and by `cmdGet` (issue #422).
  */
-async function fetchRemoteForEval(
+async function fetchRemoteSkillDir(
   input: string,
   transport: TransportMode,
   keep: boolean,
@@ -4519,7 +4931,7 @@ async function fetchRemoteForEval(
     // Defensive: looksLikeGithubInput should have filtered this, but guard
     // against future regressions so the local-path branch is the only entry.
     throw new Error(
-      `fetchRemoteForEval received a local path: "${input}". This is a bug — local paths should use the non-remote branch.`,
+      `fetchRemoteSkillDir received a local path: "${input}". This is a bug — local paths should use the non-remote branch.`,
     );
   }
   source = await resolveSubpath(source);
@@ -4722,7 +5134,7 @@ async function cmdEval(args: ParsedArgs) {
   try {
     resolved = await resolveEvalInput(rawInput, {
       fetchRemote: (input: string) =>
-        fetchRemoteForEval(input, args.flags.transport, args.flags.keep),
+        fetchRemoteSkillDir(input, args.flags.transport, args.flags.keep),
     });
   } catch (err: any) {
     if (args.flags.machine) {
@@ -6917,6 +7329,9 @@ export async function runCLI(argv: string[]): Promise<void> {
     case "inspect":
       await cmdInspect(args);
       break;
+    case "get":
+      await cmdGet(args);
+      break;
     case "uninstall":
       await cmdUninstall(args);
       break;
@@ -7001,6 +7416,7 @@ export function isCLIMode(argv: string[]): boolean {
     "list",
     "search",
     "inspect",
+    "get",
     "uninstall",
     "audit",
     "config",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -204,7 +204,12 @@ import {
   updateLibrarySkills,
 } from "./library";
 import { setVerbose } from "./logger";
-import { join as joinPath, resolve, relative as relativePath } from "path";
+import {
+  join as joinPath,
+  resolve,
+  relative as relativePath,
+  sep as pathSep,
+} from "path";
 import { toPortableRelativePath } from "./utils/fs";
 import type {
   Scope,
@@ -1335,8 +1340,16 @@ async function fetchGetFromRemote(
   // The subpath can arrive from catalog data as well as from the command line,
   // and it is joined onto a temp directory — refuse anything that climbs out of
   // it rather than reading a file outside the clone.
+  //
+  // A `..` segment can hide in the ref as well as in the subpath: for
+  // `github:o/r#main/../../x` `parseSource` reports `subpath: null` and
+  // `ref: "main/../../x"`, and `resolveSubpath` later splits that back into
+  // `ref: "main"` + `subpath: "../../x"`. Checking only the parsed subpath
+  // would let that form through, so both are checked.
+  const hasParentSegment = (value: string | null | undefined) =>
+    !!value && value.split(/[/\\]/).includes("..");
   const preParsed = parseSource(sourceInput);
-  if (preParsed.subpath?.split(/[/\\]/).includes("..")) {
+  if (hasParentSegment(preParsed.subpath) || hasParentSegment(preParsed.ref)) {
     throw new Error(
       `Invalid source: the subpath in "${sourceInput}" escapes the repository.`,
     );
@@ -1349,6 +1362,16 @@ async function fetchGetFromRemote(
     false,
   );
   try {
+    // Belt and braces: whatever the parse produced, the directory this command
+    // reads from must sit inside the temp clone. Anything else is an escape.
+    const tempRoot = resolve(remote.tempDir);
+    const readRoot = resolve(remote.rootDir);
+    if (readRoot !== tempRoot && !readRoot.startsWith(tempRoot + pathSep)) {
+      throw new Error(
+        `Invalid source: the subpath in "${sourceInput}" escapes the repository.`,
+      );
+    }
+
     const parsed = parseSource(sourceInput);
     // Keep any explicit ref in the hint — dropping it would suggest commands
     // that silently resolve against the default branch instead.
@@ -4950,6 +4973,8 @@ async function fetchRemoteSkillDir(
   keep: boolean,
 ): Promise<{
   rootDir: string;
+  /** The clone root. `rootDir` is `tempDir` or a directory inside it. */
+  tempDir: string;
   cleanup: () => Promise<void>;
   sourceRef: string;
   commitSha: string | null;
@@ -4997,7 +5022,7 @@ async function fetchRemoteSkillDir(
     await cleanupTemp(tempDir);
   };
 
-  return { rootDir, cleanup, sourceRef, commitSha };
+  return { rootDir, tempDir, cleanup, sourceRef, commitSha };
 }
 
 async function runSingleEval(target: EvalTarget): Promise<{

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -23,6 +23,7 @@ import {
   validateSkill,
   discoverSkills,
   scanForWarnings,
+  classifyWarningRisk,
   resolveProvider,
   executeInstall,
   executeInstallAllProviders,
@@ -2275,5 +2276,44 @@ describe("linkExistingSkill", () => {
         config,
       ),
     ).rejects.toThrow("not found in config");
+  });
+});
+
+// ─── classifyWarningRisk (issue #422) ──────────────────────────────────────
+//
+// `asm get` reports the verdict the install preview would show, so the mapping
+// lives in one place instead of being re-derived per command.
+
+describe("classifyWarningRisk", () => {
+  const w = (category: string) => ({
+    category,
+    file: "SKILL.md",
+    line: 1,
+    match: "x",
+  });
+
+  test("no warnings is safe", () => {
+    expect(classifyWarningRisk([])).toBe("safe");
+  });
+
+  test("external URLs alone are medium risk", () => {
+    expect(classifyWarningRisk([w("External URLs")])).toBe("medium");
+  });
+
+  test.each(["Shell commands", "Code execution", "Credentials"])(
+    "%s is high risk",
+    (category) => {
+      expect(classifyWarningRisk([w(category)])).toBe("high");
+    },
+  );
+
+  test("high risk wins over medium risk", () => {
+    expect(classifyWarningRisk([w("External URLs"), w("Shell commands")])).toBe(
+      "high",
+    );
+  });
+
+  test("an unrecognised category does not raise the verdict", () => {
+    expect(classifyWarningRisk([w("Something else")])).toBe("safe");
   });
 });

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -608,6 +608,30 @@ export async function scanForWarnings(
   return warnings;
 }
 
+/** Warning categories that make an install a high-risk preview. */
+const HIGH_RISK_WARNING_CATEGORIES = [
+  "Shell commands",
+  "Code execution",
+  "Credentials",
+];
+/** Warning categories that make an install a medium-risk preview. */
+const MEDIUM_RISK_WARNING_CATEGORIES = ["External URLs"];
+
+/**
+ * Collapse raw `scanForWarnings` output into the High / Medium / Safe label
+ * the install preview shows. Single home for the mapping so `asm get` reports
+ * the same verdict `asm install` would (issue #422).
+ */
+export function classifyWarningRisk(
+  warnings: SecurityWarning[],
+): "high" | "medium" | "safe" {
+  if (warnings.some((w) => HIGH_RISK_WARNING_CATEGORIES.includes(w.category)))
+    return "high";
+  if (warnings.some((w) => MEDIUM_RISK_WARNING_CATEGORIES.includes(w.category)))
+    return "medium";
+  return "safe";
+}
+
 export async function executeInstall(
   plan: InstallPlan,
 ): Promise<InstallResult> {

--- a/src/residency.test.ts
+++ b/src/residency.test.ts
@@ -139,18 +139,19 @@ describe("chooseDemotionAction", () => {
     });
   });
 
-  it("offers asm get on the disable path when the skill is in the library", () => {
+  it("does not offer asm get on the disable path, even for a library skill", () => {
+    // `asm disable` renames SKILL.md on the *canonical* directory, which for a
+    // library-linked skill is the library copy itself — so after disabling
+    // there is no local SKILL.md left for `asm get` to read on any rung.
     const action = chooseDemotionAction("my-skill", [
       makeInstance({ libraryLinked: true, provider: "claude" }),
       makeInstance({ libraryLinked: true, provider: "codex" }),
     ]);
     expect(action.kind).toBe("disable");
-    expect(action.reference?.command).toBe("asm get my-skill");
+    expect(action.reference).toBeUndefined();
   });
 
   it("does not offer asm get for a skill that is not in the library", () => {
-    // `asm disable` hides SKILL.md from the scanner, and a non-library skill
-    // has no other local copy — the suggestion would break on use.
     const action = chooseDemotionAction("my-skill", [
       makeInstance({ libraryLinked: false }),
     ]);
@@ -160,10 +161,11 @@ describe("chooseDemotionAction", () => {
 
   it("does not replace the primary demotion command", () => {
     const action = chooseDemotionAction("my-skill", [
-      makeInstance({ libraryLinked: true, provider: "claude" }),
-      makeInstance({ libraryLinked: true, provider: "codex" }),
+      makeInstance({ libraryLinked: true }),
     ]);
-    expect(action.command).toBe("asm disable my-skill");
+    expect(action.kind).toBe("deactivate");
+    expect(action.command).toContain("asm deactivate my-skill");
+    expect(action.reference?.command).toBe("asm get my-skill");
   });
 });
 
@@ -393,6 +395,34 @@ describe("formatResidencyReport", () => {
       ),
     );
     expect(formatResidencyReport(report)).not.toContain("asm get heavy");
+  });
+
+  it("omits the reference line on the disable path, which unlinks the body", () => {
+    // Two library-linked instances -> `asm disable`, which renames the shared
+    // canonical SKILL.md (the library copy) and leaves nothing for `asm get`.
+    const report = computeResidencyAudit(
+      withBaseline(
+        makeSkill({
+          dirName: "heavy",
+          description: longDescription(200),
+          isSymlink: true,
+          realPath: `${LIBRARY}/heavy`,
+          provider: "claude",
+        }),
+        makeSkill({
+          dirName: "heavy",
+          description: longDescription(200),
+          isSymlink: true,
+          realPath: `${LIBRARY}/heavy`,
+          provider: "codex",
+          path: "/home/u/.codex/skills/heavy",
+        }),
+      ),
+      { librarySkillsDir: LIBRARY },
+    );
+    const output = formatResidencyReport(report);
+    expect(output).toContain("asm disable heavy");
+    expect(output).not.toContain("asm get heavy");
   });
 
   it("renders every token figure with the `~` prefix, never as bytes", () => {

--- a/src/residency.test.ts
+++ b/src/residency.test.ts
@@ -126,6 +126,33 @@ describe("chooseDemotionAction", () => {
     );
     expect(action.hint).not.toContain("--tool");
   });
+
+  // ─── Reference tier (issue #422) ────────────────────────────────────────
+
+  it("offers asm get as a second demotion destination for a library skill", () => {
+    const action = chooseDemotionAction("my-skill", [
+      makeInstance({ libraryLinked: true }),
+    ]);
+    expect(action.reference).toEqual({
+      command: "asm get my-skill",
+      hint: "read it on demand, zero residency",
+    });
+  });
+
+  it("offers asm get on the disable path too", () => {
+    const action = chooseDemotionAction("my-skill", [
+      makeInstance({ libraryLinked: false }),
+    ]);
+    expect(action.kind).toBe("disable");
+    expect(action.reference?.command).toBe("asm get my-skill");
+  });
+
+  it("does not replace the primary demotion command", () => {
+    const action = chooseDemotionAction("my-skill", [
+      makeInstance({ libraryLinked: false }),
+    ]);
+    expect(action.command).toBe("asm disable my-skill");
+  });
 });
 
 // ─── Audit computation ──────────────────────────────────────────────────────
@@ -328,6 +355,17 @@ describe("formatResidencyReport", () => {
     expect(output).toContain("heavy");
     expect(output).toContain("the median description");
     expect(output).toContain("asm disable heavy");
+  });
+
+  it("renders the asm get reference tier next to the demotion command", () => {
+    const report = computeResidencyAudit(
+      withBaseline(
+        makeSkill({ dirName: "heavy", description: longDescription(200) }),
+      ),
+    );
+    const output = formatResidencyReport(report);
+    expect(output).toContain("asm get heavy");
+    expect(output).toContain("read it on demand, zero residency");
   });
 
   it("renders every token figure with the `~` prefix, never as bytes", () => {

--- a/src/residency.test.ts
+++ b/src/residency.test.ts
@@ -139,17 +139,29 @@ describe("chooseDemotionAction", () => {
     });
   });
 
-  it("offers asm get on the disable path too", () => {
+  it("offers asm get on the disable path when the skill is in the library", () => {
     const action = chooseDemotionAction("my-skill", [
-      makeInstance({ libraryLinked: false }),
+      makeInstance({ libraryLinked: true, provider: "claude" }),
+      makeInstance({ libraryLinked: true, provider: "codex" }),
     ]);
     expect(action.kind).toBe("disable");
     expect(action.reference?.command).toBe("asm get my-skill");
   });
 
-  it("does not replace the primary demotion command", () => {
+  it("does not offer asm get for a skill that is not in the library", () => {
+    // `asm disable` hides SKILL.md from the scanner, and a non-library skill
+    // has no other local copy — the suggestion would break on use.
     const action = chooseDemotionAction("my-skill", [
       makeInstance({ libraryLinked: false }),
+    ]);
+    expect(action.kind).toBe("disable");
+    expect(action.reference).toBeUndefined();
+  });
+
+  it("does not replace the primary demotion command", () => {
+    const action = chooseDemotionAction("my-skill", [
+      makeInstance({ libraryLinked: true, provider: "claude" }),
+      makeInstance({ libraryLinked: true, provider: "codex" }),
     ]);
     expect(action.command).toBe("asm disable my-skill");
   });
@@ -360,12 +372,27 @@ describe("formatResidencyReport", () => {
   it("renders the asm get reference tier next to the demotion command", () => {
     const report = computeResidencyAudit(
       withBaseline(
-        makeSkill({ dirName: "heavy", description: longDescription(200) }),
+        makeSkill({
+          dirName: "heavy",
+          description: longDescription(200),
+          isSymlink: true,
+          realPath: `${LIBRARY}/heavy`,
+        }),
       ),
+      { librarySkillsDir: LIBRARY },
     );
     const output = formatResidencyReport(report);
     expect(output).toContain("asm get heavy");
     expect(output).toContain("read it on demand, zero residency");
+  });
+
+  it("omits the reference line for a skill that is not in the library", () => {
+    const report = computeResidencyAudit(
+      withBaseline(
+        makeSkill({ dirName: "heavy", description: longDescription(200) }),
+      ),
+    );
+    expect(formatResidencyReport(report)).not.toContain("asm get heavy");
   });
 
   it("renders every token figure with the `~` prefix, never as bytes", () => {

--- a/src/residency.ts
+++ b/src/residency.ts
@@ -19,6 +19,7 @@ import {
 } from "./utils/token-count";
 import type {
   ResidencyAction,
+  ResidencyActionReference,
   ResidencyCandidate,
   ResidencyInstance,
   ResidencyReason,
@@ -122,12 +123,21 @@ export function chooseDemotionAction(
   dirName: string,
   instances: ResidencyInstance[],
 ): ResidencyAction {
+  // Second demotion destination: the reference tier (issue #422). Demoting a
+  // skill does not mean losing it — `asm get` still delivers the body on
+  // demand, at zero residency, without reinstalling anything.
+  const reference: ResidencyActionReference = {
+    command: `asm get ${dirName}`,
+    hint: "read it on demand, zero residency",
+  };
+
   if (instances.length === 1 && instances[0].libraryLinked) {
     const only = instances[0];
     return {
       kind: "deactivate",
       command: `asm deactivate ${dirName} --provider ${only.provider} --scope ${only.scope}`,
       hint: "keep it in the library, activate when needed",
+      reference,
     };
   }
   return {
@@ -137,6 +147,7 @@ export function chooseDemotionAction(
       instances.length > 1
         ? `reversible with asm enable; disables it in all ${instances.length} places`
         : "reversible with asm enable",
+    reference,
   };
 }
 
@@ -301,6 +312,12 @@ export function formatResidencyReport(
         `      ${ansi.yellow("→")} ${ansi.bold(candidate.action.command)}` +
           ansi.dim(`  (${candidate.action.hint})`),
       );
+      if (candidate.action.reference) {
+        lines.push(
+          `      ${ansi.yellow("→")} ${ansi.bold(candidate.action.reference.command)}` +
+            ansi.dim(`  (${candidate.action.reference.hint})`),
+        );
+      }
       lines.push("");
     }
     const hidden = report.candidates.length - shown.length;

--- a/src/residency.ts
+++ b/src/residency.ts
@@ -124,12 +124,22 @@ export function chooseDemotionAction(
   instances: ResidencyInstance[],
 ): ResidencyAction {
   // Second demotion destination: the reference tier (issue #422). Demoting a
-  // skill does not mean losing it — `asm get` still delivers the body on
-  // demand, at zero residency, without reinstalling anything.
-  const reference: ResidencyActionReference = {
-    command: `asm get ${dirName}`,
-    hint: "read it on demand, zero residency",
-  };
+  // library skill does not mean losing it — `asm get` still delivers the body
+  // on demand, at zero residency, without reinstalling anything.
+  //
+  // Only offered when the skill is in the `asm` library. `asm disable` renames
+  // `SKILL.md` to `SKILL.md.disabled`, which hides the skill from the scanner;
+  // for a skill that is not also in the library, `asm get <name>` would then
+  // find nothing locally. Suggesting it there would be advice that breaks the
+  // moment the user follows the primary command.
+  const reference: ResidencyActionReference | null = instances.some(
+    (i) => i.libraryLinked,
+  )
+    ? {
+        command: `asm get ${dirName}`,
+        hint: "read it on demand, zero residency",
+      }
+    : null;
 
   if (instances.length === 1 && instances[0].libraryLinked) {
     const only = instances[0];
@@ -137,7 +147,7 @@ export function chooseDemotionAction(
       kind: "deactivate",
       command: `asm deactivate ${dirName} --provider ${only.provider} --scope ${only.scope}`,
       hint: "keep it in the library, activate when needed",
-      reference,
+      ...(reference ? { reference } : {}),
     };
   }
   return {
@@ -147,7 +157,7 @@ export function chooseDemotionAction(
       instances.length > 1
         ? `reversible with asm enable; disables it in all ${instances.length} places`
         : "reversible with asm enable",
-    reference,
+    ...(reference ? { reference } : {}),
   };
 }
 

--- a/src/residency.ts
+++ b/src/residency.ts
@@ -127,19 +127,18 @@ export function chooseDemotionAction(
   // library skill does not mean losing it — `asm get` still delivers the body
   // on demand, at zero residency, without reinstalling anything.
   //
-  // Only offered when the skill is in the `asm` library. `asm disable` renames
-  // `SKILL.md` to `SKILL.md.disabled`, which hides the skill from the scanner;
-  // for a skill that is not also in the library, `asm get <name>` would then
-  // find nothing locally. Suggesting it there would be advice that breaks the
-  // moment the user follows the primary command.
-  const reference: ResidencyActionReference | null = instances.some(
-    (i) => i.libraryLinked,
-  )
-    ? {
-        command: `asm get ${dirName}`,
-        hint: "read it on demand, zero residency",
-      }
-    : null;
+  // Offered on the `deactivate` path only. `asm deactivate` removes the
+  // provider symlink and leaves the library copy intact, so `asm get` still
+  // resolves it on the library rung. `asm disable` is different: it renames
+  // `SKILL.md` to `SKILL.md.disabled` on the *canonical* directory — which,
+  // for a library-linked skill, is the library copy itself — so after
+  // disabling there is no local `SKILL.md` left for `asm get` to read on any
+  // rung. Advice that breaks the moment the user follows the primary command
+  // is worse than no advice, so the disable path gets the one command alone.
+  const reference: ResidencyActionReference = {
+    command: `asm get ${dirName}`,
+    hint: "read it on demand, zero residency",
+  };
 
   if (instances.length === 1 && instances[0].libraryLinked) {
     const only = instances[0];
@@ -147,7 +146,7 @@ export function chooseDemotionAction(
       kind: "deactivate",
       command: `asm deactivate ${dirName} --provider ${only.provider} --scope ${only.scope}`,
       hint: "keep it in the library, activate when needed",
-      ...(reference ? { reference } : {}),
+      reference,
     };
   }
   return {
@@ -157,7 +156,6 @@ export function chooseDemotionAction(
       instances.length > 1
         ? `reversible with asm enable; disables it in all ${instances.length} places`
         : "reversible with asm enable",
-    ...(reference ? { reference } : {}),
   };
 }
 

--- a/src/skill-index.test.ts
+++ b/src/skill-index.test.ts
@@ -8,7 +8,9 @@ import {
   getTotalSkillCount,
   loadAllIndices,
   getMissingMetadataFields,
+  resolveIndexedSkillByName,
 } from "./skill-index";
+import type { IndexedSkillMatch } from "./skill-index";
 import { getSkillIndexResourcesPath, getBundledIndexDir } from "./config";
 import type { IndexedSkill } from "./utils/types";
 
@@ -255,5 +257,140 @@ describe("Index resource integrity", () => {
         r.repo.owner === "emilkowalski" && r.skill.name === "emil-design-eng",
     );
     expect(emilHits).toHaveLength(1);
+  });
+});
+
+// ─── Exact-name resolution (issue #422) ────────────────────────────────────
+//
+// Every case below injects its own catalog. `loadAllIndices()` merges the
+// bundled index with a user-level one under ~/.config, so a resolver test that
+// reads the ambient catalog would pass or fail depending on whose machine ran
+// it. The injectable parameter exists precisely so these stay hermetic.
+
+function fixtureSkill(name: string, relPath: string): IndexedSkill {
+  return {
+    name,
+    description: `${name} description`,
+    version: "1.0.0",
+    license: "MIT",
+    creator: "",
+    compatibility: "",
+    allowedTools: [],
+    installUrl: `github:acme/skills:${relPath}`,
+    relPath,
+    tokenCount: 100,
+  };
+}
+
+function fixtureCatalog(
+  entries: Array<{
+    owner: string;
+    repo: string;
+    name: string;
+    relPath: string;
+  }>,
+): IndexedSkillMatch[] {
+  return entries.map((e) => ({
+    skill: {
+      ...fixtureSkill(e.name, e.relPath),
+      installUrl: `github:${e.owner}/${e.repo}:${e.relPath}`,
+    },
+    repo: { owner: e.owner, repo: e.repo },
+  }));
+}
+
+describe("resolveIndexedSkillByName (issue #422)", () => {
+  const catalog = fixtureCatalog([
+    {
+      owner: "acme",
+      repo: "skills",
+      name: "code-review",
+      relPath: "skills/code-review",
+    },
+    {
+      owner: "acme",
+      repo: "skills",
+      name: "dataviz",
+      relPath: "skills/dataviz",
+    },
+    {
+      owner: "other",
+      repo: "pack",
+      name: "code-review",
+      relPath: "code-review",
+    },
+  ]);
+
+  it("resolves a unique name to its single catalog entry", async () => {
+    const res = await resolveIndexedSkillByName("dataviz", catalog);
+    expect(res.status).toBe("found");
+    if (res.status !== "found") throw new Error("unreachable");
+    expect(res.match.skill.installUrl).toBe(
+      "github:acme/skills:skills/dataviz",
+    );
+    expect(res.match.repo).toEqual({ owner: "acme", repo: "skills" });
+  });
+
+  it("matches case-insensitively and ignores surrounding whitespace", async () => {
+    const res = await resolveIndexedSkillByName("  DataViz ", catalog);
+    expect(res.status).toBe("found");
+  });
+
+  it("reports a cross-repo collision instead of guessing", async () => {
+    const res = await resolveIndexedSkillByName("code-review", catalog);
+    expect(res.status).toBe("ambiguous");
+    if (res.status !== "ambiguous") throw new Error("unreachable");
+    expect(res.matches).toHaveLength(2);
+    expect(
+      res.matches.map((m) => `${m.repo.owner}/${m.repo.repo}`).sort(),
+    ).toEqual(["acme/skills", "other/pack"]);
+  });
+
+  it("collapses duplicate entries for the same repo and path", async () => {
+    const dupes = fixtureCatalog([
+      {
+        owner: "acme",
+        repo: "skills",
+        name: "dataviz",
+        relPath: "skills/dataviz",
+      },
+      {
+        owner: "acme",
+        repo: "skills",
+        name: "dataviz",
+        relPath: "skills/dataviz",
+      },
+    ]);
+    const res = await resolveIndexedSkillByName("dataviz", dupes);
+    expect(res.status).toBe("found");
+  });
+
+  it("returns none for an unknown name", async () => {
+    expect((await resolveIndexedSkillByName("nope", catalog)).status).toBe(
+      "none",
+    );
+  });
+
+  it("returns none for an empty or whitespace-only name", async () => {
+    expect((await resolveIndexedSkillByName("", catalog)).status).toBe("none");
+    expect((await resolveIndexedSkillByName("   ", catalog)).status).toBe(
+      "none",
+    );
+  });
+
+  it("is exact, not fuzzy — a partial name does not resolve", async () => {
+    expect((await resolveIndexedSkillByName("code", catalog)).status).toBe(
+      "none",
+    );
+    expect((await resolveIndexedSkillByName("data", catalog)).status).toBe(
+      "none",
+    );
+  });
+
+  it("falls back to the real catalog when none is injected", async () => {
+    const res = await resolveIndexedSkillByName(
+      "definitely-not-a-real-skill-name-422",
+    );
+    expect(res.status).toBe("none");
   });
 });

--- a/src/skill-index.ts
+++ b/src/skill-index.ts
@@ -203,3 +203,56 @@ export async function getTotalSkillCount(): Promise<number> {
   const indices = await loadAllIndices();
   return indices.reduce((sum, idx) => sum + idx.skillCount, 0);
 }
+
+// ─── Exact-name resolution (issue #422) ────────────────────────────────────
+
+export interface IndexedSkillMatch {
+  skill: IndexedSkill;
+  repo: { owner: string; repo: string };
+}
+
+/**
+ * Outcome of resolving an exact skill name against the indexed catalog.
+ *
+ * `searchSkills` is fuzzy and limit-capped, so it can rank an unrelated skill
+ * first — it can never be the resolution primitive for a command that has to
+ * deliver *the* named skill. This is that primitive: exact, case-insensitive
+ * name equality, with cross-repo collisions surfaced rather than guessed.
+ */
+export type IndexedNameResolution =
+  | { status: "found"; match: IndexedSkillMatch }
+  | { status: "none" }
+  | { status: "ambiguous"; matches: IndexedSkillMatch[] };
+
+/**
+ * Resolve a skill name to a single catalog entry.
+ *
+ * @param name    Exact skill name (compared case-insensitively).
+ * @param catalog Optional pre-loaded catalog. Injecting it keeps callers and
+ *                tests off the ambient user index directory.
+ */
+export async function resolveIndexedSkillByName(
+  name: string,
+  catalog?: IndexedSkillMatch[],
+): Promise<IndexedNameResolution> {
+  const target = name.trim().toLowerCase();
+  if (!target) return { status: "none" };
+
+  const all = catalog ?? (await getAllIndexedSkills());
+  const matches = all.filter((e) => e.skill.name.toLowerCase() === target);
+  if (matches.length === 0) return { status: "none" };
+
+  // Collapse entries that point at the same repo + path: the same skill listed
+  // twice is not a collision the user has to disambiguate.
+  const seen = new Set<string>();
+  const unique: IndexedSkillMatch[] = [];
+  for (const m of matches) {
+    const key = `${m.repo.owner}/${m.repo.repo}:${m.skill.relPath}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(m);
+  }
+
+  if (unique.length === 1) return { status: "found", match: unique[0] };
+  return { status: "ambiguous", matches: unique };
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -346,6 +346,18 @@ export interface ResidencyAction {
   kind: "deactivate" | "disable";
   command: string;
   hint: string;
+  /**
+   * Second demotion destination: the reference tier. Present when the skill
+   * can be pulled in on demand with `asm get` instead of staying resident.
+   */
+  reference?: ResidencyActionReference;
+}
+
+/** Zero-residency alternative offered alongside a demotion command (issue #422). */
+export interface ResidencyActionReference {
+  /** `asm get <skill>` — read the body at the point of use, pay no residency. */
+  command: string;
+  hint: string;
 }
 
 export interface ResidencyCandidate {
@@ -726,3 +738,51 @@ export type ViewState =
   | "help"
   | "config"
   | "audit";
+
+// ─── Reference Tier Types (issue #422) ─────────────────────────────────────
+
+/** Which rung of the resolution ladder produced a `asm get` body. */
+export type GetTier =
+  | "installed"
+  | "library"
+  | "index"
+  | "registry"
+  | "remote"
+  | "local";
+
+/**
+ * Security verdict attached to a remotely fetched body. This is the same scan
+ * `asm install` runs before writing anything (`scanForWarnings`), reported
+ * rather than enforced — `asm get` only prints text, it installs nothing.
+ */
+export interface GetSecurityVerdict {
+  /** `high` | `medium` | `safe` — same mapping the install preview uses. */
+  risk: "high" | "medium" | "safe";
+  /** Number of raw warnings the scan produced. */
+  warnings: number;
+  /** Distinct warning categories, e.g. `Shell commands`, `External URLs`. */
+  categories: string[];
+}
+
+/**
+ * Result of resolving a skill for the zero-residency reference tier.
+ *
+ * Assembled field by field — never spread from a `SkillInfo`, whose
+ * `_skillMdContent` cache is deliberately non-enumerable.
+ */
+export interface GetResult {
+  name: string;
+  description: string;
+  /** Which rung of the ladder answered. */
+  tier: GetTier;
+  /** Provenance: an absolute path for local tiers, a `github:` ref for remote. */
+  source: string;
+  /** Resolved commit SHA when the body came from a clone; null otherwise. */
+  commit: string | null;
+  /** Estimated token cost of the body (issue #188 heuristic). */
+  tokenCount: number;
+  /** Present only for remotely fetched bodies. */
+  security: GetSecurityVerdict | null;
+  /** The exact SKILL.md text. */
+  content: string;
+}

--- a/tests/e2e/node-e2e.test.ts
+++ b/tests/e2e/node-e2e.test.ts
@@ -356,6 +356,7 @@ describe("Node E2E: per-command --help", () => {
     "list",
     "search",
     "inspect",
+    "get",
     "install",
     "uninstall",
     "audit",


### PR DESCRIPTION
## Summary

Adds `asm get <skill>` — the missing **tier 1** of the delivery ladder in
["@skills: Attention Is All You Have"](https://arxiv.org/html/2608.12610).
ASM already shipped *saved* (`asm install --library` + `asm activate`) and
*installed* (provider directories). `asm get` adds *reference-only*: resolve a
skill, write its `SKILL.md` body to **stdout**, install nothing, pay zero
prompt residency afterwards.

```bash
asm get code-review                       # body to stdout
asm get code-review > /tmp/SKILL.md       # save it without installing
asm get github:owner/repo:skills/review   # any `asm install` shorthand
asm get code-review --json                # name, description, tier, source,
                                          # commit, tokenCount, security, content
asm get code-review | your-agent --system-prompt-file -
```

Closes #422

## Approach

Deliberately the install path **minus the write** — no parallel fetch
subsystem, no new resolution grammar.

**Resolution ladder.** Explicit sources (`github:owner/repo[#ref][:path]`, a
GitHub URL, a local path) short-circuit. A bare name walks
`installed → library → index → registry`; cheapest and most local wins, and the
rung that answered is reported as `tier` so provenance is always visible.

- **installed** — `scanAllSkills`; the scanner already retained the exact text
  on `SkillInfo._skillMdContent` (`src/scanner.ts:252`), so a hit costs no IO.
  `formatSkillInspect` never read it — that is the gap this fills.
- **library** — `findLibrarySkill`, a distinct rung because **deactivated**
  library skills are invisible to the scanner, and they are exactly the
  population `asm audit residency` points here.
- **index** — new `resolveIndexedSkillByName` in `src/skill-index.ts`.
  The issue assumed this resolver existed; it did not. The module only exported
  the **fuzzy, limit-capped** `searchSkills`, which can rank a different skill
  first and therefore can never be a resolution primitive. The new function is
  exact and case-insensitive, takes an optional injected catalog (so tests stay
  hermetic against the ambient `~/.config` index), and reports cross-repo
  collisions instead of guessing.
- **registry** — `isBareOrScopedName` + `resolveFromRegistry`, the same route
  `asm install <name>` takes.

**Reuse, not reimplementation.** `fetchRemoteForEval` (added by #193 / d6aca4c
for `asm eval`) already returned exactly the `{rootDir, cleanup, sourceRef,
commitSha}` provenance record this needed. Renamed to `fetchRemoteSkillDir`,
now shared by `cmdEval` and `cmdGet`; `cleanupTemp` runs in a `finally` on
every path. Token counts come from the existing `estimateTokenCount` (#188) and
render as `~N tokens`.

**Security.** Every remote fetch runs `scanForWarnings` — literally the scan
`asm install` runs before writing anything. The High/Medium/Safe mapping was
inline in `inspectSkillForInstall`; it is extracted to
`installer.classifyWarningRisk` so both commands report one verdict rather than
two. `asm get` **reports rather than blocks**: it writes nothing, so there is
no install to stop; the user sees the risk before feeding text to an agent.
`--audit` escalates to the full `auditSkillSecurity` report — on the temp clone
before cleanup, and on the resolved directory for installed/library/local
tiers, so the flag is never silently a no-op.

A `..` segment is refused before any clone starts — in the subpath *and* in the
ref, because `github:o/r#main/../../x` parses as `subpath: null` and
`resolveSubpath` only later splits it into ref `main` plus subpath `../../x`
(no legitimate ref can contain `..`; `git check-ref-format` forbids it). After
the clone, `fetchGetFromRemote` additionally asserts that the directory it reads
from resolves inside the clone root. Subpaths reach `asm get` from catalog data
as well as from the command line, and they are joined onto a temp directory, so
the containment check is worth the lines even though the same input shape
already flows through `asm install` / `asm eval`. The check is `resolve`-based,
not `realpath`-based: a symlink checked out *inside* the clone can still point
outside it, which is the pre-existing `asm install` behaviour and out of scope
here.

**Output discipline.** `console.log`/`console.info` are redirected to stderr for
the whole command, and the payload is written with `process.stdout.write`, so no
dependency can leak a line into a piped body. Provenance, progress, and the
security verdict go to stderr. The `--json` object is assembled field by field —
never spread from a `SkillInfo` — so the non-enumerable `_skillMdContent`
invariant (`scanner.test.ts:472`, `:897`) still holds.

### Scope decision: what "nothing persists" means

Two acceptance criteria in the issue are in tension:

- *"resolves remote sources using the same shorthand accepted by `asm install`"*
  — that shorthand includes a bare `owner/repo` / `name`, which goes through the
  registry resolver, which writes `~/.config/agent-skill-manager/registry-cache.json`
  (`src/registry.ts:415-417`).
- *"Nothing is written to any provider directory, library, or cache path that
  persists as an installation."*

**Interpretation taken here, stated so it is reviewable rather than silent:** a
registry *metadata* cache is not an installation. "Nothing persists" means no
**skill content** reaches a provider directory or the library. Registry-cache
entries and the transient clone (deleted before the command returns) are
permitted; nothing is installed anywhere. A test asserts no provider directory
and no library directory is created, with a comment recording that the registry
cache is deliberately out of scope.

### Also in this PR (small, #423 follow-on)

`asm audit residency` (shipped in #424) paired each demotion candidate with one
command. Now that a reference tier exists, each candidate also gets
`asm get <skill>  (read it on demand, zero residency)` as a second demotion
destination — one optional field on `ResidencyAction` plus one render line. The
report structure is unchanged.

It is offered on the **`asm deactivate` path only** — a single library-linked
instance. Deactivating removes the provider symlink and leaves the library copy,
so `asm get` still resolves the body on the library rung. `asm disable` is
different: `disableSkillInstance` renames `SKILL.md` on the *canonical*
directory, which for a library-linked skill is the library copy itself, so after
disabling there is no local `SKILL.md` left on any rung. Advice that breaks on
use is worse than no advice, so the `disable` path gets its one command alone.

### Deliberately out of scope

- `--source <tier>` to force a rung — no acceptance criterion needs it.
- The paper's `@skills:gh:owner/repo` address grammar — the issue itself calls it
  secondary, and it would mean a second resolution grammar to maintain.
- A raw-file HTTP fetch. There is no such path anywhere in the codebase today,
  so an index/registry/remote `get` costs a shallow clone, same as `asm eval`.
  This is documented in the README rather than hidden.

## Decision Record

| | |
|---|---|
| **Selected option** | Full resolution ladder with a reported security verdict |
| **Rejected: local-only `asm get`** | Smallest diff, but leaves four *high*-priority acceptance criteria unmet (index, remote, security scan, remote provenance) and ships a bare-name contract a follow-up would have to change. |
| **Rejected: new shared `skill-resolver.ts` module + in-memory audit + address grammar** | `src/security-auditor.ts` has three open issues against it (#380, #381, #382); a disk-free audit composition would collide with all of them. Call its entry points, restructure nothing. |
| **`scanForWarnings` over `auditSkillSecurity` as the default scan** | The criterion says *"the existing **pre-install** security scan"*. `scanForWarnings` is the one `asm install` actually runs; `auditSkillSecurity` is wired to `asm audit security` and the update re-audit, not the install path. The deeper report is available behind `--audit`. |
| **Collision → exit non-zero, never prompt** | `cmdInstall`'s disambiguation block reads stdin with a 30s timeout. A read-only command that may be piped must not prompt, so both the index and registry collision paths list qualified candidates and exit 1. |
| **Complexity / risk** | M / Medium |

## Changes

| File | Change |
|---|---|
| `src/cli.ts` | `cmdGet` + `printGetHelp` + the resolution ladder; registered in the dispatch switch, the `isCLIMode` allowlist and `printMainHelp`; `--audit` flag; `fetchRemoteForEval` → `fetchRemoteSkillDir`; `inspectSkillForInstall` now uses the extracted risk classifier |
| `src/skill-index.ts` | New `resolveIndexedSkillByName` — exact, case-insensitive, injectable catalog, collision-aware |
| `src/installer.ts` | Extracted `classifyWarningRisk` — one home for the High/Medium/Safe mapping |
| `src/utils/types.ts` | `GetResult`, `GetSecurityVerdict`, `GetTier`, `ResidencyActionReference`; `ResidencyAction.reference` |
| `src/residency.ts` | Offers `asm get <skill>` as a second demotion destination |
| `README.md` | `asm get` row in the command table, the reference tier in the demotion ladder, and a "use a skill without installing it" section covering the point-of-use / zero-residency case, the ladder, the clone cost, and the security verdict |
| `CHANGELOG.md` | Unreleased entry |
| `tests/e2e/node-e2e.test.ts` | `get` added to the per-command `--help` loop |

## Test Results

40 new unit tests plus one e2e case; all suites green.

| Suite | Result |
|---|---|
| `npx vitest run src/` (clean `HOME`) | **2072 passed**, 59 files |
| `npx vitest run tests/e2e/node-e2e.test.ts` | **74 passed** |
| `npm run typecheck` | pass |
| `npm run build` | pass — 9 outputs |

New coverage:

- **8** for `resolveIndexedSkillByName` — unique, case-insensitive, cross-repo
  collision, duplicate collapse, not-found, empty, exact-not-fuzzy, and the
  real-catalog fallback.
- **18** for `asm get` — stdout purity, provenance on stderr, installed-tier
  resolution, a **deactivated library skill the scanner cannot see**, a
  **cross-repo name collision** (bullet list + `INVALID_ARGUMENT` machine code,
  asserting no clone starts), a **subpath that climbs out of the clone**,
  a **`..` hidden in the ref** that `resolveSubpath` would otherwise split back
  out, `--audit` on a local tier, `--json` shape including no `_skillMdContent`
  leak, the `--machine` envelope, exit 2 on a missing argument, exit 1 on an
  unresolvable name, `--help`, and the **nothing-is-installed** assertion, which walks the full
  installed → library → index ladder before asserting.
- **7** for `classifyWarningRisk`, **6** for the residency reference tier
  (including that it is *omitted* for a non-library skill), and `get` added to
  the e2e per-command `--help` loop.

Every `asm get` spawn runs against a throwaway `HOME`, and every case above is
offline — no test reaches the network.

Manually verified against the network as well: the index rung correctly refuses
to guess between two repos publishing `emil-design-eng`; the explicit remote form
prints the body with `source`, commit SHA and a `[~] Medium Risk (2 warnings:
External URLs)` verdict; `--audit` prints the full audit report; no
`asm-install-*` temp directory is left behind; and the sandboxed `HOME` gains no
provider or library directory.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|---|---|---|
| Resolves a skill and writes its `SKILL.md` body to stdout without writing to any provider directory | ✅ | `cmdGet`; test *"writes the SKILL.md body to stdout and nothing else"* + *"installs nothing…"* |
| Resolves installed skills by name | ✅ | Rung 1; test *"resolves an installed skill by name and reports the installed tier"* |
| Resolves indexed catalog skills by name | ✅ | New `resolveIndexedSkillByName`, 8 unit tests; verified live against the bundled catalog |
| Resolves remote sources using the same shorthand accepted by `asm install` | ✅ | `github:owner/repo[#ref][:path]`, GitHub URLs, local paths via `parseSource`; bare/scoped names via `resolveFromRegistry` — see the scope note above |
| `--json` emits name, description, resolved source, estimated token count, and the body | ✅ | `GetResult`; `--json` shape test |
| The resolved source is reported | ✅ | `source` + `commit` + `tier`, on stderr and in `--json`; provenance test |
| Remote fetches subject to the existing pre-install security scan, with a documented way to see the verdict | ✅ | `scanForWarnings` on every remote fetch → stderr and `--json.security`; `--audit` for the full report; both documented in `asm get --help` and the README |
| Nothing written to any provider directory, library, or cache path that persists as an installation | ✅ | No provider/library write; temp clone removed in `finally` (verified live). Registry *metadata* cache narrowing stated above |
| Documented in the README command reference, including the point-of-use / zero-residency use case | ✅ | Command table row + "Reference tier: use a skill without installing it" section |

<!-- gitissue:qa v1 head=1c96710755e92bd3b984f9b043aef6c50ab452a9 profile=full cycles=1 review=clean tests=2069@1c96710755e92bd3b984f9b043aef6c50ab452a9 ui=none -->

