### PR TITLE
fix(cli): reject parent segments in remote refs (#426)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -3166,6 +3166,16 @@ describe("CLI integration: eval", () => {
     expect(parsed.error.code).toBe("SKILL_NOT_FOUND");
   });
 
+  test("eval refuses a `..` hidden in the ref before clone", async () => {
+    const { stderr, exitCode } = await runCLI(
+      "eval",
+      "github:acme/skills#main/../../x",
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("escapes the repository");
+    expect(stderr).not.toMatch(/Cloning|Fetching|ls-remote|fatal:/);
+  });
+
   test("eval --fix on github: shorthand is rejected with a clear error", async () => {
     const { stderr, exitCode } = await runCLI(
       "eval",
@@ -4290,6 +4300,28 @@ describe("CLI integration: audit security", () => {
     expect(stderr).toContain("Missing target");
   });
 
+  test("audit security refuses a `..` hidden in the ref before clone", async () => {
+    const { stderr, exitCode } = await runCLI(
+      "audit",
+      "security",
+      "github:acme/skills#main/../../x",
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("escapes the repository");
+    expect(stderr).not.toContain("Cloning");
+  });
+
+  test("audit security refuses a subpath that climbs out of the clone", async () => {
+    const { stderr, exitCode } = await runCLI(
+      "audit",
+      "security",
+      "github:acme/skills:../../../etc",
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("escapes the repository");
+    expect(stderr).not.toContain("Cloning");
+  });
+
   test("audit security --all exits 0", async () => {
     const { exitCode } = await runCLI("audit", "security", "--all");
     expect(exitCode).toBe(0);
@@ -4494,6 +4526,17 @@ describe("CLI integration: install error paths", () => {
     );
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Error");
+  });
+
+  test("install refuses a `..` hidden in the ref before clone", async () => {
+    const { stderr, exitCode } = await runCLI(
+      "install",
+      "github:acme/skills#main/../../x",
+      "-y",
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("escapes the repository");
+    expect(stderr).not.toContain("Cloning repository");
   });
 
   test("install with invalid --transport exits 2", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,9 @@ import {
   isLocalPath,
   isExistingLocalDir,
   sanitizeName,
+  assertNoParentSegments,
+  assertPathInsideRoot,
+  hasParentPathSegment,
   checkGitAvailable,
   cloneToTemp,
   validateSkill,
@@ -204,12 +207,7 @@ import {
   updateLibrarySkills,
 } from "./library";
 import { setVerbose } from "./logger";
-import {
-  join as joinPath,
-  resolve,
-  relative as relativePath,
-  sep as pathSep,
-} from "path";
+import { join as joinPath, resolve, relative as relativePath } from "path";
 import { toPortableRelativePath } from "./utils/fs";
 import type {
   Scope,
@@ -1337,23 +1335,9 @@ async function fetchGetFromRemote(
   sourceInput: string,
   tier: GetTier,
 ): Promise<GetResolution> {
-  // The subpath can arrive from catalog data as well as from the command line,
-  // and it is joined onto a temp directory — refuse anything that climbs out of
-  // it rather than reading a file outside the clone.
-  //
-  // A `..` segment can hide in the ref as well as in the subpath: for
-  // `github:o/r#main/../../x` `parseSource` reports `subpath: null` and
-  // `ref: "main/../../x"`, and `resolveSubpath` later splits that back into
-  // `ref: "main"` + `subpath: "../../x"`. Checking only the parsed subpath
-  // would let that form through, so both are checked.
-  const hasParentSegment = (value: string | null | undefined) =>
-    !!value && value.split(/[/\\]/).includes("..");
-  const preParsed = parseSource(sourceInput);
-  if (hasParentSegment(preParsed.subpath) || hasParentSegment(preParsed.ref)) {
-    throw new Error(
-      `Invalid source: the subpath in "${sourceInput}" escapes the repository.`,
-    );
-  }
+  // Refuse an escaping subpath before announcing a fetch, so the failure costs
+  // no network round-trip and stdout/stderr stay clean.
+  assertNoParentSegments(parseSource(sourceInput), sourceInput);
 
   process.stderr.write(ansi.dim(`Fetching ${sourceInput}…\n`));
   const remote = await fetchRemoteSkillDir(
@@ -1362,16 +1346,6 @@ async function fetchGetFromRemote(
     false,
   );
   try {
-    // Belt and braces: whatever the parse produced, the directory this command
-    // reads from must sit inside the temp clone. Anything else is an escape.
-    const tempRoot = resolve(remote.tempDir);
-    const readRoot = resolve(remote.rootDir);
-    if (readRoot !== tempRoot && !readRoot.startsWith(tempRoot + pathSep)) {
-      throw new Error(
-        `Invalid source: the subpath in "${sourceInput}" escapes the repository.`,
-      );
-    }
-
     const parsed = parseSource(sourceInput);
     // Keep any explicit ref in the hint — dropping it would suggest commands
     // that silently resolve against the default branch instead.
@@ -2508,6 +2482,8 @@ async function cmdAuditSecuritySource(
       );
     }
 
+    assertNoParentSegments(source, target);
+
     await checkGitAvailable();
 
     // Resolve ref/subpath for subfolder URLs
@@ -2521,6 +2497,13 @@ async function cmdAuditSecuritySource(
     const auditDir = source.subpath
       ? joinPath(tempDir, source.subpath)
       : tempDir;
+    try {
+      assertPathInsideRoot(tempDir, auditDir, target);
+    } catch (guardErr) {
+      await cleanupTemp(tempDir);
+      tempDir = null;
+      throw guardErr;
+    }
 
     const { name } = await validateSkill(auditDir);
     const report = await auditSkillSecurity(
@@ -3443,6 +3426,14 @@ async function cmdInstall(args: ParsedArgs) {
     // Step 1: Parse source
     console.info(stepHeader("Parsing source"));
     let source = parseSource(sourceStr);
+    if (!source.isLocal) {
+      assertNoParentSegments(source, sourceStr);
+      if (hasParentPathSegment(args.flags.path)) {
+        throw new Error(
+          `Invalid source: the subpath in "${args.flags.path}" escapes the repository.`,
+        );
+      }
+    }
     const isLocal = !!source.isLocal;
 
     if (isLocal) {
@@ -3622,6 +3613,17 @@ async function cmdInstall(args: ParsedArgs) {
     if (effectivePath) {
       // Case 1: path specified — install specific subdirectory
       const skillDir = joinPath(scanBaseDir, effectivePath);
+      if (!isLocal) {
+        try {
+          assertPathInsideRoot(scanBaseDir, skillDir, sourceStr);
+        } catch (guardErr) {
+          if (tempDir) {
+            await cleanupTemp(tempDir);
+            tempDir = null;
+          }
+          throw guardErr;
+        }
+      }
       let foundSkill = false;
       try {
         await validateSkill(skillDir);
@@ -4988,6 +4990,7 @@ async function fetchRemoteSkillDir(
       `fetchRemoteSkillDir received a local path: "${input}". This is a bug — local paths should use the non-remote branch.`,
     );
   }
+  assertNoParentSegments(source, input);
   source = await resolveSubpath(source);
 
   const tempDir = await cloneToTemp(source, transport);
@@ -4995,6 +4998,13 @@ async function fetchRemoteSkillDir(
   // `source.subpath` may point at a subdirectory inside the repo. Use that as
   // the root when present so the eval pipeline treats the subdir as the skill.
   const rootDir = source.subpath ? joinPath(tempDir, source.subpath) : tempDir;
+
+  try {
+    assertPathInsideRoot(tempDir, rootDir, input);
+  } catch (guardErr) {
+    await cleanupTemp(tempDir);
+    throw guardErr;
+  }
 
   // Commit SHA — best-effort; we do not fail the whole eval if git can't resolve it.
   let commitSha: string | null = null;
@@ -6465,11 +6475,19 @@ async function cmdBundle(args: ParsedArgs) {
             let skillDir: string;
 
             if (!isLocal) {
+              assertNoParentSegments(source, skill.installUrl);
               tempDir = await cloneToTemp(source, args.flags.transport);
               rootDir = tempDir;
               skillDir = source.subpath
                 ? joinPath(tempDir, source.subpath)
                 : tempDir;
+              try {
+                assertPathInsideRoot(tempDir, skillDir, skill.installUrl);
+              } catch (guardErr) {
+                await cleanupTemp(tempDir);
+                tempDir = null;
+                throw guardErr;
+              }
             } else {
               rootDir = source.localPath!;
               skillDir = source.localPath!;

--- a/src/ingester.test.ts
+++ b/src/ingester.test.ts
@@ -315,6 +315,15 @@ describe("buildSkillInstallUrl", () => {
   });
 });
 
+describe("ingestRepo path containment", () => {
+  it("rejects a `..` hidden in the ref before clone", async () => {
+    const result = await ingestRepo("github:acme/skills#main/../../x");
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/escapes the repository/);
+    expect(ingestMocks.cloneToTemp).not.toHaveBeenCalled();
+  });
+});
+
 describe("parallel skill ingestion (issue #372)", () => {
   let tempDir: string;
   let repoName: string;

--- a/src/ingester.ts
+++ b/src/ingester.ts
@@ -6,6 +6,7 @@ import {
   cloneToTemp,
   cleanupTemp,
   checkGitAvailable,
+  assertNoParentSegments,
 } from "./installer";
 import { getIndexDir } from "./config";
 import { loadAllIndices } from "./skill-index";
@@ -67,6 +68,12 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
       error:
         "Local paths are not supported for indexing. Use a GitHub source instead.",
     };
+  }
+
+  try {
+    assertNoParentSegments(source, sourceInput);
+  } catch (err: any) {
+    return { success: false, repoIndex: null, error: err.message };
   }
 
   debug(`ingester: cloning ${source.owner}/${source.repo}`);

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -14,6 +14,8 @@ import { join, relative, resolve, isAbsolute, basename, dirname } from "path";
 import { tmpdir } from "os";
 import {
   parseSource,
+  assertNoParentSegments,
+  assertPathInsideRoot,
   isLocalPath,
   isExistingLocalDir,
   parseLocalSource,
@@ -63,6 +65,56 @@ vi.mock("./config", async () => {
 });
 
 // ─── parseSource tests ─────────────────────────────────────────────────────
+
+describe("assertNoParentSegments", () => {
+  test("rejects `..` hidden in the ref (parseSource leaves subpath null)", () => {
+    const source = parseSource("github:acme/skills#main/../../x");
+    expect(source.subpath).toBeNull();
+    expect(source.ref).toBe("main/../../x");
+    expect(() =>
+      assertNoParentSegments(source, "github:acme/skills#main/../../x"),
+    ).toThrow(/escapes the repository/);
+  });
+
+  test("rejects an explicit escaping subpath", () => {
+    const source = parseSource("github:acme/skills:../../../etc");
+    expect(() =>
+      assertNoParentSegments(source, "github:acme/skills:../../../etc"),
+    ).toThrow(/escapes the repository/);
+  });
+
+  test("allows #feature/foo and :skills/review", () => {
+    expect(() =>
+      assertNoParentSegments(
+        parseSource("github:acme/skills#feature/foo"),
+        "github:acme/skills#feature/foo",
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertNoParentSegments(
+        parseSource("github:acme/skills:skills/review"),
+        "github:acme/skills:skills/review",
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("assertPathInsideRoot", () => {
+  test("uses a path-separator boundary so a sibling prefix cannot pass", () => {
+    const root = join(tmpdir(), "asm-clone-root");
+    const sibling = `${root}-escape`;
+    expect(() =>
+      assertPathInsideRoot(root, sibling, "github:acme/skills:../x"),
+    ).toThrow(/escapes the repository/);
+  });
+
+  test("allows a nested directory inside the root", () => {
+    const root = join(tmpdir(), "asm-clone-root");
+    expect(() =>
+      assertPathInsideRoot(root, join(root, "skills", "review"), "in"),
+    ).not.toThrow();
+  });
+});
 
 describe("parseSource", () => {
   test("valid source without ref", () => {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -13,7 +13,7 @@ import {
   mkdir,
 } from "fs/promises";
 import { existsSync } from "fs";
-import { join, resolve, relative, basename, dirname } from "path";
+import { join, resolve, relative, basename, dirname, sep } from "path";
 import { homedir } from "os";
 import { tmpdir } from "os";
 import {
@@ -207,6 +207,53 @@ export function parseSource(input: string): ParsedSource {
     `install: parsed source -> owner=${owner} repo=${repo} ref=${ref} subpath=${subpath}`,
   );
   return result;
+}
+
+/**
+ * Reject a source whose subpath would climb out of the clone, before any
+ * network access.
+ *
+ * A `..` segment can hide in the ref as well as in the subpath: for
+ * `github:o/r#main/../../x` `parseSource` reports `subpath: null` and
+ * `ref: "main/../../x"`, and `resolveSubpath` later splits that back into
+ * `ref: "main"` + `subpath: "../../x"`, which is then joined onto the temp
+ * clone. Checking only the parsed subpath would let that form through, so both
+ * are checked. No legitimate git ref contains `..` (`git check-ref-format`
+ * forbids it).
+ */
+export function hasParentPathSegment(
+  value: string | null | undefined,
+): boolean {
+  return !!value && value.split(/[/\\]/).includes("..");
+}
+
+export function assertNoParentSegments(
+  source: { subpath: string | null; ref: string | null },
+  input: string,
+): void {
+  if (
+    hasParentPathSegment(source.subpath) ||
+    hasParentPathSegment(source.ref)
+  ) {
+    throw new Error(
+      `Invalid source: the subpath in "${input}" escapes the repository.`,
+    );
+  }
+}
+
+/** Post-clone containment: resolved candidate must sit inside root (+ sep). */
+export function assertPathInsideRoot(
+  root: string,
+  candidate: string,
+  input: string,
+): void {
+  const cloneRoot = resolve(root);
+  const readRoot = resolve(candidate);
+  if (readRoot !== cloneRoot && !readRoot.startsWith(cloneRoot + sep)) {
+    throw new Error(
+      `Invalid source: the subpath in "${input}" escapes the repository.`,
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #426

## Summary

Hoists the existing `asm get` path-traversal guard into a shared installer helper so every remote-source entry (`eval`, `audit security`, `install`, catalog ingest, bundle install) rejects a `..` segment in the ref or subpath before cloning, then asserts post-clone containment with a path-separator boundary and cleans up the temp clone if the join would escape.

## Approach

Option 2 — Balanced approach: one shared definition of the `..` rule plus post-clone containment, applied at every remote join site, without introducing a new RemoteSource type.

## Decision Record

- **Root cause:** `parseSource` can hide `..` in the ref (`github:o/r#main/../../x` → `subpath: null`, `ref: "main/../../x"`). `resolveSubpath` later splits that into `ref: "main"` + `subpath: "../../x"` and callers join it onto the temp clone. Only `fetchGetFromRemote` was hardened after #422.
- **Options considered:** Option 1 — Minimal fix; Option 2 — Balanced approach; Option 3 — Comprehensive refactor
- **Options rejected:** Option 1 — Does not cover install/catalog or a shared helper; Option 3 — Scope exceeds the AC and rewrites the already-hardened get path
- **Selected option:** Option 2 — Balanced approach
- **Residual risk:** Live post-clone containment is hard to hit once `..` is rejected up front (unit-tested only). Bundle-install shares the helper without an extra CLI fixture.
- **Reproduction:** `npx vitest run src/cli.test.ts src/ingester.test.ts -t "hidden in the ref|climbs out of the clone|ingestRepo path containment"` confirmed red (eval/audit cloned instead of rejecting) → regression tests in `src/cli.test.ts`, `src/installer.test.ts`, `src/ingester.test.ts`

Analyzed at: `fix/426-path-traversal-a-in-a-remote-ref-escapes @ 9e3c31e` (2026-08-18)

## Changes

| File | Change |
|------|--------|
| `src/installer.ts` | Shared `hasParentPathSegment`, `assertNoParentSegments`, `assertPathInsideRoot` |
| `src/cli.ts` | Pre-check kept on get before Fetching; eval/audit/install/bundle use shared rule + cleanup |
| `src/ingester.ts` | Reject `..` in catalog/source ref/subpath before clone |
| `src/cli.test.ts` | Eval/audit/install regressions for `#main/../../x` |
| `src/installer.test.ts` | Unit tests for ref-hidden `..`, legitimate slash refs, sep-boundary |
| `src/ingester.test.ts` | `ingestRepo` rejects `#main/../../x` without cloning |

## Test Results

- Unit tests: 607 passed (`src/cli.test.ts`, `src/installer.test.ts`, `src/ingester.test.ts`)
- Integration tests: included in the 607
- E2e tests: skipped (pre-push hook ran e2e separately and passed)
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| A `..` in the ref or the subpath is rejected before any clone occurs, for every remote-source entry point | pass | `assertNoParentSegments` in `src/installer.ts`; called from get/eval/audit/install/ingest |
| `asm eval <github source>` cannot read outside its temp clone | pass | Verified red: `npx vitest run src/cli.test.ts -t "hidden in the ref"` → `src/cli.test.ts` eval case |
| `asm audit security <github source>` cannot read outside its temp clone | pass | Verified red: same command → `src/cli.test.ts` audit ref + subpath cases |
| `asm install` is audited for the same pattern and fixed if affected | pass | `cmdInstall` + `--path` use the helper; CLI test in `src/cli.test.ts` |
| The rule has a single shared definition rather than being copied per call site | pass | `src/installer.ts` `assertNoParentSegments` / `assertPathInsideRoot` |
| A post-clone containment assertion uses a path-separator boundary so sibling-prefix directories do not false-pass | pass | `assertPathInsideRoot` + `src/installer.test.ts` prefix-boundary case |
| The temp clone is cleaned up when a guard fires | pass | `fetchRemoteSkillDir` / install cleanup before throw |
| Legitimate slash-bearing refs and subpaths (`#feature/foo`, `:skills/review`) keep working | pass | `src/installer.test.ts` positive cases |
| Traversal carried by a catalog `installUrl` or registry-derived ref is rejected on the same terms | pass | `src/ingester.ts` + `src/ingester.test.ts` |
| Regression tests cover the ref-hidden case (`#main/../../x`), not only the subpath case | pass | Verified red: `#main/../../x` tests in `src/cli.test.ts` and `src/installer.test.ts` |

<!-- gitissue:qa v1 head=9e3c31ee5bbdacaa2129874a9ec8dee690975429 profile=full cycles=1 review=clean tests=607@9e3c31ee5bbdacaa2129874a9ec8dee690975429 ui=none -->
