### PR TITLE
feat(cli): show invocability and add invocable filters (#417)

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,8 @@ Multiple `asm` binaries on `PATH` can shadow a fresh upgrade.
 --json                 JSON output
 -s, --scope <scope>    global, project, or both
 --sort <field>         name, version, or location
+--model-invocable      Only skills the model can invoke
+--user-invocable       Only skills the user can invoke
 -y, --yes              Skip confirmations
 --no-color             Disable ANSI colors
 ```
@@ -614,6 +616,12 @@ asm list --summary
 ```bash
 asm list --compact --group-by tool --limit 20
 ```
+
+```bash
+asm list --model-invocable --user-invocable
+```
+
+Listings and `asm inspect` show invocability as `model`, `user`, or `both` (never collapsed). `--model-invocable` and `--user-invocable` are independent; both flags keep skills that match both (typically `both`).
 
 ```bash
 asm search "code review" --json

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2658,6 +2658,18 @@ describe("parseArgs: additional flags", () => {
     expect(result.flags.available).toBe(false);
   });
 
+  test("parses independent invocability flags (#417)", () => {
+    const none = parse("list");
+    expect(none.flags.modelInvocable).toBe(false);
+    expect(none.flags.userInvocable).toBe(false);
+    const both = parse("list", "--model-invocable", "--user-invocable");
+    expect(both.flags.modelInvocable).toBe(true);
+    expect(both.flags.userInvocable).toBe(true);
+    const search = parse("search", "q", "--user-invocable");
+    expect(search.flags.userInvocable).toBe(true);
+    expect(search.flags.modelInvocable).toBe(false);
+  });
+
   test("parses --tool as alias for --provider", () => {
     const result = parse("list", "--tool", "claude");
     expect(result.flags.provider).toBe("claude");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,13 @@ import {
   resolveProviderPath,
 } from "./config";
 import { scanAllSkills, searchSkills, sortSkills } from "./scanner";
-import { parseFrontmatter } from "./utils/frontmatter";
+import {
+  parseFrontmatter,
+  resolveModelInvocable,
+  resolveUserInvocable,
+  matchesInvocabilityFilters,
+  formatInvocability,
+} from "./utils/frontmatter";
 import {
   loadSkillState,
   saveSkillState,
@@ -296,6 +302,8 @@ interface ParsedArgs {
     available: boolean;
     has: string[];
     missing: string[];
+    modelInvocable: boolean;
+    userInvocable: boolean;
     dryRun: boolean;
     /** `asm import --diff` — show unified diffs for conflicts. */
     diff: boolean;
@@ -379,6 +387,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       available: false,
       has: [],
       missing: [],
+      modelInvocable: false,
+      userInvocable: false,
       dryRun: false,
       diff: false,
       machine: false,
@@ -541,6 +551,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
     } else if (arg === "--missing") {
       i++;
       if (args[i]) result.flags.missing.push(args[i]);
+    } else if (arg === "--model-invocable") {
+      result.flags.modelInvocable = true;
+    } else if (arg === "--user-invocable") {
+      result.flags.userInvocable = true;
     } else if (arg === "--add") {
       i++;
       result.flags.add = args[i] || null;
@@ -664,6 +678,8 @@ ${ansi.bold("Options:")}
   --summary            Print only the summary (counts by tool/scope/effort)
   --group-by <axis>    Group rows under headers (axis: tool | scope | effort)
   --limit <N>          Limit rendered rows (0 = no limit)
+  --model-invocable    Only skills the model can invoke
+  --user-invocable     Only skills the user can invoke (slash command)
   --json               Output as JSON array
   --machine            Output in stable machine-readable v1 envelope format
   --no-color           Disable ANSI colors
@@ -697,6 +713,8 @@ ${ansi.bold("Options:")}
   -p, --tool <p>       Filter by tool (claude, codex, openclaw, agents)
   --installed          Show only installed skills
   --available          Show only available (not installed) skills
+  --model-invocable    Only skills the model can invoke
+  --user-invocable     Only skills the user can invoke (slash command)
   --flat               Show one row per tool instance (ungrouped)
   --json               Output as JSON array
   --machine            Output in stable machine-readable v1 envelope format
@@ -1003,6 +1021,14 @@ async function cmdList(args: ParsedArgs) {
   if (args.flags.provider && args.command === "list") {
     allSkills = allSkills.filter((s) => s.provider === args.flags.provider);
   }
+  if (args.flags.modelInvocable || args.flags.userInvocable) {
+    allSkills = allSkills.filter((s) =>
+      matchesInvocabilityFilters(s, {
+        modelInvocable: args.flags.modelInvocable,
+        userInvocable: args.flags.userInvocable,
+      }),
+    );
+  }
 
   await enrichWithHealth(allSkills);
   const sorted = sortSkills(allSkills, args.flags.sort);
@@ -1100,6 +1126,14 @@ async function cmdSearch(args: ParsedArgs) {
     if (args.flags.provider) {
       allSkills = allSkills.filter((s) => s.provider === args.flags.provider);
     }
+    if (args.flags.modelInvocable || args.flags.userInvocable) {
+      allSkills = allSkills.filter((s) =>
+        matchesInvocabilityFilters(s, {
+          modelInvocable: args.flags.modelInvocable,
+          userInvocable: args.flags.userInvocable,
+        }),
+      );
+    }
     const filtered = searchSkills(allSkills, query);
     installedResults = sortSkills(filtered, args.flags.sort);
   }
@@ -1107,7 +1141,16 @@ async function cmdSearch(args: ParsedArgs) {
   // --- Available (index) skills ---
   let indexResults: Awaited<ReturnType<typeof searchIndexSkills>> = [];
   if (showAvailable) {
-    indexResults = await searchIndexSkills(query);
+    indexResults = await searchIndexSkills(
+      query,
+      20,
+      args.flags.modelInvocable || args.flags.userInvocable
+        ? {
+            modelInvocable: args.flags.modelInvocable || undefined,
+            userInvocable: args.flags.userInvocable || undefined,
+          }
+        : undefined,
+    );
     // Deduplicate: remove index results that match an installed skill by name
     if (installedResults.length > 0) {
       const installedNames = new Set(
@@ -1193,6 +1236,10 @@ async function cmdSearch(args: ParsedArgs) {
         verified: r.skill.verified,
         repoLabel: `${r.repo.owner}/${r.repo.repo}`,
         installUrl: r.skill.installUrl,
+        invocability: formatInvocability(
+          r.skill.modelInvocable,
+          r.skill.userInvocable,
+        ),
       })),
       query,
     );
@@ -1945,6 +1992,8 @@ async function reconstructDisabledSkills(
           license: (fm.license || "").trim(),
           compatibility: (fm.compatibility || "").trim(),
           allowedTools: [],
+          modelInvocable: resolveModelInvocable(fm),
+          userInvocable: resolveUserInvocable(fm),
           dirName,
           path: skillDir,
           originalPath: skillDir,
@@ -6006,6 +6055,8 @@ ${ansi.bold("Options:")}
   --json           Output as JSON
   --has <field>    Only show skills that have <field> (license, creator, version)
   --missing <field> Only show skills missing <field> (license, creator, version)
+  --model-invocable Only skills the model can invoke
+  --user-invocable  Only skills the user can invoke
   -y, --yes        Skip confirmation prompts
   --no-color       Disable ANSI colors
   -V, --verbose    Show debug output
@@ -6078,7 +6129,9 @@ async function cmdIndex(args: ParsedArgs) {
       if (
         !query &&
         args.flags.has.length === 0 &&
-        args.flags.missing.length === 0
+        args.flags.missing.length === 0 &&
+        !args.flags.modelInvocable &&
+        !args.flags.userInvocable
       ) {
         error("Missing required argument: <query>");
         console.error(`Run "asm index --help" for usage.`);
@@ -6092,8 +6145,14 @@ async function cmdIndex(args: ParsedArgs) {
       if (args.flags.missing.length > 0) {
         filters.missing = args.flags.missing;
       }
+      if (args.flags.modelInvocable) filters.modelInvocable = true;
+      if (args.flags.userInvocable) filters.userInvocable = true;
 
-      const hasFilters = filters.has || filters.missing;
+      const hasFilters =
+        filters.has ||
+        filters.missing ||
+        filters.modelInvocable ||
+        filters.userInvocable;
       const results = hasFilters
         ? await searchIndexSkills(query || "", 20, filters)
         : await searchIndexSkills(query);

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -104,6 +104,7 @@ describe("formatSkillTable", () => {
     expect(headerLine).toContain("Version");
     expect(headerLine).toContain("Creator");
     expect(headerLine).toContain("Effort");
+    expect(headerLine).toContain("Invoke");
     expect(headerLine).toContain("Tool");
     expect(headerLine).toContain("Scope");
     expect(headerLine).toContain("Type");
@@ -159,6 +160,23 @@ describe("formatSkillDetail", () => {
     expect(output).toContain("File Count: 3");
     expect(output).toContain("Type: directory");
     expect(output).toContain("Description: A test skill");
+    expect(output).toContain("Invocable: both");
+  });
+
+  test("shows model invocability without collapsing to both", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({ modelInvocable: true, userInvocable: false }),
+    );
+    expect(output).toContain("Invocable: model");
+    expect(output).not.toContain("Invocable: both");
+  });
+
+  test("shows user invocability without collapsing to both", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({ modelInvocable: false, userInvocable: true }),
+    );
+    expect(output).toContain("Invocable: user");
+    expect(output).not.toContain("Invocable: both");
   });
 
   test("shows symlink target when symlink", async () => {
@@ -554,9 +572,19 @@ describe("formatGroupedTable", () => {
     expect(output).toContain("Version");
     expect(output).toContain("Creator");
     expect(output).toContain("Effort");
+    expect(output).toContain("Invoke");
     expect(output).toContain("Tools");
     expect(output).toContain("Scope");
     expect(output).toContain("Type");
+    expect(output).toContain("both");
+  });
+
+  test("renders model invocability without collapsing to both", () => {
+    const output = formatGroupedTable([
+      makeSkill({ modelInvocable: true, userInvocable: false }),
+    ]);
+    expect(output).toMatch(/\bmodel\b/);
+    expect(output).not.toMatch(/\bboth\b/);
   });
 
   test("shows footer with counts", () => {

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -818,6 +818,26 @@ describe("effort field display", () => {
     const output = await formatSkillInspect(skills);
     expect(output).not.toContain("Effort:");
   });
+
+  test("formatSkillInspect shows invocability for multi-instance skills", async () => {
+    const skills = [
+      makeSkill({
+        modelInvocable: true,
+        userInvocable: false,
+        providerLabel: "Claude Code",
+      }),
+      makeSkill({
+        modelInvocable: true,
+        userInvocable: false,
+        providerLabel: "Codex",
+        provider: "codex",
+        path: "/other",
+      }),
+    ];
+    const output = await formatSkillInspect(skills);
+    expect(output).toContain("Invocable: model");
+    expect(output).not.toContain("Invocable: both");
+  });
 });
 
 // ─── colorTool / formatAllowedTools ─────────────────────────────────────────

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -929,6 +929,12 @@ export async function formatSkillInspect(skills: SkillInfo[]): Promise<string> {
   if (ref.effort) {
     lines.push(label("  Effort", colorEffort(ref.effort)));
   }
+  lines.push(
+    label(
+      "  Invocable",
+      formatInvocability(ref.modelInvocable, ref.userInvocable),
+    ),
+  );
 
   const fileCount = ref.fileCount ?? (await countFiles(ref.path));
   lines.push(label("  File Count", String(fileCount)));

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,6 +1,7 @@
 import type { SkillInfo } from "./utils/types";
 import { countFiles } from "./scanner";
 import { formatTokenCount } from "./utils/token-count";
+import { formatInvocability } from "./utils/frontmatter";
 
 // ─── Color helpers ──────────────────────────────────────────────────────────
 
@@ -107,6 +108,7 @@ export function formatSkillTable(skills: SkillInfo[]): string {
     "Version",
     "Creator",
     "Effort",
+    "Invoke",
     "Tool",
     "Scope",
     "Type",
@@ -120,6 +122,7 @@ export function formatSkillTable(skills: SkillInfo[]): string {
     s.version,
     s.creator || "\u2014",
     s.effort || "\u2014",
+    formatInvocability(s.modelInvocable, s.userInvocable),
     s.providerLabel,
     s.scope,
     s.isSymlink ? "symlink" : "directory",
@@ -155,6 +158,7 @@ interface GroupedSkill {
   version: string;
   creator: string;
   effort: string;
+  invoke: string;
   tokens: string;
   providers: Array<{ provider: string; label: string }>;
   scope: "global" | "project" | "mixed";
@@ -190,6 +194,7 @@ function groupSkills(skills: SkillInfo[]): GroupedSkill[] {
       version: ref.version,
       creator: ref.creator || "",
       effort: ref.effort || "",
+      invoke: formatInvocability(ref.modelInvocable, ref.userInvocable),
       tokens:
         typeof ref.tokenCount === "number"
           ? formatTokenCount(ref.tokenCount)
@@ -365,7 +370,8 @@ export function formatCompactTable(skills: SkillInfo[]): string {
     const provPadding = providerW - providerPlain[i].length;
     const prov = providerStrs[i] + " ".repeat(Math.max(0, provPadding));
     const scope = ansi.dim(pad(g.scope, scopeW));
-    const row = `${name}  ${version}  ${prov}  ${scope}`;
+    const invoke = pad(g.invoke, 5);
+    const row = `${name}  ${version}  ${invoke}  ${prov}  ${scope}`;
     lines.push(g.disabled ? ansi.dim(row) : row);
   }
 
@@ -488,6 +494,7 @@ export function formatGroupedTable(skills: SkillInfo[]): string {
     6,
     ...grouped.map((g) => (g.effort || "\u2014").length),
   );
+  const invokeW = Math.max(6, ...grouped.map((g) => g.invoke.length));
   // Tokens column — render `~N tokens` directly (e.g. "~1.2k tokens").
   // Width follows the longest cell; header label fallback `Tokens` is 6.
   const hasAnyTokens = grouped.some((g) => g.tokens.length > 0);
@@ -510,11 +517,11 @@ export function formatGroupedTable(skills: SkillInfo[]): string {
 
   // Header
   const tokensHeader = hasAnyTokens ? `  ${pad("Tokens", tokensW)}` : "";
-  const header = `${pad("Name", nameW)}  ${pad("Version", versionW)}  ${pad("Creator", creatorW)}  ${pad("Effort", effortW)}${tokensHeader}  ${pad("Tools", providerW)}  ${pad("Scope", scopeW)}  ${pad("Type", typeW)}`;
+  const header = `${pad("Name", nameW)}  ${pad("Version", versionW)}  ${pad("Creator", creatorW)}  ${pad("Effort", effortW)}  ${pad("Invoke", invokeW)}${tokensHeader}  ${pad("Tools", providerW)}  ${pad("Scope", scopeW)}  ${pad("Type", typeW)}`;
   lines.push(useColor() ? ansi.bold(header) : header);
   const tokensSep = hasAnyTokens ? `  ${"-".repeat(tokensW)}` : "";
   lines.push(
-    `${"-".repeat(nameW)}  ${"-".repeat(versionW)}  ${"-".repeat(creatorW)}  ${"-".repeat(effortW)}${tokensSep}  ${"-".repeat(providerW)}  ${"-".repeat(scopeW)}  ${"-".repeat(typeW)}`,
+    `${"-".repeat(nameW)}  ${"-".repeat(versionW)}  ${"-".repeat(creatorW)}  ${"-".repeat(effortW)}  ${"-".repeat(invokeW)}${tokensSep}  ${"-".repeat(providerW)}  ${"-".repeat(scopeW)}  ${"-".repeat(typeW)}`,
   );
 
   // Data rows
@@ -543,7 +550,8 @@ export function formatGroupedTable(skills: SkillInfo[]): string {
         ? ` ${ansi.yellow(`(${g.warningCount} warning${g.warningCount > 1 ? "s" : ""})`)}`
         : "";
 
-    const row = `${name}  ${version}  ${creator}  ${effort}${tokensCell}  ${prov}  ${scope}  ${type}${warn}`;
+    const invoke = pad(g.invoke, invokeW);
+    const row = `${name}  ${version}  ${creator}  ${effort}  ${invoke}${tokensCell}  ${prov}  ${scope}  ${type}${warn}`;
     lines.push(g.disabled ? ansi.dim(row) : row);
   }
 
@@ -617,10 +625,11 @@ export function formatSearchResults(
   const pad = (s: string, w: number) => s.padEnd(w);
 
   // Header
-  const header = `${pad("Name", nameW)}  ${pad("Version", versionW)}  ${pad("Creator", creatorW)}  ${pad("Effort", effortW)}  ${pad("Tools", providerW)}  ${pad("Scope", scopeW)}  ${pad("Type", typeW)}`;
+  const invokeW = 6;
+  const header = `${pad("Name", nameW)}  ${pad("Version", versionW)}  ${pad("Creator", creatorW)}  ${pad("Effort", effortW)}  ${pad("Invoke", invokeW)}  ${pad("Tools", providerW)}  ${pad("Scope", scopeW)}  ${pad("Type", typeW)}`;
   lines.push(useColor() ? ansi.bold(header) : header);
   lines.push(
-    `${"-".repeat(nameW)}  ${"-".repeat(versionW)}  ${"-".repeat(creatorW)}  ${"-".repeat(effortW)}  ${"-".repeat(providerW)}  ${"-".repeat(scopeW)}  ${"-".repeat(typeW)}`,
+    `${"-".repeat(nameW)}  ${"-".repeat(versionW)}  ${"-".repeat(creatorW)}  ${"-".repeat(effortW)}  ${"-".repeat(invokeW)}  ${"-".repeat(providerW)}  ${"-".repeat(scopeW)}  ${"-".repeat(typeW)}`,
   );
 
   // Data rows with highlighting
@@ -642,8 +651,9 @@ export function formatSearchResults(
     const scope = pad(g.scope, scopeW);
     const type = pad(g.type, typeW);
 
+    const invoke = pad(g.invoke, invokeW);
     lines.push(
-      `${name}  ${version}  ${creator}  ${effort}  ${prov}  ${scope}  ${type}`,
+      `${name}  ${version}  ${creator}  ${effort}  ${invoke}  ${prov}  ${scope}  ${type}`,
     );
   }
 
@@ -659,6 +669,7 @@ export interface AvailableSkillResult {
   verified?: boolean;
   repoLabel: string;
   installUrl: string;
+  invocability?: string;
 }
 
 export function formatAvailableSearchResults(
@@ -685,8 +696,11 @@ export function formatAvailableSearchResults(
     );
     // Skill name + version + verified badge + repo
     const verifiedTag = result.verified ? ansi.blue(" [verified]") : "";
+    const invokeTag = result.invocability
+      ? ansi.dim(` [${result.invocability}]`)
+      : "";
     lines.push(
-      `  ${ansi.cyan(result.name)} ${ansi.dim(`v${result.version}`)}${verifiedTag} ${ansi.dim(`[${result.repoLabel}]`)}`,
+      `  ${ansi.cyan(result.name)} ${ansi.dim(`v${result.version}`)}${verifiedTag}${invokeTag} ${ansi.dim(`[${result.repoLabel}]`)}`,
     );
     // Description
     for (const dl of wordWrap(result.description, 76)) {
@@ -750,6 +764,12 @@ export async function formatSkillDetail(skill: SkillInfo): Promise<string> {
   if (skill.effort) {
     lines.push(label("Effort", colorEffort(skill.effort)));
   }
+  lines.push(
+    label(
+      "Invocable",
+      formatInvocability(skill.modelInvocable, skill.userInvocable),
+    ),
+  );
   lines.push(label("Tool", skill.providerLabel));
   lines.push(label("Scope", skill.scope));
   lines.push(label("Location", skill.location));

--- a/src/ingester.ts
+++ b/src/ingester.ts
@@ -213,6 +213,8 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
           creator: skill.creator,
           compatibility: skill.compatibility,
           allowedTools: skill.allowedTools,
+          modelInvocable: skill.modelInvocable !== false,
+          userInvocable: skill.userInvocable !== false,
           installUrl: buildSkillInstallUrl(source, skill.relPath),
           relPath: skill.relPath,
           verified: verification.verified,

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -20,6 +20,8 @@ import {
   parseFrontmatter,
   resolveVersion,
   resolveAllowedTools,
+  resolveModelInvocable,
+  resolveUserInvocable,
 } from "./utils/frontmatter";
 import { estimateTokenCount } from "./utils/token-count";
 import { resolveProviderPath } from "./config";
@@ -522,6 +524,8 @@ export async function discoverSkills(
       creator: (fm["metadata.creator"] || "").trim(),
       compatibility: (fm.compatibility || "").trim(),
       allowedTools: resolveAllowedTools(fm),
+      modelInvocable: resolveModelInvocable(fm),
+      userInvocable: resolveUserInvocable(fm),
       tokenCount: estimateTokenCount(content),
     });
   } catch {
@@ -564,6 +568,8 @@ export async function discoverSkills(
           creator: (fm["metadata.creator"] || "").trim(),
           compatibility: (fm.compatibility || "").trim(),
           allowedTools: resolveAllowedTools(fm),
+          modelInvocable: resolveModelInvocable(fm),
+          userInvocable: resolveUserInvocable(fm),
           tokenCount: estimateTokenCount(content),
         });
         // Don't recurse into directories that have SKILL.md

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -1149,6 +1149,8 @@ describe("scanPluginMarketplaces", () => {
         "compatibility: Claude 3+",
         "effort: medium",
         "allowed-tools: Bash, Read",
+        "disable-model-invocation: true",
+        "user-invocable: true",
         "---",
         "Body content",
       ].join("\n"),
@@ -1165,6 +1167,8 @@ describe("scanPluginMarketplaces", () => {
     expect(s.effort).toBe("medium");
     expect(s.allowedTools).toContain("Bash");
     expect(s.allowedTools).toContain("Read");
+    expect(s.modelInvocable).toBe(false);
+    expect(s.userInvocable).toBe(true);
   });
 
   it("sets isSymlink=false and symlinkTarget=null for all marketplace skills", async () => {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -12,6 +12,8 @@ import {
   parseFrontmatter,
   resolveVersion,
   resolveAllowedTools,
+  resolveModelInvocable,
+  resolveUserInvocable,
 } from "./utils/frontmatter";
 import { estimateTokenCount } from "./utils/token-count";
 import { resolveProviderPath } from "./config";
@@ -324,6 +326,8 @@ async function scanDirectory(
         license: (fm.license || "").trim(),
         compatibility: (fm.compatibility || "").trim(),
         allowedTools: resolveAllowedTools(fm),
+        modelInvocable: resolveModelInvocable(fm),
+        userInvocable: resolveUserInvocable(fm),
         effort: fm.effort || fm["metadata.effort"] || undefined,
         dirName: entry,
         path: resolvedPath,
@@ -464,6 +468,8 @@ export async function scanPluginMarketplaces(
         license: (fm.license || "").trim(),
         compatibility: (fm.compatibility || "").trim(),
         allowedTools: resolveAllowedTools(fm),
+        modelInvocable: resolveModelInvocable(fm),
+        userInvocable: resolveUserInvocable(fm),
         effort: fm.effort || fm["metadata.effort"] || undefined,
         dirName: entry,
         path: resolvedPath,

--- a/src/skill-index.test.ts
+++ b/src/skill-index.test.ts
@@ -198,6 +198,23 @@ describe("searchSkills with filters", () => {
     const filtered = await searchSkills("code", 100, { missing: ["license"] });
     expect(filtered.length).toBeLessThanOrEqual(allResults.length);
   });
+
+  it("filters by model and user invocability independently", async () => {
+    const modelOnly = await searchSkills("", 100, { modelInvocable: true });
+    expect(modelOnly.length).toBeGreaterThan(0);
+    for (const r of modelOnly) {
+      expect(r.skill.modelInvocable).not.toBe(false);
+    }
+    const both = await searchSkills("", 100, {
+      modelInvocable: true,
+      userInvocable: true,
+    });
+    for (const r of both) {
+      expect(r.skill.modelInvocable).not.toBe(false);
+      expect(r.skill.userInvocable).not.toBe(false);
+    }
+    expect(both.length).toBeLessThanOrEqual(modelOnly.length);
+  });
 });
 
 describe("Index resource integrity", () => {

--- a/src/skill-index.ts
+++ b/src/skill-index.ts
@@ -2,6 +2,7 @@ import { readdir, readFile } from "fs/promises";
 import { join } from "path";
 import { getIndexDir, getBundledIndexDir } from "./config";
 import type { RepoIndex, IndexedSkill } from "./utils/types";
+import { matchesInvocabilityFilters } from "./utils/frontmatter";
 
 export interface SearchResult {
   skill: IndexedSkill;
@@ -110,6 +111,8 @@ export async function loadAllIndices(): Promise<RepoIndex[]> {
 export interface SearchFilters {
   has?: string[];
   missing?: string[];
+  modelInvocable?: boolean;
+  userInvocable?: boolean;
 }
 
 const FILTERABLE_FIELDS = ["license", "creator", "version"] as const;
@@ -127,6 +130,7 @@ function getFilterableValue(
 }
 
 function matchesFilters(skill: IndexedSkill, filters: SearchFilters): boolean {
+  if (!matchesInvocabilityFilters(skill, filters)) return false;
   if (filters.has) {
     for (const field of filters.has) {
       if (!isFilterableField(field)) continue;

--- a/src/utils/frontmatter.test.ts
+++ b/src/utils/frontmatter.test.ts
@@ -3,6 +3,10 @@ import {
   parseFrontmatter,
   resolveVersion,
   resolveAllowedTools,
+  resolveModelInvocable,
+  resolveUserInvocable,
+  formatInvocability,
+  matchesInvocabilityFilters,
 } from "./frontmatter";
 
 describe("parseFrontmatter", () => {
@@ -383,5 +387,57 @@ describe("resolveAllowedTools", () => {
     expect(
       resolveAllowedTools({ "allowed-tools": "Bash, Read, Grep" }),
     ).toEqual(["Bash", "Read", "Grep"]);
+  });
+});
+
+describe("invocability frontmatter (#417)", () => {
+  it("defaults model and user invocability to true", () => {
+    expect(resolveModelInvocable({})).toBe(true);
+    expect(resolveUserInvocable({})).toBe(true);
+    expect(formatInvocability(undefined, undefined)).toBe("both");
+  });
+
+  it("treats disable-model-invocation true as model off", () => {
+    expect(
+      resolveModelInvocable({ "disable-model-invocation": "true" }),
+    ).toBe(false);
+    expect(formatInvocability(false, true)).toBe("user");
+  });
+
+  it("treats user-invocable false as user off", () => {
+    expect(resolveUserInvocable({ "user-invocable": "false" })).toBe(false);
+    expect(formatInvocability(true, false)).toBe("model");
+  });
+
+  it("never collapses both into a single-side label", () => {
+    expect(formatInvocability(true, true)).toBe("both");
+    expect(formatInvocability(false, false)).toBe("none");
+  });
+
+  it("filters independently and ANDs when both flags are set", () => {
+    const both = { modelInvocable: true, userInvocable: true };
+    const modelOnly = { modelInvocable: true, userInvocable: false };
+    const userOnly = { modelInvocable: false, userInvocable: true };
+    expect(
+      matchesInvocabilityFilters(modelOnly, { modelInvocable: true }),
+    ).toBe(true);
+    expect(
+      matchesInvocabilityFilters(userOnly, { modelInvocable: true }),
+    ).toBe(false);
+    expect(
+      matchesInvocabilityFilters(userOnly, { userInvocable: true }),
+    ).toBe(true);
+    expect(
+      matchesInvocabilityFilters(modelOnly, {
+        modelInvocable: true,
+        userInvocable: true,
+      }),
+    ).toBe(false);
+    expect(
+      matchesInvocabilityFilters(both, {
+        modelInvocable: true,
+        userInvocable: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/utils/frontmatter.test.ts
+++ b/src/utils/frontmatter.test.ts
@@ -398,9 +398,9 @@ describe("invocability frontmatter (#417)", () => {
   });
 
   it("treats disable-model-invocation true as model off", () => {
-    expect(
-      resolveModelInvocable({ "disable-model-invocation": "true" }),
-    ).toBe(false);
+    expect(resolveModelInvocable({ "disable-model-invocation": "true" })).toBe(
+      false,
+    );
     expect(formatInvocability(false, true)).toBe("user");
   });
 
@@ -421,12 +421,12 @@ describe("invocability frontmatter (#417)", () => {
     expect(
       matchesInvocabilityFilters(modelOnly, { modelInvocable: true }),
     ).toBe(true);
-    expect(
-      matchesInvocabilityFilters(userOnly, { modelInvocable: true }),
-    ).toBe(false);
-    expect(
-      matchesInvocabilityFilters(userOnly, { userInvocable: true }),
-    ).toBe(true);
+    expect(matchesInvocabilityFilters(userOnly, { modelInvocable: true })).toBe(
+      false,
+    );
+    expect(matchesInvocabilityFilters(userOnly, { userInvocable: true })).toBe(
+      true,
+    );
     expect(
       matchesInvocabilityFilters(modelOnly, {
         modelInvocable: true,

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -123,3 +123,53 @@ export function resolveAllowedTools(fm: Record<string, string>): string[] {
     .map((t) => t.trim())
     .filter(Boolean);
 }
+
+function normalizeFmBool(value: string | undefined): string {
+  return (value || "").trim().toLowerCase();
+}
+
+function isTruthyFm(value: string | undefined): boolean {
+  const v = normalizeFmBool(value);
+  return v === "true" || v === "yes" || v === "1";
+}
+
+function isFalsyFm(value: string | undefined): boolean {
+  const v = normalizeFmBool(value);
+  return v === "false" || v === "no" || v === "0";
+}
+
+/** Agent Skills: `disable-model-invocation: true` turns off model invocation. Default on. */
+export function resolveModelInvocable(fm: Record<string, string>): boolean {
+  return !isTruthyFm(fm["disable-model-invocation"]);
+}
+
+/** Agent Skills: `user-invocable: false` turns off slash/user invocation. Default on. */
+export function resolveUserInvocable(fm: Record<string, string>): boolean {
+  if (!("user-invocable" in fm)) return true;
+  return !isFalsyFm(fm["user-invocable"]);
+}
+
+export type InvocabilityLabel = "model" | "user" | "both" | "none";
+
+export function formatInvocability(
+  modelInvocable?: boolean,
+  userInvocable?: boolean,
+): InvocabilityLabel {
+  const model = modelInvocable !== false;
+  const user = userInvocable !== false;
+  if (model && user) return "both";
+  if (model) return "model";
+  if (user) return "user";
+  return "none";
+}
+
+export function matchesInvocabilityFilters(
+  skill: { modelInvocable?: boolean; userInvocable?: boolean },
+  filters: { modelInvocable?: boolean; userInvocable?: boolean },
+): boolean {
+  const model = skill.modelInvocable !== false;
+  const user = skill.userInvocable !== false;
+  if (filters.modelInvocable && !model) return false;
+  if (filters.userInvocable && !user) return false;
+  return true;
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -13,6 +13,10 @@ export interface SkillInfo {
   license: string;
   compatibility: string;
   allowedTools: string[];
+  /** Agent Skills model invocation. Default true when omitted. */
+  modelInvocable?: boolean;
+  /** Agent Skills user/slash invocation. Default true when omitted. */
+  userInvocable?: boolean;
   dirName: string;
   path: string;
   originalPath: string;
@@ -531,6 +535,8 @@ export interface DiscoveredSkill {
   creator: string;
   compatibility: string;
   allowedTools: string[];
+  modelInvocable?: boolean;
+  userInvocable?: boolean;
   /**
    * Estimated token count for the SKILL.md content. Populated by
    * `discoverSkills` so downstream consumers (ingester) don't have to
@@ -564,6 +570,8 @@ export interface IndexedSkill {
   creator: string;
   compatibility: string;
   allowedTools: string[];
+  modelInvocable?: boolean;
+  userInvocable?: boolean;
   installUrl: string;
   relPath: string;
   verified?: boolean;

--- a/src/views/skill-detail.tsx
+++ b/src/views/skill-detail.tsx
@@ -5,6 +5,7 @@ import type { SkillInfo } from "../utils/types";
 import { countFiles } from "../scanner";
 import { wordWrap, HIGH_RISK_TOOLS, MEDIUM_RISK_TOOLS } from "../formatter";
 import { formatTokenCount } from "../utils/token-count";
+import { formatInvocability } from "../utils/frontmatter";
 
 const EFFORT_COLORS: Record<string, string> = {
   low: theme.green,
@@ -117,6 +118,10 @@ export function SkillDetailView({ skill }: SkillDetailProps) {
           valueColor={EFFORT_COLORS[skill.effort.toLowerCase()] || theme.fg}
         />
       )}
+      <Row
+        label="Invocable"
+        value={formatInvocability(skill.modelInvocable, skill.userInvocable)}
+      />
       <Row
         label="Tool"
         value={skill.providerLabel}

--- a/src/views/skill-list.test.tsx
+++ b/src/views/skill-list.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "ink-testing-library";
+import { SkillListView, calcDescWidth } from "./skill-list";
+import type { SkillInfo } from "../utils/types";
+
+function makeSkill(over: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    name: "sample-skill",
+    version: "1.0.0",
+    description: "A sample skill.",
+    creator: "tester",
+    license: "MIT",
+    compatibility: "",
+    allowedTools: [],
+    dirName: "sample-skill",
+    path: "/tmp/sample-skill",
+    originalPath: "/tmp/sample-skill",
+    location: "global",
+    scope: "global",
+    provider: "claude",
+    providerLabel: "Claude Code",
+    isSymlink: false,
+    symlinkTarget: null,
+    realPath: "/tmp/sample-skill",
+    fileCount: 1,
+    ...over,
+  };
+}
+
+describe("calcDescWidth", () => {
+  // Regression test for issue #417 review: adding the Invoke column must not
+  // silently grow the fixed (non-description) row budget beyond what was
+  // reclaimed from other columns. See the comment on calcDescWidth for the
+  // full addend breakdown that sums to this constant.
+  it("pins the fixed row-content budget", () => {
+    const fixed = 105;
+    expect(calcDescWidth(200)).toBe(200 - fixed);
+  });
+
+  it("never returns a negative width on narrow terminals", () => {
+    expect(calcDescWidth(80)).toBe(0);
+    expect(calcDescWidth(0)).toBe(0);
+  });
+});
+
+describe("SkillListView row width", () => {
+  it("keeps the Invoke column while staying within the pinned fixed budget", () => {
+    const { lastFrame, unmount } = render(
+      <SkillListView
+        skills={[makeSkill({ modelInvocable: true, userInvocable: false })]}
+        selectedIndex={0}
+        visibleCount={5}
+        termWidth={200}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Invoke");
+    // formatInvocability("model", true, false) === "model".
+    expect(frame).toContain("model");
+    unmount();
+  });
+});

--- a/src/views/skill-list.tsx
+++ b/src/views/skill-list.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from "ink";
 import { theme } from "../utils/colors";
 import type { SkillInfo } from "../utils/types";
 import { formatTokenCount } from "../utils/token-count";
+import { formatInvocability } from "../utils/frontmatter";
 
 function compactTokens(tokenCount: number | undefined): string {
   if (typeof tokenCount !== "number") return "—";
@@ -11,8 +12,8 @@ function compactTokens(tokenCount: number | undefined): string {
 
 function calcDescWidth(termWidth: number): number {
   // 2(border) + 2(padding) + 4(#) + 24(name) + 8(ver) + 13(creator) + 7(effort)
-  // + 8(tokens) + 12(provider) + 8(scope) + 6(type) + 9(spaces) = 103
-  const fixed = 103;
+  // + 7(invoke) + 8(tokens) + 12(provider) + 8(scope) + 6(type) + 10(spaces) = 111
+  const fixed = 111;
   return Math.max(0, termWidth - fixed);
 }
 
@@ -35,6 +36,7 @@ function formatSkillRow(
   const creator = creatorRaw.length > 12 ? creatorRaw.slice(0, 12) : creatorRaw;
   const effortRaw = skill.effort || "—";
   const effort = effortRaw.length > 6 ? effortRaw.slice(0, 6) : effortRaw;
+  const invoke = formatInvocability(skill.modelInvocable, skill.userInvocable);
   const tokensRaw = compactTokens(skill.tokenCount);
   const tokens = tokensRaw.length > 7 ? tokensRaw.slice(0, 7) : tokensRaw;
   const prov =
@@ -45,7 +47,7 @@ function formatSkillRow(
   const type = skill.isSymlink ? "→link" : " dir ";
   const desc =
     descWidth > 0 ? " " + (skill.description || "").slice(0, descWidth) : "";
-  return `${idx} ${name.padEnd(24)} ${ver.padEnd(8)} ${creator.padEnd(13)} ${effort.padEnd(7)} ${tokens.padEnd(8)} ${prov.padEnd(12)} ${scope.padEnd(8)} ${type.padEnd(6)}${desc}`;
+  return `${idx} ${name.padEnd(24)} ${ver.padEnd(8)} ${creator.padEnd(13)} ${effort.padEnd(7)} ${invoke.padEnd(6)} ${tokens.padEnd(8)} ${prov.padEnd(12)} ${scope.padEnd(8)} ${type.padEnd(6)}${desc}`;
 }
 
 export interface SkillListProps {
@@ -63,7 +65,7 @@ export function SkillListView({
 }: SkillListProps) {
   const descWidth = calcDescWidth(termWidth);
   const descHeader = descWidth > 0 ? " Description" : "";
-  const header = `${"#".padStart(3)} ${"Name".padEnd(26)} ${"Ver".padEnd(8)} ${"Creator".padEnd(13)} ${"Effort".padEnd(7)} ${"Tokens".padEnd(8)} ${"Tool".padEnd(12)} ${"Scope".padEnd(8)} ${"Type".padEnd(6)}${descHeader}`;
+  const header = `${"#".padStart(3)} ${"Name".padEnd(26)} ${"Ver".padEnd(8)} ${"Creator".padEnd(13)} ${"Effort".padEnd(7)} ${"Invoke".padEnd(6)} ${"Tokens".padEnd(8)} ${"Tool".padEnd(12)} ${"Scope".padEnd(8)} ${"Type".padEnd(6)}${descHeader}`;
 
   // Compute scroll window so the cursor stays visible
   const total = skills.length;

--- a/src/views/skill-list.tsx
+++ b/src/views/skill-list.tsx
@@ -10,10 +10,16 @@ function compactTokens(tokenCount: number | undefined): string {
   return formatTokenCount(tokenCount).replace(/ tokens$/, "");
 }
 
-function calcDescWidth(termWidth: number): number {
-  // 2(border) + 2(padding) + 4(#) + 24(name) + 8(ver) + 13(creator) + 7(effort)
-  // + 7(invoke) + 8(tokens) + 12(provider) + 8(scope) + 6(type) + 10(spaces) = 111
-  const fixed = 111;
+export function calcDescWidth(termWidth: number): number {
+  // Fixed (non-description) row content, measured empirically from
+  // formatSkillRow with descWidth=0: "{prefix}{idx} {name} {ver} {creator}
+  // {effort} {invoke} {tokens} {prov} {scope} {type}" plus the box's
+  // border/padding and the description's own leading space.
+  //   2(border) + 2(padding) + 2(prefix) + 3(idx) + 24(name) + 8(ver)
+  //   + 11(creator) + 7(effort) + 6(invoke) + 6(tokens) + 12(provider)
+  //   + 7(scope) + 5(type) + 9(spaces between fields) + 1(desc leading space)
+  //   = 105
+  const fixed = 105;
   return Math.max(0, termWidth - fixed);
 }
 
@@ -33,12 +39,12 @@ function formatSkillRow(
   const ver =
     skill.version.length > 7 ? skill.version.slice(0, 7) : skill.version;
   const creatorRaw = skill.creator || "—";
-  const creator = creatorRaw.length > 12 ? creatorRaw.slice(0, 12) : creatorRaw;
+  const creator = creatorRaw.length > 10 ? creatorRaw.slice(0, 10) : creatorRaw;
   const effortRaw = skill.effort || "—";
   const effort = effortRaw.length > 6 ? effortRaw.slice(0, 6) : effortRaw;
   const invoke = formatInvocability(skill.modelInvocable, skill.userInvocable);
   const tokensRaw = compactTokens(skill.tokenCount);
-  const tokens = tokensRaw.length > 7 ? tokensRaw.slice(0, 7) : tokensRaw;
+  const tokens = tokensRaw.length > 5 ? tokensRaw.slice(0, 5) : tokensRaw;
   const prov =
     skill.providerLabel.length > 11
       ? skill.providerLabel.slice(0, 11)
@@ -47,7 +53,7 @@ function formatSkillRow(
   const type = skill.isSymlink ? "→link" : " dir ";
   const desc =
     descWidth > 0 ? " " + (skill.description || "").slice(0, descWidth) : "";
-  return `${idx} ${name.padEnd(24)} ${ver.padEnd(8)} ${creator.padEnd(13)} ${effort.padEnd(7)} ${invoke.padEnd(6)} ${tokens.padEnd(8)} ${prov.padEnd(12)} ${scope.padEnd(8)} ${type.padEnd(6)}${desc}`;
+  return `${idx} ${name.padEnd(24)} ${ver.padEnd(8)} ${creator.padEnd(11)} ${effort.padEnd(7)} ${invoke.padEnd(6)} ${tokens.padEnd(6)} ${prov.padEnd(12)} ${scope.padEnd(7)} ${type.padEnd(5)}${desc}`;
 }
 
 export interface SkillListProps {
@@ -65,7 +71,7 @@ export function SkillListView({
 }: SkillListProps) {
   const descWidth = calcDescWidth(termWidth);
   const descHeader = descWidth > 0 ? " Description" : "";
-  const header = `${"#".padStart(3)} ${"Name".padEnd(26)} ${"Ver".padEnd(8)} ${"Creator".padEnd(13)} ${"Effort".padEnd(7)} ${"Invoke".padEnd(6)} ${"Tokens".padEnd(8)} ${"Tool".padEnd(12)} ${"Scope".padEnd(8)} ${"Type".padEnd(6)}${descHeader}`;
+  const header = `${"#".padStart(3)} ${"Name".padEnd(26)} ${"Ver".padEnd(8)} ${"Creator".padEnd(11)} ${"Effort".padEnd(7)} ${"Invoke".padEnd(6)} ${"Tokens".padEnd(6)} ${"Tool".padEnd(12)} ${"Scope".padEnd(7)} ${"Type".padEnd(5)}${descHeader}`;
 
   // Compute scroll window so the cursor stays visible
   const total = skills.length;


### PR DESCRIPTION
Closes #417

## Summary

Surface each skill's invocability (`model`, `user`, `both`, or `none`) in CLI listings, inspect, index output, and TUI, and add independent `--model-invocable` / `--user-invocable` filters so users can tell which skills an agent may auto-trigger versus which only run when asked.

## Approach

Parse + display + independent filters — map Agent Skills frontmatter (`disable-model-invocation`, `user-invocable`) onto `SkillInfo`/`IndexedSkill`, render an unambiguous label everywhere skills are listed or inspected, and filter with two independent boolean flags (neither = unfiltered; both = AND).

## Decision Record

- **Root cause:** Inventory and catalog models never stored invocability; tables, inspect, TUI, and filters had no field to show or query.
- **Options considered:** Option 1 — parse + display + independent filters (direct light-profile plan)
- **Options rejected:** none (light profile skipped 3-option synthesis)
- **Selected option:** Option 1 — parse + display + independent filters
- **Residual risk:** Catalog JSON only includes the new fields after the next ingest; `asm inspect` of multi-install name collisions still omits the Invocable line (single-skill inspect and TUI do show it).
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/417-show-invocability-in-skill-listings @ f27ec9e` (2026-08-17)

## Changes

| File | Change |
|------|--------|
| `src/utils/types.ts` | `modelInvocable` / `userInvocable` on SkillInfo and IndexedSkill |
| `src/utils/frontmatter.ts` | Parse invocability keys; label + match helpers |
| `src/scanner.ts` / `src/ingester.ts` / `src/installer.ts` | Map fields through scan/ingest/install |
| `src/formatter.ts` | Invoke column + `Invocable:` on detail |
| `src/cli.ts` | `--model-invocable` / `--user-invocable` on list/search/index |
| `src/skill-index.ts` | Index SearchFilters for invocability |
| `src/views/skill-list.tsx` / `src/views/skill-detail.tsx` | TUI column and detail |
| `README.md` | Document flags |
| `src/*.test.ts` | Unit coverage for parse, display, filters |

## Test Results

- Unit tests: invocability suite passed (frontmatter, formatter, CLI parse, index filter)
- Integration tests: full hook run 2095 passed; 1 pre-existing fail (`emilkowalski/skills` count 9 vs 8)
- E2e tests: pre-push hook passed
- Build: passed
- QA cycles: 1 (code review PASS; UI code review noted non-blocking)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Skill listing output shows each skill's invocability (model-invocable, user-invocable, or both) | pass | `src/formatter.ts` Invoke column; labels `model`/`user`/`both`/`none` |
| Skill detail/info output shows the same invocability information | pass | `formatSkillDetail` `Invocable:` line; TUI `skill-detail.tsx` |
| A filter restricts results to model-invocable skills | pass | `--model-invocable`; `src/cli.ts` + `frontmatter.test.ts` |
| A filter restricts results to user-invocable skills | pass | `--user-invocable` |
| The two filters can be applied independently, and applying neither leaves output unfiltered as today | pass | AND when both set; neither unset = no filter (`frontmatter.test.ts`, `skill-index.test.ts`) |
| The new filters are documented in the README command/options reference | pass | `README.md` list/search/index options |

<!-- gitissue:qa v1 head=f27ec9e43fd4a8dafb711407ee3c4a87f85cb0dd profile=light cycles=1 review=clean ui=code:noted@fea9b89205f3a0199c268e9b34c20fe3c13ee43f -->
