### PR TITLE
docs(agents): add CLAUDE.md project context for coding agents (#434)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,8 @@ state a floor with no ceiling, and `engines` is the one that is correct.
   machine-dependent. `CI=true` sandboxes nothing.
 - A local failure in `src/skill-index.test.ts` is usually that non-hermeticity, not
   the change under review. Confirm against CI before "fixing" it.
-- Never commit `dist/`, `node_modules/`, or generated website artifacts.
+- Never commit `dist/` or `node_modules/`. Most of `website/` is gitignored, but its
+  `*-stats.json` and `robots.txt` are tracked — commit those only on a deliberate regeneration.
 - Never delete or rewrite untracked scratch files at the repo root; other sessions
   own them.
 - Conventional Commits; branch from `main` as `<type>/<issue>-<description>`; PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+`agent-skill-manager` (`asm`) — a TypeScript CLI plus ink/React TUI that manages
+Agent Skills installed for Claude Code, Codex, Gemini, and OpenClaw.
+
+## Critical commands
+
+```bash
+npm install          # postinstall no-ops when CI or ASM_SKIP_POSTINSTALL is set
+npm run build        # tsx scripts/build.ts -> dist/ (gitignored)
+CI=true npm test     # unit suite — the command of record
+npm run typecheck    # tsc --noEmit
+npm run lint:site    # eslint over website-src/src
+npm run test:e2e     # tests/e2e/ — NOT covered by `npm test`
+npm start            # run the TUI from source
+```
+
+`npm test` is `vitest run src/`, and that argument is a **substring filter on the
+test path**, not a directory — `website-src/src/__tests__/` matches it too, so
+`npm run test:site` is a subset of `npm test`, not a separate leg. Only
+`tests/e2e/` is excluded. Measured timings and evidence: `docs/AGENT_ENVIRONMENT.md`.
+
+Node and npm must satisfy `package.json` `engines` — node `">=18 <23"`, npm
+`">=9"`. Mind the upper bound: `CONTRIBUTING.md` and `docs/DEVELOPMENT.md` still
+state a floor with no ceiling, and `engines` is the one that is correct.
+
+## Architecture map
+
+- `bin/agent-skill-manager.ts` — entry point: args go to `src/cli.ts`, none to the TUI.
+- `src/cli.ts` — ~30 `cmd*` handlers, all output through `src/formatter.ts`.
+- `src/index.tsx` + `src/views/` — the ink/React TUI.
+- `src/*.ts` — one module per domain (scanner, installer, auditor, skill-index, …),
+  each with its `*.test.ts` beside it.
+- `data/skill-index/` — committed per-repo index JSON; generated, never hand-edited.
+- `website-src/` — site source; `website/` — its published output.
+- `scripts/` — build, preindex, catalog generation.
+- Detail: `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`.
+
+## Hard rules
+
+- **YOU MUST NOT run `npm run preindex`, `npm run build:website`, or
+  `npm run refresh:repo-bundles` as a probe.** They rewrite tracked files under
+  `data/skill-index/` and `website/`. Run them only when regenerating the catalog
+  is the point of the change, then review the diff.
+- **IMPORTANT: `npm run preindex` also rewrites the developer's real
+  `~/.config/agent-skill-manager/skill-index/`** — a mutation no git diff shows.
+- **IMPORTANT: the unit suite writes to the real `~/.config/agent-skill-manager/`.**
+  `src/config.ts` derives that path from `homedir()` at module load with no
+  override, so tests mutate developer state and local results are
+  machine-dependent. `CI=true` sandboxes nothing.
+- A local failure in `src/skill-index.test.ts` is usually that non-hermeticity, not
+  the change under review. Confirm against CI before "fixing" it.
+- Never commit `dist/`, `node_modules/`, or generated website artifacts.
+- Never delete or rewrite untracked scratch files at the repo root; other sessions
+  own them.
+- Conventional Commits; branch from `main` as `<type>/<issue>-<description>`; PR
+  into `main`.
+
+## Workflow preferences
+
+- Iterate with the narrowest runner — `npx vitest run src/<module>.test.ts` — and
+  run `CI=true npm test` only before pushing.
+- Run `npm run typecheck` after a series of edits; do not wait for the commit hook.
+- Change `src/<name>.ts` and its `src/<name>.test.ts` together.
+- Install both hook stages; a plain `pre-commit install` silently skips pre-push:
+  `pre-commit install --hook-type pre-commit --hook-type pre-push`.
+- Prettier runs on commit — do not hand-format markdown, TS, or JSON to match it.
+- Keep changes minimal and scoped to the task; do not opportunistically refactor.
+
+## Token Efficiency
+
+- Never re-read files you just wrote or edited. You know the contents.
+- Never re-run commands to "verify" unless the outcome was uncertain.
+- Don't echo back large blocks of code or file contents unless asked.
+- Batch related edits into single operations. Don't make 5 edits when 1 handles it.
+- Skip confirmations like "I'll continue..." Just do it.
+- If a task needs 1 tool call, don't use 3. Plan before acting.
+- Do not summarize what you just did unless the result is ambiguous or you need additional input.


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md` at the repo root — the project context an agent loads at session
start. It names the four commands of record established by #433 and carries this
repo's two non-obvious mutation traps as short warnings, linking to
`docs/AGENT_ENVIRONMENT.md` for the full measured detail rather than duplicating it.

Closes #434

## Approach

Authored to the `/agent-config` `create` checklist: under 80 lines, the five
required sections (Critical commands, Architecture map, Hard rules, Workflow
preferences, and What-NOT-to-include by absence), and the mandatory verbatim
`## Token Efficiency` block.

Every factual claim is taken from the repository itself, not restated from memory:
the command list and `engines` range from `package.json`, the substring-filter
behaviour of `npm test` and both traps from `docs/AGENT_ENVIRONMENT.md`, the
module map from `docs/ARCHITECTURE.md`, and the two-stage hook install from
`.pre-commit-config.yaml`.

Per `references/anti-patterns.md`, no frequently-changing information is included:
no version numbers, no dated audit test counts, no ticket IDs. The hermeticity
trap is stated as a durable behavioural rule instead.

## Decision Record

**Root cause:** `CLAUDE.md` has never existed in this repo, so no project context
loads for an agent at session start. The declared dependency on #433 is effectively
circular — #433's verify line greps this very file — so the two issues are one
artifact split across two tickets.

**Options considered:**

| # | Option | Outcome |
|---|--------|---------|
| 1 | Minimal create satisfying only the two issue ACs | Rejected — would fail `/agent-config`'s own acceptance gate (no Token Efficiency block, three of five sections missing) and be reopened by a later audit. |
| 2 | Create via `/agent-config` to the skill's full checklist | **Selected** — satisfies both issue ACs and #433's verify line in one artifact, and passes the prescribed skill's gate. |
| 3 | Create `CLAUDE.md` and `AGENTS.md` in one run | Rejected — couples #435 into this PR, breaking issue atomicity, and risks violating that issue's no-commands content firewall. |

**Selected option:** #2 — a full-checklist create carrying #433's recorded
commands as the Critical commands section, linking out for detail.

**Residual risk:** `/agent-config`'s mandatory repo-sync step was deliberately
skipped. It runs `git stash push -u` on a dirty tree, which in this working tree
would have swept away another session's untracked files. The skill's own edge
cases permit proceeding without sync; `main` was already synced to `origin` at
`de71b30`, so nothing was lost by skipping it.

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | New — 79 lines of project context: critical commands, architecture map, hard rules, workflow preferences, token-efficiency block. |

No source, test, or configuration file is touched.

## Test Results

Documentation-only change; no code path is affected and no test was added or
modified. `git grep` confirms no module reads a repo-root `CLAUDE.md`, so runtime
impact is nil.

The full pre-commit gate ran on this commit and passed end to end:

```
trailing-whitespace  Passed      prettier      Passed
end-of-file-fixer    Passed      unit tests    Passed
check-added-large-files Passed   security check Passed
```

The `unit-tests` hook is `npx vitest run src/` — the same suite as
`CI=true npm test` — and it passed on this branch.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `CLAUDE.md` exists at the repo root | PASS | `test -f CLAUDE.md` → true; the file is the sole entry in this diff. |
| 2 | `CLAUDE.md` names the recorded build/test commands from Pre.1 | PASS | All four appear: `npm run build`, `CI=true npm test`, `npm run typecheck`, `npm run lint:site`. |
| 3 | #433 verify line: `test -s CLAUDE.md && grep -q 'CI=true npm test' CLAUDE.md` | PASS | `grep -c 'CI=true npm test' CLAUDE.md` → 2. |
| 4 | `/agent-config` gate: `## Token Efficiency` block present, file under 80 lines | PASS | Block present verbatim at line 71; file is 79 lines. |
| 5 | Scope: `AGENTS.md` not created, `docs/AGENT_ENVIRONMENT.md` not modified | PASS | One file in the diff. |

<!-- gitissue:qa v1 head=f149a6f5b857b2ef7b6aa9babd2848ed777d487c profile=light cycles=1 review=clean ui=none -->

