### PR TITLE
docs(agents): record the install, build, and test commands an agent needs (#433)

### DIFF
--- a/docs/AGENT_ENVIRONMENT.md
+++ b/docs/AGENT_ENVIRONMENT.md
@@ -5,7 +5,7 @@ working in this repository, plus the two traps that are not obvious from
 `package.json`.
 
 Recorded on branch `chore/433-record-the-install-build-and-test`, base commit
-`a46b652`, on 2026-08-19. Every result below was observed by running the command,
+`a46b652`, on 2026-08-19. Every result in the table below was observed by running the command,
 not copied from another document. Re-verify after any dependency or toolchain
 change.
 
@@ -49,8 +49,8 @@ npm install     # or `npm ci` for a lockfile-exact install (what CI uses)
 | `npm run typecheck` | **PASS** (exit 0) — `tsc --noEmit`, no output                                                            | ~2 s      |
 | `npm run lint:site` | **PASS** (exit 0) — eslint over `website-src/src/**/*.{js,jsx}`, no findings                             | ~1 s      |
 
-`git status` was byte-identical before and after all four: none of them modify a
-tracked file. `npm run build` writes only to `dist/`, which is gitignored.
+`git status --porcelain` was unchanged before and after all four — the same three
+untracked files, no tracked modifications. `npm run build` writes only to `dist/`, which is gitignored.
 
 ### Two things `CI=true npm test` is not
 
@@ -59,9 +59,17 @@ tracked file. `npm run build` writes only to `dist/`, which is gitignored.
    `vitest.config.ts` reads it. `CI=true` is the command of record because it
    matches how CI installs, not because it isolates anything. See the user-config
    trap below.
-2. **`npm test` is not the whole suite.** It is `vitest run src/` — unit tests
-   only. The other runners: `npm run test:site` (`website-src/`), `npm run
-test:e2e` (`tests/e2e/`), and `npm run test:all` (unit + site + build + e2e).
+2. **`npm test` is not the whole suite — but it is wider than it looks.** It is
+   `vitest run src/`, and that argument is a **substring filter on the relative
+   test path**, not a directory. `website-src/src/__tests__/…` contains `src/`,
+   so the site tests match too. The observed `60 passed (60)` is 49 `*.test.ts`
+   files under `src/` plus 11 under `website-src/`. Only the 4 files in
+   `tests/e2e/` are excluded. Consequently `npm run test:site`
+   (`vitest run website-src/`, those same 11 files) is a **subset** of
+   `npm test`, not a separate leg — and CI has no site-test job because
+   `npx vitest run src/` in the `unit-tests` job already covers it. The genuinely
+   separate runners are `npm run test:e2e` (`tests/e2e/`) and `npm run test:all`
+   (unit + site + build + e2e).
 
 ### Baseline note
 
@@ -71,21 +79,26 @@ The difference is not a fix — it is the non-hermeticity described below. The t
 that flips (`src/skill-index.test.ts`, "indexes emilkowalski/skills with expected
 skills and install URLs") pins `emilkowalski/skills` to 11 named skills and reads
 the _developer's_ `~/.config/agent-skill-manager/skill-index/` merged over the
-bundled `data/skill-index/`. On this machine that user copy is currently
-byte-identical to the repo's `data/skill-index/emilkowalski_skills.json`, so the
-assertion holds by coincidence. A machine whose ingested index has drifted will
-see 2099/2100. Do not read a local 2100/2100 as evidence of hermeticity.
+bundled `data/skill-index/`. At `ad961d2` both the bundled file and the pin said
+8 skills while this machine's ingested copy said 11, so the assertion failed; the
+base commit `a46b652` (`chore(index): refresh indexed skill sources`) raised both
+to 11, which happens to match what this machine has ingested — `cmp` reports the
+user copy and `data/skill-index/emilkowalski_skills.json` byte-identical. The
+assertion passes by coincidence of state, not because the test stopped reading
+your home directory. A machine whose ingested index has drifted from the bundled
+one will see 2099/2100. Do not read a local 2100/2100 as evidence of
+hermeticity.
 
 ## Trap 1 — scripts that rewrite tracked files
 
 Never run these as a casual probe. They are catalog-regeneration steps, not
 build steps, and they overwrite files that are committed:
 
-| Command                        | Rewrites                                                                                                                                                                                                                                    |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `npm run preindex`             | `data/skill-index/*.json` — **57 tracked files**                                                                                                                                                                                            |
-| `npm run refresh:repo-bundles` | files under `data/skill-index/`                                                                                                                                                                                                             |
-| `npm run build:website`        | `scripts/build-catalog.ts` + `vite build`. Tracked outputs: `website/repo-stats.json`, `website/author-stats.json`, `website/index-stats.json` (each carries a fresh `generatedAt`, so every run produces a diff), and `website/robots.txt` |
+| Command                        | Rewrites                                                                                                                                                                                                                                                                            |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `npm run preindex`             | the per-repo JSONs under `data/skill-index/` — up to **56 of the 57 tracked files**: it iterates only repos marked `enabled` in `data/skill-index-resources.json` (`scripts/preindex.ts:24-28`), and `github:luongnv89/asm` is disabled, so `luongnv89_asm.json` is never rewritten |
+| `npm run refresh:repo-bundles` | the same directory: it walks **every** `*.json` in `data/skill-index/`, recomputes the `bundles` field, and writes back only the files whose serialization changed (`scripts/refresh-repo-bundles.ts:18-45`)                                                                        |
+| `npm run build:website`        | `scripts/build-catalog.ts` + `vite build`. Tracked outputs: `website/repo-stats.json`, `website/author-stats.json`, `website/index-stats.json` (all three carry a `generatedAt` timestamp, so every run produces a diff), and `website/robots.txt`                                  |
 
 Everything else `build:website` emits — `catalog.json`, `skills.min.json`,
 `search.idx.json`, `skills/*.json`, `bundles.json`, `llms.txt`, `sitemap.xml`,
@@ -102,9 +115,14 @@ diff. Do not fold it into an unrelated change.
 
 ## Trap 2 — the unit suite writes to your real user config
 
-`src/config.ts:16` computes `CONFIG_DIR` as `join(homedir(), ".config",
-"agent-skill-manager")` with no environment or dependency-injection override, so
-tests operate on the real directory. This is finding `F-TEST-001`.
+`src/config.ts:15-16` computes `const HOME = homedir()` and then
+`const CONFIG_DIR = join(HOME, ".config", "agent-skill-manager")`, at module
+load, with no environment or dependency-injection override — `src/config.ts`
+contains no `process.env` reference at all. In-process tests therefore operate on
+the real directory. This is finding `F-TEST-001`. (Two partial escape hatches
+exist and cover only their own cases: `src/utils/test-spawn.ts` redirects
+`HOME`/`USERPROFILE` for tests that spawn the built CLI, and `loadAllIndices()`
+accepts an injectable catalog argument.)
 
 Observed during the `CI=true npm test` run above, in
 `~/.config/agent-skill-manager/`:
@@ -132,11 +150,21 @@ directory byte-identical.
 
 ## Pre-commit hooks
 
-`.pre-commit-config.yaml` (install with `pre-commit install`) gates two stages:
+`.pre-commit-config.yaml` defines hooks for two stages, but sets neither
+`default_install_hook_types` nor `default_stages`. A plain `pre-commit install`
+therefore installs the **commit stage only** — the pre-push hooks silently never
+fire. To get both:
 
-- **pre-commit:** local security check, prettier, `tsc --noEmit`, and
-  `npx vitest run src/`.
-- **pre-push:** `npm run build` and `npx vitest run tests/e2e/node-e2e.test.ts`.
+```bash
+pre-commit install --hook-type pre-commit --hook-type pre-push
+```
+
+- **Commit stage:** the upstream `pre-commit-hooks` set (trailing-whitespace,
+  end-of-file-fixer, check-yaml, check-json, check-added-large-files), the local
+  security check, prettier, `tsc --noEmit`, and `npx vitest run src/`.
+- **Push stage:** `npm run build` and
+  `npx vitest run tests/e2e/node-e2e.test.ts` — plus prettier and `tsc --noEmit`
+  again, because those two declare no `stages:` and so run in every stage.
 
 The `unit-tests` hook runs the same non-hermetic suite described above, so on a
 machine with a drifted skill index it can block a commit for a reason unrelated

--- a/docs/AGENT_ENVIRONMENT.md
+++ b/docs/AGENT_ENVIRONMENT.md
@@ -1,0 +1,149 @@
+# Agent Environment Notes
+
+Verified install, build, and test commands for anyone — human or coding agent —
+working in this repository, plus the two traps that are not obvious from
+`package.json`.
+
+Recorded on branch `chore/433-record-the-install-build-and-test`, base commit
+`a46b652`, on 2026-08-19. Every result below was observed by running the command,
+not copied from another document. Re-verify after any dependency or toolchain
+change.
+
+## Node and npm
+
+`package.json` `engines` reads, literally:
+
+```json
+"engines": {
+  "node": ">=18 <23",
+  "npm": ">=9"
+}
+```
+
+That is the authoritative range: Node **>= 18 and < 23**, npm **>= 9**. Note the
+**upper bound** — Node 23+ is outside the declared range.
+
+- CI (`.github/workflows/ci.yml`) runs unit tests and both e2e jobs on a Node
+  `18, 20, 22` matrix; the `build` job pins Node `22`.
+- `docs/DEVELOPMENT.md` says "Node.js >= 18.0.0" with no upper bound. It is
+  out of step with `engines`; treat `engines` as correct.
+- **The measurements below were taken on Node `v26.7.0` / npm `11.19.0`** — above
+  the supported ceiling. They all passed, but any disagreement between these
+  numbers and a supported-Node run should be attributed to that first.
+
+## Install
+
+```bash
+npm install     # or `npm ci` for a lockfile-exact install (what CI uses)
+```
+
+`postinstall` runs `node scripts/postinstall.cjs`. It short-circuits when
+`ASM_SKIP_POSTINSTALL` or `CI` is set, or when the install is not global.
+
+## The four commands of record
+
+| Command             | Observed result                                                                                          | Wall time |
+| ------------------- | -------------------------------------------------------------------------------------------------------- | --------- |
+| `npm run build`     | **PASS** (exit 0) — `Built agent-skill-manager v2.15.0 (a46b652)`, `9 output(s) in dist/`                | ~1 s      |
+| `CI=true npm test`  | **PASS** (exit 0) — Test Files `60 passed (60)`, Tests **`2100 passed (2100)`**, vitest Duration 90.72 s | ~91 s     |
+| `npm run typecheck` | **PASS** (exit 0) — `tsc --noEmit`, no output                                                            | ~2 s      |
+| `npm run lint:site` | **PASS** (exit 0) — eslint over `website-src/src/**/*.{js,jsx}`, no findings                             | ~1 s      |
+
+`git status` was byte-identical before and after all four: none of them modify a
+tracked file. `npm run build` writes only to `dist/`, which is gitignored.
+
+### Two things `CI=true npm test` is not
+
+1. **`CI` does not sandbox the suite.** The only consumer of that variable in
+   this repo is `scripts/postinstall.cjs:20`; nothing under `src/`, `tests/`, or
+   `vitest.config.ts` reads it. `CI=true` is the command of record because it
+   matches how CI installs, not because it isolates anything. See the user-config
+   trap below.
+2. **`npm test` is not the whole suite.** It is `vitest run src/` — unit tests
+   only. The other runners: `npm run test:site` (`website-src/`), `npm run
+test:e2e` (`tests/e2e/`), and `npm run test:all` (unit + site + build + e2e).
+
+### Baseline note
+
+The 2026-08-19 modernization audit recorded **2099/2100 locally** and 2100/2100
+in CI at commit `ad961d2`. This run observed **2100/2100 locally** at `a46b652`.
+The difference is not a fix — it is the non-hermeticity described below. The test
+that flips (`src/skill-index.test.ts`, "indexes emilkowalski/skills with expected
+skills and install URLs") pins `emilkowalski/skills` to 11 named skills and reads
+the _developer's_ `~/.config/agent-skill-manager/skill-index/` merged over the
+bundled `data/skill-index/`. On this machine that user copy is currently
+byte-identical to the repo's `data/skill-index/emilkowalski_skills.json`, so the
+assertion holds by coincidence. A machine whose ingested index has drifted will
+see 2099/2100. Do not read a local 2100/2100 as evidence of hermeticity.
+
+## Trap 1 — scripts that rewrite tracked files
+
+Never run these as a casual probe. They are catalog-regeneration steps, not
+build steps, and they overwrite files that are committed:
+
+| Command                        | Rewrites                                                                                                                                                                                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `npm run preindex`             | `data/skill-index/*.json` — **57 tracked files**                                                                                                                                                                                            |
+| `npm run refresh:repo-bundles` | files under `data/skill-index/`                                                                                                                                                                                                             |
+| `npm run build:website`        | `scripts/build-catalog.ts` + `vite build`. Tracked outputs: `website/repo-stats.json`, `website/author-stats.json`, `website/index-stats.json` (each carries a fresh `generatedAt`, so every run produces a diff), and `website/robots.txt` |
+
+Everything else `build:website` emits — `catalog.json`, `skills.min.json`,
+`search.idx.json`, `skills/*.json`, `bundles.json`, `llms.txt`, `sitemap.xml`,
+the built React bundle and copied assets — is gitignored, so it produces no diff.
+`website/robots.txt` is rendered from `website-src/robots.txt`, which contains no
+`{{TOKEN}}` placeholders; the rewrite is currently byte-identical and shows no
+diff, but it is still an overwrite of a tracked file.
+
+`website/data/acknowledgements.json` is tracked but is an **input**, not an
+output — no script writes it.
+
+If you need the catalog regenerated, do it deliberately and review the resulting
+diff. Do not fold it into an unrelated change.
+
+## Trap 2 — the unit suite writes to your real user config
+
+`src/config.ts:16` computes `CONFIG_DIR` as `join(homedir(), ".config",
+"agent-skill-manager")` with no environment or dependency-injection override, so
+tests operate on the real directory. This is finding `F-TEST-001`.
+
+Observed during the `CI=true npm test` run above, in
+`~/.config/agent-skill-manager/`:
+
+```
+config.json                              (rewritten)
+.skill-lock.json                         (rewritten)
+registry-cache.json                      (rewritten)
+.tmp/                                    (touched)
+bundles/__test-modify-add-bundle__.json  (created by a test)
+```
+
+Consequences for an agent working here:
+
+- A test run mutates developer state. Back the directory up before running the
+  suite on a machine where that state matters.
+- Local pass/fail is machine-dependent. Reproduce a disagreement in CI, or on a
+  clean `~/.config/agent-skill-manager/`, before believing a local result.
+- `CI=true` does **not** prevent any of this (see above).
+
+This holds until the hermeticity work lands — modernization plan task 0.1,
+tracked as issue #436. After that, the local bar becomes 2100/2100 on a machine
+with a populated `~/.config/agent-skill-manager/`, and a run must leave the
+directory byte-identical.
+
+## Pre-commit hooks
+
+`.pre-commit-config.yaml` (install with `pre-commit install`) gates two stages:
+
+- **pre-commit:** local security check, prettier, `tsc --noEmit`, and
+  `npx vitest run src/`.
+- **pre-push:** `npm run build` and `npx vitest run tests/e2e/node-e2e.test.ts`.
+
+The `unit-tests` hook runs the same non-hermetic suite described above, so on a
+machine with a drifted skill index it can block a commit for a reason unrelated
+to the change. Confirm the failure is the known baseline one before working
+around it.
+
+## See also
+
+- `docs/DEVELOPMENT.md` — setup, debugging, project layout.
+- `docs/ARCHITECTURE.md` — component breakdown and data flow.

--- a/docs/AGENT_ENVIRONMENT.md
+++ b/docs/AGENT_ENVIRONMENT.md
@@ -49,8 +49,9 @@ npm install     # or `npm ci` for a lockfile-exact install (what CI uses)
 | `npm run typecheck` | **PASS** (exit 0) — `tsc --noEmit`, no output                                                            | ~2 s      |
 | `npm run lint:site` | **PASS** (exit 0) — eslint over `website-src/src/**/*.{js,jsx}`, no findings                             | ~1 s      |
 
-`git status --porcelain` was unchanged before and after all four — the same three
-untracked files, no tracked modifications. `npm run build` writes only to `dist/`, which is gitignored.
+`git status --porcelain` was unchanged before and after all four — no tracked
+modifications, and the same set of untracked scratch files either side.
+`npm run build` writes only to `dist/`, which is gitignored.
 
 ### Two things `CI=true npm test` is not
 
@@ -67,8 +68,8 @@ untracked files, no tracked modifications. `npm run build` writes only to `dist/
    `website-src/src/__tests__/` (`*.test.js` / `*.test.jsx`). Only the 6 files
    in `tests/e2e/` are excluded. Consequently `npm run test:site`
    (`vitest run website-src/`, those same 11 files) is a **subset** of
-   `npm test`, not a separate leg — and CI has no site-test job because
-   `npx vitest run src/` in the `unit-tests` job already covers it. The genuinely
+   `npm test`, not a separate leg — and CI needs no site-test job, since
+   `npx vitest run src/` in the `unit-tests` job already covers those files. The genuinely
    separate runners are `npm run test:e2e` (`tests/e2e/`) and `npm run test:all`
    (unit + site + build + e2e).
 
@@ -95,11 +96,11 @@ hermeticity.
 Never run these as a casual probe. They are catalog-regeneration steps, not
 build steps, and they overwrite files that are committed:
 
-| Command                        | Rewrites                                                                                                                                                                                                                                                                            |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `npm run preindex`             | the per-repo JSONs under `data/skill-index/` — up to **56 of the 57 tracked files**: it iterates only repos marked `enabled` in `data/skill-index-resources.json` (`scripts/preindex.ts:24-28`), and `github:luongnv89/asm` is disabled, so `luongnv89_asm.json` is never rewritten |
-| `npm run refresh:repo-bundles` | the same directory: it walks **every** `*.json` in `data/skill-index/`, recomputes the `bundles` field, and writes back only the files whose serialization changed (`scripts/refresh-repo-bundles.ts:18-45`)                                                                        |
-| `npm run build:website`        | `scripts/build-catalog.ts` + `vite build`. Tracked outputs: `website/repo-stats.json`, `website/author-stats.json`, `website/index-stats.json` (all three carry a `generatedAt` timestamp, so every run produces a diff), and `website/robots.txt`                                  |
+| Command                        | Rewrites                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `npm run preindex`             | the per-repo JSONs under `data/skill-index/` — up to **56 of the 57 tracked files**: it iterates only repos marked `enabled` in `data/skill-index-resources.json` (`scripts/preindex.ts:24-28`), and `github:luongnv89/asm` is disabled, so `luongnv89_asm.json` is never rewritten. **Also rewrites your real `~/.config/agent-skill-manager/skill-index/`**: `ingestRepo()` writes there first and `preindex` copies the result into `data/` (`scripts/preindex.ts:42-54`). That mutation shows in no git diff — see Trap 2 |
+| `npm run refresh:repo-bundles` | the same directory: it walks **every** `*.json` in `data/skill-index/`, recomputes the `bundles` field, and writes back only the files whose serialization changed (`scripts/refresh-repo-bundles.ts:18-45`)                                                                                                                                                                                                                                                                                                                  |
+| `npm run build:website`        | `scripts/build-catalog.ts` + `vite build`. Tracked outputs: `website/repo-stats.json`, `website/author-stats.json`, `website/index-stats.json` (all three carry a `generatedAt` timestamp, so every run produces a diff), and `website/robots.txt`                                                                                                                                                                                                                                                                            |
 
 Everything else `build:website` emits — `catalog.json`, `skills.min.json`,
 `search.idx.json`, `skills/*.json`, `bundles.json`, `llms.txt`, `sitemap.xml`,
@@ -121,8 +122,9 @@ diff. Do not fold it into an unrelated change.
 load, with no environment or dependency-injection override — `src/config.ts`
 contains no `process.env` reference at all. In-process tests therefore operate on
 the real directory. This is finding `F-TEST-001`. (Two partial escape hatches
-exist and cover only their own cases: `src/utils/test-spawn.ts` redirects
-`HOME`/`USERPROFILE` for tests that spawn the built CLI, and
+exist and cover only their own cases: `src/utils/test-spawn.ts` mirrors a
+caller-redirected `HOME` onto `USERPROFILE` so the sandbox survives on Windows —
+the redirect itself is done by each test that spawns the built CLI — and
 `resolveIndexedSkillByName(name, catalog?)` (`src/skill-index.ts:238-240`) takes
 an optional pre-loaded catalog so its callers can stay off the ambient user
 index. `loadAllIndices()` itself takes no arguments and always reads the real

--- a/docs/AGENT_ENVIRONMENT.md
+++ b/docs/AGENT_ENVIRONMENT.md
@@ -62,9 +62,10 @@ untracked files, no tracked modifications. `npm run build` writes only to `dist/
 2. **`npm test` is not the whole suite — but it is wider than it looks.** It is
    `vitest run src/`, and that argument is a **substring filter on the relative
    test path**, not a directory. `website-src/src/__tests__/…` contains `src/`,
-   so the site tests match too. The observed `60 passed (60)` is 49 `*.test.ts`
-   files under `src/` plus 11 under `website-src/`. Only the 4 files in
-   `tests/e2e/` are excluded. Consequently `npm run test:site`
+   so the site tests match too. The observed `60 passed (60)` is the 49 test
+   files under `src/` (47 `*.test.ts` plus 2 `*.test.tsx`) and the 11 under
+   `website-src/src/__tests__/` (`*.test.js` / `*.test.jsx`). Only the 6 files
+   in `tests/e2e/` are excluded. Consequently `npm run test:site`
    (`vitest run website-src/`, those same 11 files) is a **subset** of
    `npm test`, not a separate leg — and CI has no site-test job because
    `npx vitest run src/` in the `unit-tests` job already covers it. The genuinely
@@ -121,8 +122,11 @@ load, with no environment or dependency-injection override — `src/config.ts`
 contains no `process.env` reference at all. In-process tests therefore operate on
 the real directory. This is finding `F-TEST-001`. (Two partial escape hatches
 exist and cover only their own cases: `src/utils/test-spawn.ts` redirects
-`HOME`/`USERPROFILE` for tests that spawn the built CLI, and `loadAllIndices()`
-accepts an injectable catalog argument.)
+`HOME`/`USERPROFILE` for tests that spawn the built CLI, and
+`resolveIndexedSkillByName(name, catalog?)` (`src/skill-index.ts:238-240`) takes
+an optional pre-loaded catalog so its callers can stay off the ambient user
+index. `loadAllIndices()` itself takes no arguments and always reads the real
+user index directory merged over the bundled one.)
 
 Observed during the `CI=true npm test` run above, in
 `~/.config/agent-skill-manager/`:
@@ -162,9 +166,14 @@ pre-commit install --hook-type pre-commit --hook-type pre-push
 - **Commit stage:** the upstream `pre-commit-hooks` set (trailing-whitespace,
   end-of-file-fixer, check-yaml, check-json, check-added-large-files), the local
   security check, prettier, `tsc --noEmit`, and `npx vitest run src/`.
-- **Push stage:** `npm run build` and
-  `npx vitest run tests/e2e/node-e2e.test.ts` — plus prettier and `tsc --noEmit`
-  again, because those two declare no `stages:` and so run in every stage.
+- **Push stage:** `npm run build`,
+  `npx vitest run tests/e2e/node-e2e.test.ts` — plus everything above that is
+  not pinned to the commit stage, which is most of it. Only `security-check` and
+  `unit-tests` carry an explicit `stages: [pre-commit]`. prettier and
+  `tsc --noEmit` declare no `stages:` here, and all five upstream hooks also run
+  at push (trailing-whitespace, end-of-file-fixer and check-added-large-files
+  declare `stages: [pre-commit, pre-push, manual]` in the upstream manifest;
+  check-yaml and check-json declare none, which likewise means every stage).
 
 The `unit-tests` hook runs the same non-hermetic suite described above, so on a
 machine with a drifted skill index it can block a commit for a reason unrelated

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -37,6 +37,12 @@ npm test             # Run all tests
 npm run typecheck    # Type-check without emitting
 ```
 
+Verified results for `npm run build`, `CI=true npm test`, `npm run typecheck`,
+and `npm run lint:site`, the Node version constraints, and two repo-specific
+traps (scripts that rewrite tracked files; the unit suite writing to your real
+`~/.config/agent-skill-manager/`) are recorded in
+[AGENT_ENVIRONMENT.md](AGENT_ENVIRONMENT.md).
+
 Test files are co-located with source files using the `*.test.ts` convention.
 44 `*.test.ts` files live under `src/`, one per module — e.g. `cli.test.ts`,
 `scanner.test.ts`, `installer.test.ts`, `eval/*.test.ts`. Run `npm test` for


### PR DESCRIPTION
## Summary

Completes modernization-plan task **Pre.1**: record the install, build, and test
commands an agent needs, together with the two non-obvious traps in this repo.

Adds `docs/AGENT_ENVIRONMENT.md` and links it from `docs/DEVELOPMENT.md`.

Closes #433

## Approach

Every number in the new file was **measured on this branch**, not copied from the
audit. All four commands of record were run at base commit `a46b652`:

| Command | Observed | Wall time |
|---|---|---|
| `npm run build` | PASS (exit 0) — `Built agent-skill-manager v2.15.0 (a46b652)`, 9 outputs in `dist/` | ~1 s |
| `CI=true npm test` | PASS (exit 0) — 60/60 test files, **2100/2100 tests**, vitest Duration 90.72 s | ~91 s |
| `npm run typecheck` | PASS (exit 0) | ~2 s |
| `npm run lint:site` | PASS (exit 0) | ~1 s |

Three findings that changed what got written:

1. **Local run is 2100/2100, not the audit's 2099/2100.** That is not a fix. The
   flipping test (`src/skill-index.test.ts`, "indexes emilkowalski/skills …")
   merges the developer's `~/.config/agent-skill-manager/skill-index/` over the
   bundled `data/skill-index/`; on this machine that user copy is currently
   byte-identical to the repo's `emilkowalski_skills.json`, so the pin holds by
   coincidence. The doc says so explicitly, so nobody reads a local green as
   hermeticity.
2. **`CI=true` does not sandbox anything.** The only consumer of `process.env.CI`
   in the repo is `scripts/postinstall.cjs:20` — nothing in `src/`, `tests/`, or
   `vitest.config.ts` reads it. It is the command of record for CI parity only.
   Confirmed empirically: the test run rewrote `config.json`, `.skill-lock.json`,
   `registry-cache.json` and created
   `bundles/__test-modify-add-bundle__.json` in the real
   `~/.config/agent-skill-manager/` (finding `F-TEST-001`, tracked as #436).
3. **`build:website` rewrites four tracked files, not three.** The audit named the
   three stats JSONs; `scripts/build-catalog.ts` also renders
   `website/robots.txt` from `website-src/robots.txt`. That template carries no
   `{{TOKEN}}` placeholders, so the rewrite is currently byte-identical — but it
   is still an overwrite of a tracked file, and the doc says which of the two it
   is.

Measurements were taken on Node `v26.7.0` / npm `11.19.0`, which is **above** the
declared `engines` ceiling of `>=18 <23`. The doc records that adjacent to the
results rather than presenting them as in-range.

## Decision Record

**Selected option:** write the Pre.1 notes as a new standalone
`docs/AGENT_ENVIRONMENT.md`, linked from `docs/DEVELOPMENT.md`.

**Why not `CLAUDE.md`:** the plan's `Verify` line for Pre.1
(`test -s CLAUDE.md && grep -q 'CI=true npm test' CLAUDE.md`) is **circular** —
`CLAUDE.md` is created by task Pre.2 / issue #434, which depends on Pre.1 and is
resolved after it. Creating `CLAUDE.md` here would collapse two issues into one
PR. The three acceptance criteria never name a location; they say only "Notes
record …". #434 will create `CLAUDE.md` containing the literal string
`CI=true npm test` and pointing at this file, at which point the plan's `Verify`
line becomes true.

**Rejected — fold the notes into `docs/DEVELOPMENT.md`:** that file is a
human-onboarding guide; the audit-time measurement record needs its own commit
pin and re-verification note, and burying it would make both documents worse. A
link keeps the entry point.

**Out of scope, recorded not fixed:** `docs/DEVELOPMENT.md` states
`npm test # Run all tests` (it is `vitest run src/` only) and "Node.js >= 18.0.0"
with no upper bound. Both are noted inside `AGENT_ENVIRONMENT.md`; correcting
`DEVELOPMENT.md` itself belongs to a separate change.

## Changes

| File | Change |
|---|---|
| `docs/AGENT_ENVIRONMENT.md` | New — commands of record with measured results, `engines` guidance, the two traps, pre-commit stages |
| `docs/DEVELOPMENT.md` | +5 lines — link to the new notes from the Testing section |

## QA

Two rounds. Round 1 (resolver, light profile): a fresh reviewer fact-checked
every claim in the new file against the repository and found **3 blocking
factual errors**, all fixed in `e0f9585`:

1. **`vitest run src/` is a substring filter on the relative test path, not a
   directory scope.** `website-src/src/__tests__/…` contains `src/`, so the site
   tests run too — the observed `60 passed (60)` is the 49 files under `src/`
   plus the 11 under `website-src/`. `npm run test:site` is a *subset* of
   `npm test`, not a separate leg, which is also why CI has no site-test job.
2. **`preindex` rewrites up to 56 of the 57 tracked files, not all 57.** It
   iterates only repos marked `enabled` in `data/skill-index-resources.json`;
   `github:luongnv89/asm` is disabled, so `luongnv89_asm.json` is never touched.
3. **A plain `pre-commit install` installs the commit stage only.** The config
   sets no `default_install_hook_types`, so the `pre-push` hooks (`build`,
   `e2e-node`) silently never fire without `--hook-type pre-push`.

Round 2 (`/issue-pr-review`): an independent fact-check of every remaining
claim found **4 more factual errors**, fixed in `db58c4e`:

1. **`loadAllIndices()` takes no arguments.** The injectable-catalog escape
   hatch is `resolveIndexedSkillByName(name, catalog?)`
   (`src/skill-index.ts:238-240`); `loadAllIndices()` always reads the real user
   index directory merged over the bundled one.
2. **`tests/e2e/` holds 6 test files, not 4** — two are `*.test.tsx`
   (`tui-integration`, `tui-smoke`).
3. **`src/` holds 47 `*.test.ts` plus 2 `*.test.tsx`**, not 49 `*.test.ts`. The
   49 + 11 = 60 arithmetic was right; the glob label was not.
4. **All five upstream `pre-commit-hooks` also run at the push stage**, not just
   prettier and `tsc --noEmit`. Three declare
   `stages: [pre-commit, pre-push, manual]` upstream and two declare none; only
   `security-check` and `unit-tests` are commit-only.

Three further accuracy fixes landed in `4e26af4`: `preindex` also rewrites the real
`~/.config/agent-skill-manager/skill-index/` via `ingestRepo()` before copying
into `data/` (a mutation that shows in no git diff); `test-spawn.ts` mirrors a
caller-redirected `HOME` onto `USERPROFILE` rather than performing the redirect;
and a machine-specific untracked-file count plus an unsourced claim about CI's
missing site-test job were dropped.

Six non-blocking notes were folded in as well: the upstream commit-stage hooks
are now listed, `prettier`/`typecheck` are noted as running in both stages (they
declare no `stages:`), `src/config.ts:15-16` is quoted literally with its two
partial escape hatches named, and the 2099→2100 shift is explained by the
`emilkowalski/skills` pin moving from 8 to 11 at `a46b652` rather than left as
"coincidence".

## Test Results

Documentation-only; no test code added or changed.

- `CI=true npm test` — **2100/2100 passed**, 60/60 files, re-run green at the final
  commit `e0f9585`; CI re-ran green on the 18/20/22 matrix at `db58c4e` and
  `4e26af4`
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm run lint:site` — pass
- `npx vitest run tests/e2e/node-e2e.test.ts` — 74/74 passed (pre-push hook stage)
- `npx prettier --check docs/AGENT_ENVIRONMENT.md docs/DEVELOPMENT.md` — pass

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|---|---|---|
| Notes record `npm run build`, `CI=true npm test`, `npm run typecheck`, `npm run lint:site` with their audit-time results | ✅ | "The four commands of record" table — each command actually run on this branch at `a46b652`, with exit status, counts, and wall time |
| Notes state that `preindex` and `build:website` mutate tracked `data/` and `website/`, and that the unit suite writes to the real user config until 0.1 lands | ✅ | "Trap 1 — scripts that rewrite tracked files" (the 57 tracked `data/skill-index/*.json`, written per `enabled` repo; the three `website/*-stats.json` plus `website/robots.txt`) and "Trap 2 — the unit suite writes to your real user config" (observed file list, `F-TEST-001`, gated on task 0.1 / #436) |
| Node version guidance matches `package.json` `engines` at the time of writing | ✅ | "Node and npm" quotes `">=18 <23"` and `">=9"` literally, flags the upper bound, and notes the measurement host was Node v26.7.0 |

Part of #432
