### PR TITLE
docs(agents): add AGENTS.md subagent definitions (#435)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,11 +33,11 @@ You own `data/skill-index/*.json` and `data/skill-index-resources.json`.
 These files are generated, never hand-edited. Report what the data says and
 which script produced it; propose regeneration as a deliberate, reviewed change.
 Boundary: never edit a file under `data/`, and never run the catalog- or
-index-regeneration scripts in `scripts/` (preindex, refresh-repo-bundles,
-build-website). They rewrite tracked files under `data/skill-index/` and
-`website/` **and** mutate the developer's real
-`~/.config/agent-skill-manager/skill-index/`, which no diff shows. See
-`CLAUDE.md` → Hard rules and `docs/AGENT_ENVIRONMENT.md` → Trap 1.
+index-regeneration scripts in `scripts/` (`preindex.ts`,
+`refresh-repo-bundles.ts`, `build-catalog.ts`). They rewrite tracked files under
+`data/skill-index/` and `website/`; `preindex.ts` **additionally** mutates the
+developer's real `~/.config/agent-skill-manager/skill-index/`, which no diff
+shows. See `CLAUDE.md` → Hard rules and `docs/AGENT_ENVIRONMENT.md` → Trap 1.
 Output: findings as `path:line` references plus a one-line verdict.
 ```
 
@@ -125,8 +125,8 @@ that only manifests in the output.
 
 ## Editing this file
 
-`asm` itself manages parts of a project-root `AGENTS.md`: `src/uninstaller.ts`
-adds and removes regions delimited by
+`asm` itself treats a project-root `AGENTS.md` as a file it manages:
+`src/uninstaller.ts` detects and removes regions delimited by
 `<!-- agent-skill-manager: <skill> -->` … `<!-- /agent-skill-manager: <skill> -->`.
 Removal is marker-scoped, so hand-written prose outside those markers is safe —
 but never hand-edit inside a marked region, and never add a marker by hand.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+# AGENTS.md
+
+Subagent definitions for `agent-skill-manager` (`asm`) — which specialised
+agents this repo wants, what each owns, when to delegate, and where each must
+stop.
+
+Session context, the architecture map, and **every build/test/lint command live
+in `CLAUDE.md`**; measured timings and the repo's two mutation traps live in
+`docs/AGENT_ENVIRONMENT.md`. This file deliberately carries **no commands** — a
+second copy would drift. Delegating agents read those two files first.
+
+The `.claude/`, `.codex/`, `.gemini/`, `.opencode/` and `.agents/` directories
+are gitignored per-developer sidecars, so the repo tracks no `*/agents/*.md`
+definitions. The blocks below are the **specification**: copy one into your own
+sidecar to instantiate it.
+
+## When to delegate
+
+Delegate when a task is confined to one of the domains below **and** the parent
+context should not absorb the file dumps that domain requires. A change that
+spans `src/` and `data/` is the parent's job, not a subagent's.
+
+## Definitions
+
+```markdown
+---
+name: skill-index-curator
+description: Investigates the committed skill index and catalog data under data/
+tools: Read, Grep, Glob
+---
+
+You own `data/skill-index/*.json` and `data/skill-index-resources.json`.
+These files are generated, never hand-edited. Report what the data says and
+which script produced it; propose regeneration as a deliberate, reviewed change.
+Boundary: never edit a file under `data/`, and never run the catalog- or
+index-regeneration scripts in `scripts/` (preindex, refresh-repo-bundles,
+build-website). They rewrite tracked files under `data/skill-index/` and
+`website/` **and** mutate the developer's real
+`~/.config/agent-skill-manager/skill-index/`, which no diff shows. See
+`CLAUDE.md` → Hard rules and `docs/AGENT_ENVIRONMENT.md` → Trap 1.
+Output: findings as `path:line` references plus a one-line verdict.
+```
+
+```markdown
+---
+name: cli-surface-reviewer
+description: Reviews changes to the CLI command surface and its output
+tools: Read, Grep, Glob
+---
+
+You own `bin/agent-skill-manager.ts` and `src/cli.ts` — roughly thirty `cmd*`
+handlers. Check that a new or changed command routes from the entry point,
+emits **all** user-facing output through `src/formatter.ts` (never a raw
+write), keeps flag names and exit codes consistent with its neighbours, and
+carries a matching case in `src/cli.test.ts`.
+Boundary: do not touch `src/views/` or `src/index.tsx` — argv goes to the CLI,
+no argv goes to the TUI. Report, do not refactor.
+Output: blocking issues first, each with `path:line` and a concrete fix.
+```
+
+```markdown
+---
+name: tui-reviewer
+description: Reviews the ink/React terminal UI in src/index.tsx and src/views/
+tools: Read, Grep, Glob
+---
+
+You own the ink/React TUI: `src/index.tsx` and `src/views/`. Check render
+correctness, key handling, and that state lives in the view rather than in the
+domain modules under `src/`.
+Boundary: **`console.log` interferes with the terminal UI**
+(`docs/DEVELOPMENT.md:70`) — flag any that a change introduces. Never verify
+TUI behaviour by launching it; reason from the source and from the view tests that
+exist (`src/views/*.test.tsx`).
+Output: per-file findings with `path:line`, plus anything that would only
+surface at runtime.
+```
+
+```markdown
+---
+name: test-hermeticity-auditor
+description: Audits tests for reads and writes outside the repository
+tools: Read, Grep, Glob
+---
+
+You detect tests that touch developer state. `src/config.ts:15-16` computes the
+config directory from `homedir()` at module load with no override, so in-process
+tests operate on the real `~/.config/agent-skill-manager/`. This is finding
+`F-TEST-001`, tracked as issue #436.
+When a local failure appears in `src/skill-index.test.ts`, the first hypothesis
+is that non-hermeticity, **not** the change under review — say so, and ask for
+a CI result before anything gets "fixed".
+Boundary: audit only. Do not edit `src/` or `tests/`, and do not run the suite
+to reproduce — a run mutates the very directory you are auditing
+(`docs/AGENT_ENVIRONMENT.md` → Trap 2).
+Output: a table of test file → external path touched → mechanism.
+```
+
+```markdown
+---
+name: website-content-reviewer
+description: Reviews website-src/ changes and their generated output in website/
+tools: Read, Grep, Glob
+---
+
+You own `website-src/` (source) and the boundary with `website/` (generated
+output). Most of `website/` is gitignored, but `website/*-stats.json`,
+`website/robots.txt` and `website/data/acknowledgements.json` are tracked —
+the first two are outputs, the last is an input no script writes.
+Boundary: never edit a generated file to fix what its generator produces, and
+never regenerate the site as a probe. Route generator bugs to `scripts/`.
+Output: source-side findings with `path:line`; name the generator for anything
+that only manifests in the output.
+```
+
+## Shared boundaries
+
+- Every agent above is **read-only by default**; the parent applies edits.
+- Ground each claim in a `path:line` reference. An unverifiable claim is a
+  question, not a finding.
+- Keep to one domain. Hand back anything outside your files instead of widening
+  scope.
+- Never delete or rewrite untracked scratch files at the repo root — other
+  sessions own them.
+
+## Editing this file
+
+`asm` itself manages parts of a project-root `AGENTS.md`: `src/uninstaller.ts`
+adds and removes regions delimited by
+`<!-- agent-skill-manager: <skill> -->` … `<!-- /agent-skill-manager: <skill> -->`.
+Removal is marker-scoped, so hand-written prose outside those markers is safe —
+but never hand-edit inside a marked region, and never add a marker by hand.
+
+## Token Efficiency
+
+- Never re-read files you just wrote or edited. You know the contents.
+- Never re-run commands to "verify" unless the outcome was uncertain.
+- Don't echo back large blocks of code or file contents unless asked.
+- Batch related edits into single operations. Don't make 5 edits when 1 handles it.
+- Skip confirmations like "I'll continue..." Just do it.
+- If a task needs 1 tool call, don't use 3. Plan before acting.
+- Do not summarize what you just did unless the result is ambiguous or you need additional input.


### PR DESCRIPTION
Closes #435

## Summary

Adds `AGENTS.md` at the repo root (plan task **Pre.3**, milestone ME). The file is
written against agent-config's **AGENTS.md** guidance — subagent definitions — and
deliberately carries **no build/test/lint commands**: acceptance criterion 2 keeps the
command inventory in `CLAUDE.md` (#434) and `docs/AGENT_ENVIRONMENT.md` (#433), and
`AGENTS.md` points at both rather than copying them. Five repo-specific agent roles are
specified, each with `name` / `description` / `tools` frontmatter, a purpose, and an
explicit boundary grounded in a verified `path:line` in this repo.

## Approach

Option 2 — **Subagent-definition catalog per agent-config**. The repo tracks no subagent
definitions (`.claude/`, `.codex/`, `.gemini/`, `.opencode/` and `.agents/` are gitignored
per-developer sidecars, `.gitignore:56`), so the definitions are authored from scratch and
the file is framed as the *specification* to copy into a sidecar, not a description of
files that exist. Roles: `skill-index-curator`, `cli-surface-reviewer`, `tui-reviewer`,
`test-hermeticity-auditor`, `website-content-reviewer`.

## Decision Record

- **Root cause:** `AGENTS.md` has never existed, and `.gitignore`'s untracked-sidecar policy
  means the repo holds no tracked subagent definitions to harvest, so the definitions must be
  authored from scratch against agent-config's AGENTS.md guidance while keeping build/test
  commands out per AC2.
- **Options considered:** Option 1 — Vendor-neutral project brief; Option 2 — Subagent-definition
  catalog per agent-config; Option 3 — Catalog plus formalising the existing agent prompts
- **Options rejected:** Option 1 — violates AC2 by putting build/test commands in `AGENTS.md`,
  and duplicates `CLAUDE.md`; Option 3 — editing a shipped skill's internals
  (`skills/skill-creator/agents/*.md`) is out of scope for a size:S documentation create
- **Selected option:** Option 2 — Subagent-definition catalog per agent-config
- **Residual risk:** agent-config's `claude-md-checklist.md` §4 mandates a *Critical commands*
  section, which AC2 forbids here; the checklist's own "or have a clear reason for omission"
  clause covers it, and the omission is recorded in the table below. `src/uninstaller.ts:52`
  treats a project-root `AGENTS.md` as a file `asm` manages, so the new file carries an
  *Editing this file* section explaining the marker-scoped regions
  (`<!-- agent-skill-manager: <skill> -->`); removal is marker-scoped and
  `src/uninstaller.test.ts` asserts an unmarked file is not rewritten, so the coexistence is
  behaviourally safe. Plan task 3.5 (#457) verifies root docs with `ls *.md` and will need to
  whitelist the two files Pre.2 and Pre.3 legitimately add.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `main @ ad961d2` (2026-08-19)

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | New. Scope note pointing at `CLAUDE.md` / `docs/AGENT_ENVIRONMENT.md` for commands, a *When to delegate* rule, five subagent definitions with frontmatter and boundaries, shared boundaries, an *Editing this file* note about `asm`'s marker-managed regions, and the mandatory *Token Efficiency* block. |

## Test Results

- Unit tests: 2100 passed (60 files) — `CI=true npm test` at `b00f5aa` (and again at `b940485`)
- Integration tests: covered by the unit suite (CLI integration specs run under `src/`)
- E2e tests: skipped — documentation-only change, no runtime surface touched
- Build: not run — no source change; the pre-commit typecheck hook was a no-op for a markdown-only diff
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `AGENTS.md` exists at the repo root | pass | `AGENTS.md` added at the repo root; `test -f AGENTS.md` succeeds |
| `AGENTS.md` is written against agent-config's checklists only (subagent definitions); build/test commands stay in Pre.1 notes and `CLAUDE.md` | pass | Content is five subagent definitions with `name`/`description`/`tools` frontmatter per agent-config's *AGENTS.md Guidelines*. `grep -nE 'npm (run \|ci\|test\|install)\|CI=true\|vitest\|tsc \|eslint\|prettier --' AGENTS.md` returns **nothing** at `b00f5aa`. Commands are referenced by pointer to `CLAUDE.md` and `docs/AGENT_ENVIRONMENT.md`, never restated. |
| agent-config: mandatory *Token Efficiency* block present | pass | `grep -c '^## Token Efficiency' AGENTS.md` → 1. Included per the skill's non-negotiable rule even though `CLAUDE.md` carries the same block; the block is content-neutral and does not restate commands. |
| agent-config `claude-md-checklist.md` §4 — *Critical commands* section | unverified (N/A) | Deliberately omitted. That checklist is the **CLAUDE.md** audit standard and its §4 preamble allows omission with "a clear reason": acceptance criterion 2 of this issue confines command inventory to `CLAUDE.md` and `docs/AGENT_ENVIRONMENT.md`. Including it would fail the issue. |

## QA

One review cycle (light profile). The reviewer found one blocking factual error and two
accuracy nits, all three fixed in `b00f5aa`:

- **Blocking:** the *Editing this file* section said `src/uninstaller.ts` "adds and removes"
  the marker regions. No code in the repo writes an opening marker — `src/uninstaller.ts`
  only detects (`:529`) and removes (`:188-221`). Reworded to "detects and removes".
- The `skill-index-curator` boundary broadened a `preindex`-only `~/.config` mutation to all
  three regeneration scripts, softly contradicting `CLAUDE.md` and `docs/AGENT_ENVIRONMENT.md`.
  Scoped back to `preindex.ts`.
- The script list named a non-existent `build-website`; corrected to the real
  `scripts/build-catalog.ts`.

No second review pass ran (light profile caps QA at one cycle), so this PR carries no QA
handoff marker — `/issue-pr-review` should run its full review.

## Notes

- Scope is exactly one new file. `CLAUDE.md` and `docs/AGENT_ENVIRONMENT.md` are unmodified;
  no `.claude/agents/*.md` files were created (that directory is gitignored).
- Every `path:line` claim in the new file was verified against the tree at `b00f5aa`.
