### PR TITLE
refactor(stats): polish tokens and residency review notes (#427)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1233,7 +1233,7 @@ describe("CLI integration: stats with nothing installed", () => {
   test("the human dashboard still degrades to a sentence", async () => {
     const { stdout, exitCode } = await runEmpty("stats");
     expect(exitCode).toBe(0);
-    expect(stdout.trim()).toBe("No skills found.");
+    expect(stdout.trim()).toBe("No installed skills.");
   });
 
   test("--tokens and audit residency both report an empty set", async () => {
@@ -3692,8 +3692,8 @@ describe("CLI integration: stats", () => {
   test("stats --json returns valid JSON with expected fields", async () => {
     const { stdout, exitCode } = await runCLI("stats", "--json");
     expect(exitCode).toBe(0);
-    // If no skills, stats outputs "No skills found." to stdout
-    if (stdout === "No skills found.") return;
+    // If no skills, the human dashboard degrades to this sentence.
+    if (stdout.trim() === "No installed skills.") return;
     const data = JSON.parse(stdout);
     expect(data).toHaveProperty("totalSkills");
     expect(data).toHaveProperty("byProvider");
@@ -3705,7 +3705,7 @@ describe("CLI integration: stats", () => {
   test("stats --json --verbose includes perSkillDiskBytes", async () => {
     const { stdout, exitCode } = await runCLI("stats", "--json", "--verbose");
     expect(exitCode).toBe(0);
-    if (stdout === "No skills found.") return;
+    if (stdout.trim() === "No installed skills.") return;
     const data = JSON.parse(stdout);
     expect(data).toHaveProperty("perSkillDiskBytes");
   });
@@ -3713,7 +3713,7 @@ describe("CLI integration: stats", () => {
   test("stats --json without verbose omits perSkillDiskBytes", async () => {
     const { stdout, exitCode } = await runCLI("stats", "--json");
     expect(exitCode).toBe(0);
-    if (stdout === "No skills found.") return;
+    if (stdout.trim() === "No installed skills.") return;
     const data = JSON.parse(stdout);
     expect(data).not.toHaveProperty("perSkillDiskBytes");
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4667,7 +4667,7 @@ async function cmdStats(args: ParsedArgs) {
   // installed; only the human dashboard degrades to a sentence (it charts
   // maxima that an empty set has none of).
   if (allSkills.length === 0 && !args.flags.json && !args.flags.machine) {
-    console.log("No skills found.");
+    console.log("  No installed skills.");
     return;
   }
 

--- a/src/residency.test.ts
+++ b/src/residency.test.ts
@@ -113,18 +113,41 @@ describe("chooseDemotionAction", () => {
     expect(action.command).toBe("asm disable my-skill");
   });
 
-  it("says the disable covers every place, because it has no --tool switch", () => {
-    // Symlinked siblings share one canonical SKILL.md, so `asm disable` demotes
-    // the whole group; promising a per-tool demotion would be a lie.
+  it("does not claim a scoped instance count in the disable hint", () => {
+    // Bare `asm disable name` is unscoped. Do not say "all N places" — the
+    // report may already be --scope filtered.
     const action = chooseDemotionAction("my-skill", [
       makeInstance({ libraryLinked: true, provider: "claude" }),
       makeInstance({ libraryLinked: true, provider: "codex" }),
       makeInstance({ libraryLinked: false, provider: "agents" }),
     ]);
     expect(action.hint).toBe(
-      "reversible with asm enable; disables it in all 3 places",
+      "reversible with asm enable; disables every ASM-managed copy of this skill name",
     );
+    expect(action.hint).not.toMatch(/all \d+ places/);
     expect(action.hint).not.toContain("--tool");
+  });
+
+  it("falls back to asm disable when the provider is custom or unknown", () => {
+    const custom = chooseDemotionAction("my-skill", [
+      makeInstance({
+        libraryLinked: true,
+        provider: "custom",
+        scope: "project",
+      }),
+    ]);
+    expect(custom.kind).toBe("disable");
+    expect(custom.command).toBe("asm disable my-skill");
+    expect(custom.reference).toBeUndefined();
+
+    const unknown = chooseDemotionAction("my-skill", [
+      makeInstance({
+        libraryLinked: true,
+        provider: "not-a-provider",
+      }),
+    ]);
+    expect(unknown.kind).toBe("disable");
+    expect(unknown.command).toBe("asm disable my-skill");
   });
 
   // ─── Reference tier (issue #422) ────────────────────────────────────────

--- a/src/residency.ts
+++ b/src/residency.ts
@@ -10,6 +10,7 @@
  */
 
 import { resolve, sep } from "path";
+import { getDefaultConfig } from "./config";
 import { ansi } from "./formatter";
 import { median } from "./stats";
 import {
@@ -142,21 +143,31 @@ export function chooseDemotionAction(
 
   if (instances.length === 1 && instances[0].libraryLinked) {
     const only = instances[0];
-    return {
-      kind: "deactivate",
-      command: `asm deactivate ${dirName} --provider ${only.provider} --scope ${only.scope}`,
-      hint: "keep it in the library, activate when needed",
-      reference,
-    };
+    // `asm deactivate --provider X` must be a name resolveProvider accepts
+    // (config.providers). customPaths scan as provider "custom", which is not
+    // a valid --provider flag — fall back to disable.
+    if (isResolvableProviderName(only.provider)) {
+      return {
+        kind: "deactivate",
+        command: `asm deactivate ${dirName} --provider ${only.provider} --scope ${only.scope}`,
+        hint: "keep it in the library, activate when needed",
+        reference,
+      };
+    }
   }
   return {
     kind: "disable",
     command: `asm disable ${dirName}`,
     hint:
       instances.length > 1
-        ? `reversible with asm enable; disables it in all ${instances.length} places`
+        ? "reversible with asm enable; disables every ASM-managed copy of this skill name"
         : "reversible with asm enable",
   };
+}
+
+/** Names `resolveProvider` would accept from the default provider table. */
+function isResolvableProviderName(name: string): boolean {
+  return getDefaultConfig().providers.some((p) => p.name === name);
 }
 
 /**

--- a/src/stats.test.ts
+++ b/src/stats.test.ts
@@ -973,6 +973,26 @@ describe("computeTokenBudget", () => {
     expect(computeTokenBudget(skills, 2).heaviestResident).toHaveLength(2);
   });
 
+  it("caps heaviestResident at 10 and reports the untruncated total", () => {
+    const skills = Array.from({ length: 11 }, (_, i) =>
+      makeSkill({ name: `s${i}`, dirName: `s${i}`, description: "a b c" }),
+    );
+    const report = computeTokenBudget(skills);
+    expect(report.heaviestResident).toHaveLength(10);
+    expect(report.heaviestResidentTotal).toBe(11);
+    expect(report.heaviestResidentTruncated).toBe(true);
+  });
+
+  it("does not mark an exact-limit list as truncated", () => {
+    const skills = Array.from({ length: 10 }, (_, i) =>
+      makeSkill({ name: `s${i}`, dirName: `s${i}`, description: "a b c" }),
+    );
+    const report = computeTokenBudget(skills);
+    expect(report.heaviestResident).toHaveLength(10);
+    expect(report.heaviestResidentTotal).toBe(10);
+    expect(report.heaviestResidentTruncated).toBe(false);
+  });
+
   it("reports zeroes for an empty installed set", () => {
     const report = computeTokenBudget([]);
     expect(report).toMatchObject({
@@ -980,6 +1000,8 @@ describe("computeTokenBudget", () => {
       totalResidentTokens: 0,
       totalBodyTokens: 0,
       medianResidentTokens: 0,
+      heaviestResidentTotal: 0,
+      heaviestResidentTruncated: false,
     });
     expect(report.heaviestResident).toEqual([]);
   });
@@ -1030,7 +1052,16 @@ describe("formatTokenBudgetReport", () => {
 
   it("handles an empty installed set", () => {
     expect(formatTokenBudgetReport(computeTokenBudget([]))).toContain(
-      "No installed skills",
+      "  No installed skills.",
+    );
+  });
+
+  it("mentions hidden heaviest rows when the list is truncated", () => {
+    const skills = Array.from({ length: 11 }, (_, i) =>
+      makeSkill({ name: `s${i}`, dirName: `s${i}`, description: "a b c" }),
+    );
+    expect(formatTokenBudgetReport(computeTokenBudget(skills))).toContain(
+      "… 1 more not shown — use --json for the full list",
     );
   });
 });

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -264,12 +264,12 @@ export function computeTokenBudget(
     });
   }
 
-  const heaviestResident = [...perSkill]
-    .sort(
-      (a, b) =>
-        b.residentTokens - a.residentTokens || a.name.localeCompare(b.name),
-    )
-    .slice(0, limit > 0 ? limit : perSkill.length);
+  const ranked = [...perSkill].sort(
+    (a, b) =>
+      b.residentTokens - a.residentTokens || a.name.localeCompare(b.name),
+  );
+  const cap = limit > 0 ? limit : ranked.length;
+  const heaviestResident = ranked.slice(0, cap);
 
   return {
     totalSkills: skills.length,
@@ -283,6 +283,8 @@ export function computeTokenBudget(
       (a, b) => b.residentTokens - a.residentTokens,
     ),
     heaviestResident,
+    heaviestResidentTotal: perSkill.length,
+    heaviestResidentTruncated: heaviestResident.length < perSkill.length,
   };
 }
 
@@ -408,6 +410,13 @@ export function formatTokenBudgetReport(report: TokenBudgetReport): string {
           ) +
           "  " +
           ansi.dim(`(${skill.provider}, ${skill.scope})`),
+      );
+    }
+    const hidden =
+      report.heaviestResidentTotal - report.heaviestResident.length;
+    if (hidden > 0) {
+      lines.push(
+        ansi.dim(`  … ${hidden} more not shown — use --json for the full list`),
       );
     }
     lines.push("");

--- a/src/utils/machine.ts
+++ b/src/utils/machine.ts
@@ -13,6 +13,11 @@ export interface MachineEnvelopeMeta {
   duration_ms: number;
 }
 
+/**
+ * v1 machine envelope. Envelope keys and `meta` stay snake_case (`asm_version`,
+ * `duration_ms`). Command `data` objects keep TypeScript camelCase — the same
+ * shapes as `--json`. Do not dual-key or rename either side in v1.
+ */
 export interface MachineOutput<T = unknown> {
   version: 1;
   command: string;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -294,7 +294,12 @@ export interface TokenBudgetReport {
   medianResidentTokens: number;
   byProvider: TokenBudgetGroup[];
   byScope: TokenBudgetGroup[];
+  /** Capped list (see HEAVIEST_RESIDENT_LIMIT). */
   heaviestResident: ResidentSkillCost[];
+  /** Full per-skill count before the heaviest-resident cap. */
+  heaviestResidentTotal: number;
+  /** True when heaviestResident is a prefix of the full ranking. */
+  heaviestResidentTruncated: boolean;
 }
 
 // ─── Residency Audit Types (issue #423) ─────────────────────────────────


### PR DESCRIPTION
Closes #427

## Summary

Applies the six non-blocking review notes from PR #424: truncation is visible in machine output, the v1 camelCase data contract is recorded, the human heaviest list shows a remainder line, empty-state copy is unified, deactivate is only suggested for resolvable providers, and the disable hint no longer overstates a scoped blast radius.

## Approach

six-item polish, keep v1 camelCase data — smallest change that meets every AC without renaming machine keys or un-capping the listed array.

## Decision Record

- **Root cause:** PR #424 shipped two new surfaces that drifted from existing CLI conventions (cap without remainder, empty copy, deactivate interpolation, scoped wording vs unscoped disable) and left a camelCase-vs-snake_case envelope question undecided.
- **Options considered:** Option 1 — six-item polish, keep v1 camelCase data
- **Options rejected:** n/a — trivial change, direct plan (light profile)
- **Selected option:** Option 1 — six-item polish, keep v1 camelCase data
- **Residual risk:** Human remainder line still says use --json for the full list while --json keeps the capped heaviestResident array plus heaviestResidentTotal / heaviestResidentTruncated. Default-config provider names only: user-added providers get asm disable (safer than a failing deactivate).
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/427-polish-pass-on-asm-stats-tokens-and @ c9c05b5` (2026-08-18)

## Changes

| File | Change |
|------|--------|
| `src/utils/types.ts` | heaviestResidentTotal + heaviestResidentTruncated |
| `src/stats.ts` | Populate cap metadata; dim remainder line |
| `src/utils/machine.ts` | Document v1: envelope snake_case, data camelCase |
| `src/cli.ts` | asm stats empty line matches tokens/residency |
| `src/residency.ts` | Deactivate only for resolvable providers; unscoped disable hint |
| `src/stats.test.ts` | Cap/total/truncated + remainder + empty copy |
| `src/residency.test.ts` | Unknown provider to disable; no all-N-places wording |
| `src/cli.test.ts` | Empty dashboard assertion |

## Test Results

- Unit tests: 501 focused (stats/residency/cli/machine) passed
- Integration tests: included in cli.test.ts
- E2e tests: skipped for this change
- Build: passed (pre-push hook)
- QA cycles: 1
- Full vitest run: 3 failures pre-existing (catalog/index drift) — not in this diff

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Truncated heaviestResident distinguishable in --json / --machine | pass | src/stats.ts sets heaviestResidentTotal / heaviestResidentTruncated; src/stats.test.ts |
| Deliberate camelCase/snake_case decision recorded and applied | pass | Comment on src/utils/machine.ts; no key rename |
| Human heaviest list shows remainder line like residency | pass | src/stats.ts overflow line; format test |
| Three surfaces share empty-state phrasing | pass | "  No installed skills." in cli.ts, stats.ts, residency.ts |
| No suggested deactivate names a rejected provider | pass | isResolvableProviderName + disable fallback; custom-provider test |
| Disable hint blast radius matches the command | pass | Hint no longer uses all N places |
| Existing tests pass; new truncation + scope cases | pass | 501 focused tests green |

<!-- gitissue:qa v1 head=c9c05b5221e53ecb77c64454d6dd1b97ba2ccde3 profile=light cycles=1 review=clean ui=none -->
