### PR TITLE
fix(test): sandbox the unit suite away from host config (#436)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,16 +83,16 @@ description: Audits tests for reads and writes outside the repository
 tools: Read, Grep, Glob
 ---
 
-You detect tests that touch developer state. `src/config.ts:15-16` computes the
-config directory from `homedir()` at module load with no override, so in-process
-tests operate on the real `~/.config/agent-skill-manager/`. This is finding
-`F-TEST-001`, tracked as issue #436.
-When a local failure appears in `src/skill-index.test.ts`, the first hypothesis
-is that non-hermeticity, **not** the change under review — say so, and ask for
-a CI result before anything gets "fixed".
-Boundary: audit only. Do not edit `src/` or `tests/`, and do not run the suite
-to reproduce — a run mutates the very directory you are auditing
-(`docs/AGENT_ENVIRONMENT.md` → Trap 2).
+You detect tests that touch developer state. `src/config.ts` `getConfigDir()`
+reads `ASM_CONFIG_DIR` (else `~/.config/agent-skill-manager`); vitest
+`src/test-setup.ts` must set `HOME`/`USERPROFILE`/`ASM_CONFIG_DIR` to a temp
+dir so in-process tests never use the real user config. F-TEST-001 (#436)
+closed that hole — flag any new `homedir()` / config-path read that ignores
+those overrides, or any removal of `setupFiles`.
+When a local failure appears in `src/skill-index.test.ts`, check that the
+sandbox is still wired (`ASM_CONFIG_DIR` in `src/test-setup.ts`) before
+assuming host-index pollution.
+Boundary: audit only. Do not edit `src/` or `tests/`.
 Output: a table of test file → external path touched → mechanism.
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Make the unit suite hermetic: `getConfigDir()` honors `ASM_CONFIG_DIR`, and vitest sandboxes `HOME`/`USERPROFILE`/`ASM_CONFIG_DIR` so tests no longer read or write `~/.config/agent-skill-manager` ([#436](https://github.com/luongnv89/asm/issues/436))
+
 ### Features
 
 - Add `asm get <skill>` — a zero-residency reference tier that resolves a skill through the installed / library / index / registry ladder (plus any `asm install` shorthand) and writes its `SKILL.md` body to stdout without installing anything; remote fetches run the same pre-install security scan, reported on stderr and under `--json` ([#422](https://github.com/luongnv89/asm/issues/422)) — @luongnv89

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,12 +44,12 @@ state a floor with no ceiling, and `engines` is the one that is correct.
   is the point of the change, then review the diff.
 - **IMPORTANT: `npm run preindex` also rewrites the developer's real
   `~/.config/agent-skill-manager/skill-index/`** — a mutation no git diff shows.
-- **IMPORTANT: the unit suite writes to the real `~/.config/agent-skill-manager/`.**
-  `src/config.ts` derives that path from `homedir()` at module load with no
-  override, so tests mutate developer state and local results are
-  machine-dependent. `CI=true` sandboxes nothing.
-- A local failure in `src/skill-index.test.ts` is usually that non-hermeticity, not
-  the change under review. Confirm against CI before "fixing" it.
+- **Unit tests sandbox user state.** `src/test-setup.ts` (vitest `setupFiles`)
+  sets `HOME`, `USERPROFILE`, and `ASM_CONFIG_DIR` to a temp dir. `getConfigDir()`
+  in `src/config.ts` reads `ASM_CONFIG_DIR` (fallback `~/.config/agent-skill-manager`).
+  Do not remove that setup — without it the suite writes the real user config.
+- **IMPORTANT: `CI=true` does not itself isolate the suite**; hermeticity is the
+  env override + lazy `getConfigDir()`, not the `CI` flag.
 - Never commit `dist/` or `node_modules/`. Most of `website/` is gitignored, but its
   `*-stats.json` and `robots.txt` are tracked — commit those only on a deliberate regeneration.
 - Never delete or rewrite untracked scratch files at the repo root; other sessions

--- a/docs/AGENT_ENVIRONMENT.md
+++ b/docs/AGENT_ENVIRONMENT.md
@@ -115,44 +115,26 @@ output — no script writes it.
 If you need the catalog regenerated, do it deliberately and review the resulting
 diff. Do not fold it into an unrelated change.
 
-## Trap 2 — the unit suite writes to your real user config
+## Trap 2 — do not remove the unit-suite sandbox
 
-`src/config.ts:15-16` computes `const HOME = homedir()` and then
-`const CONFIG_DIR = join(HOME, ".config", "agent-skill-manager")`, at module
-load, with no environment or dependency-injection override — `src/config.ts`
-contains no `process.env` reference at all. In-process tests therefore operate on
-the real directory. This is finding `F-TEST-001`. (Two partial escape hatches
-exist and cover only their own cases: `src/utils/test-spawn.ts` mirrors a
-caller-redirected `HOME` onto `USERPROFILE` so the sandbox survives on Windows —
-the redirect itself is done by each test that spawns the built CLI — and
-`resolveIndexedSkillByName(name, catalog?)` (`src/skill-index.ts:238-240`) takes
-an optional pre-loaded catalog so its callers can stay off the ambient user
-index. `loadAllIndices()` itself takes no arguments and always reads the real
-user index directory merged over the bundled one.)
+F-TEST-001 (#436) is closed: in-process tests must not read or write the real
+`~/.config/agent-skill-manager/`. Two pieces keep that true:
 
-Observed during the `CI=true npm test` run above, in
-`~/.config/agent-skill-manager/`:
+- `getConfigDir()` in `src/config.ts` reads `process.env.ASM_CONFIG_DIR`, falling
+  back to `join(homedir(), ".config", "agent-skill-manager")`. Bundles and the
+  registry cache default under that directory (or `ASM_REGISTRY_CACHE`).
+- Vitest `setupFiles`: `src/test-setup.ts` points `HOME`, `USERPROFILE`, and
+  `ASM_CONFIG_DIR` at a per-file temp dir _before_ any `src/` import. That also
+  covers leftover `homedir()` sites (scanner, uninstaller, `~` expansion).
 
-```
-config.json                              (rewritten)
-.skill-lock.json                         (rewritten)
-registry-cache.json                      (rewritten)
-.tmp/                                    (touched)
-bundles/__test-modify-add-bundle__.json  (created by a test)
-```
+`src/utils/test-spawn.ts` still mirrors a redirected `HOME` onto `USERPROFILE`
+for spawned CLI processes on Windows. `CI=true` still does not isolate anything
+by itself — the env override does.
 
-Consequences for an agent working here:
-
-- A test run mutates developer state. Back the directory up before running the
-  suite on a machine where that state matters.
-- Local pass/fail is machine-dependent. Reproduce a disagreement in CI, or on a
-  clean `~/.config/agent-skill-manager/`, before believing a local result.
-- `CI=true` does **not** prevent any of this (see above).
-
-This holds until the hermeticity work lands — modernization plan task 0.1,
-tracked as issue #436. After that, the local bar becomes 2100/2100 on a machine
-with a populated `~/.config/agent-skill-manager/`, and a run must leave the
-directory byte-identical.
+A regression looks like a test (or a removed `setupFiles` entry) resolving
+config paths from the host `homedir()` again. Audit with
+`getConfigDir() === process.env.ASM_CONFIG_DIR` and by hashing
+`~/.config/agent-skill-manager` before and after `CI=true npm test`.
 
 ## Pre-commit hooks
 

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -1,8 +1,8 @@
 import { readFile, writeFile, readdir, access, mkdir, rm } from "fs/promises";
 import { join, resolve, dirname } from "path";
-import { homedir } from "os";
 import { fileURLToPath } from "url";
 import { debug } from "./logger";
+import { getConfigDir } from "./config";
 import { readLock } from "./utils/lock";
 import { loadAllIndices } from "./skill-index";
 import { repoBundlesForIndex } from "./repo-bundles";
@@ -17,8 +17,6 @@ import type {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
-const BUNDLE_DIR = join(homedir(), ".config", "agent-skill-manager", "bundles");
 
 /**
  * Path to the shipped (predefined) bundles directory bundled with ASM.
@@ -152,11 +150,11 @@ export async function skillInfoToRef(
 // ─── Bundle Storage ────────────────────────────────────────────────────────
 
 export function getBundleDir(): string {
-  return BUNDLE_DIR;
+  return join(getConfigDir(), "bundles");
 }
 
 export async function ensureBundleDir(): Promise<void> {
-  await mkdir(BUNDLE_DIR, { recursive: true });
+  await mkdir(getBundleDir(), { recursive: true });
 }
 
 function sanitizeBundleName(name: string): string {
@@ -180,7 +178,7 @@ function sanitizeBundleName(name: string): string {
 export async function saveBundle(bundle: BundleManifest): Promise<string> {
   await ensureBundleDir();
   const filename = `${sanitizeBundleName(bundle.name)}.json`;
-  const filePath = join(BUNDLE_DIR, filename);
+  const filePath = join(getBundleDir(), filename);
   await writeFile(filePath, JSON.stringify(bundle, null, 2) + "\n", "utf-8");
   debug(`bundle: saved to ${filePath}`);
   return filePath;
@@ -232,7 +230,7 @@ export async function loadBundle(nameOrPath: string): Promise<BundleManifest> {
 
   // Look in the user bundles directory first
   const filename = `${sanitizeBundleName(nameOrPath)}.json`;
-  const filePath = join(BUNDLE_DIR, filename);
+  const filePath = join(getBundleDir(), filename);
 
   try {
     return await readBundleFile(filePath);
@@ -326,21 +324,21 @@ export async function listBundles(): Promise<BundleManifest[]> {
   const bundles: BundleManifest[] = [];
 
   try {
-    await access(BUNDLE_DIR);
+    await access(getBundleDir());
   } catch {
     return bundles;
   }
 
   let entries: string[];
   try {
-    entries = await readdir(BUNDLE_DIR);
+    entries = await readdir(getBundleDir());
   } catch {
     return bundles;
   }
 
   for (const entry of entries) {
     if (!entry.endsWith(".json")) continue;
-    const filePath = join(BUNDLE_DIR, entry);
+    const filePath = join(getBundleDir(), entry);
     try {
       const bundle = await readBundleFile(filePath);
       bundles.push(bundle);
@@ -358,7 +356,7 @@ export async function listBundles(): Promise<BundleManifest[]> {
  */
 export async function removeBundle(name: string): Promise<boolean> {
   const filename = `${sanitizeBundleName(name)}.json`;
-  const filePath = join(BUNDLE_DIR, filename);
+  const filePath = join(getBundleDir(), filename);
 
   try {
     await rm(filePath);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import {
   getDefaultConfig,
   resolveProviderPath,
+  getConfigDir,
   getConfigPath,
+  getIndexDir,
   loadConfig,
   saveConfig,
   saveSelectedTools,
@@ -113,6 +115,38 @@ describe("getConfigPath", () => {
     expect(path).toContain(
       join(".config", "agent-skill-manager", "config.json"),
     );
+  });
+});
+
+describe("getConfigDir", () => {
+  it("uses ASM_CONFIG_DIR when set", () => {
+    expect(process.env.ASM_CONFIG_DIR).toBeTruthy();
+    expect(getConfigDir()).toBe(process.env.ASM_CONFIG_DIR);
+    expect(getIndexDir()).toBe(
+      join(process.env.ASM_CONFIG_DIR!, "skill-index"),
+    );
+  });
+
+  it("does not resolve to the host ~/.config/agent-skill-manager", () => {
+    const hostHome = process.env.ASM_TEST_HOST_HOME;
+    expect(hostHome).toBeTruthy();
+    expect(getConfigDir()).not.toBe(
+      join(hostHome!, ".config", "agent-skill-manager"),
+    );
+    expect(homedir()).not.toBe(hostHome);
+  });
+
+  it("reads ASM_CONFIG_DIR at call time, not at module load", () => {
+    const previous = process.env.ASM_CONFIG_DIR;
+    const override = join(tmpdir(), "asm-config-override");
+    try {
+      process.env.ASM_CONFIG_DIR = override;
+      expect(getConfigDir()).toBe(override);
+      expect(getConfigPath()).toBe(join(override, "config.json"));
+    } finally {
+      if (previous === undefined) delete process.env.ASM_CONFIG_DIR;
+      else process.env.ASM_CONFIG_DIR = previous;
+    }
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,15 +12,16 @@ import type {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const HOME = homedir();
-const CONFIG_DIR = join(HOME, ".config", "agent-skill-manager");
-const CONFIG_PATH = join(CONFIG_DIR, "config.json");
-const LOCK_PATH = join(CONFIG_DIR, ".skill-lock.json");
-const SKILL_STATE_PATH = join(CONFIG_DIR, "skill-state.json");
-const INDEX_DIR = join(CONFIG_DIR, "skill-index");
-const LIBRARY_DIR = join(CONFIG_DIR, "library");
-const LIBRARY_SKILLS_DIR = join(LIBRARY_DIR, "skills");
-const LIBRARY_LOCK_PATH = join(LIBRARY_DIR, "library-lock.json");
+/**
+ * User-state root (`config.json`, skill-index, bundles, lock, library).
+ * `ASM_CONFIG_DIR` overrides the default `~/.config/agent-skill-manager`
+ * so in-process tests can point at a temp dir. Unset in production.
+ */
+export function getConfigDir(): string {
+  const override = process.env.ASM_CONFIG_DIR;
+  if (override) return override;
+  return join(homedir(), ".config", "agent-skill-manager");
+}
 
 const DEFAULT_PROVIDERS: ProviderConfig[] = [
   // ── Priority providers (ordered by user preference) ──
@@ -174,11 +175,11 @@ export function getDefaultConfig(): AppConfig {
 }
 
 export function getConfigPath(): string {
-  return CONFIG_PATH;
+  return join(getConfigDir(), "config.json");
 }
 
 export function getLockPath(): string {
-  return LOCK_PATH;
+  return join(getConfigDir(), ".skill-lock.json");
 }
 
 /**
@@ -186,23 +187,23 @@ export function getLockPath(): string {
  * disabled (survives across sessions). See `src/skill-state.ts`.
  */
 export function getSkillStatePath(): string {
-  return SKILL_STATE_PATH;
+  return join(getConfigDir(), "skill-state.json");
 }
 
 export function getIndexDir(): string {
-  return INDEX_DIR;
+  return join(getConfigDir(), "skill-index");
 }
 
 export function getLibraryDir(): string {
-  return LIBRARY_DIR;
+  return join(getConfigDir(), "library");
 }
 
 export function getLibrarySkillsDir(): string {
-  return LIBRARY_SKILLS_DIR;
+  return join(getLibraryDir(), "skills");
 }
 
 export function getLibraryLockPath(): string {
-  return LIBRARY_LOCK_PATH;
+  return join(getLibraryDir(), "library-lock.json");
 }
 
 export function getBundledIndexDir(): string {
@@ -223,7 +224,7 @@ export async function loadSkillIndexResources(): Promise<SkillIndexResources> {
 
 export function resolveProviderPath(pathTemplate: string): string {
   if (pathTemplate.startsWith("~/")) {
-    return join(HOME, pathTemplate.slice(2));
+    return join(homedir(), pathTemplate.slice(2));
   }
   if (pathTemplate.startsWith("/")) {
     return pathTemplate;
@@ -273,11 +274,12 @@ function mergeWithDefaults(config: Partial<AppConfig>): AppConfig {
 }
 
 export async function loadConfig(): Promise<AppConfig> {
-  debug(`config: checking ${CONFIG_PATH}`);
+  const configPath = getConfigPath();
+  debug(`config: checking ${configPath}`);
 
   let raw: string;
   try {
-    raw = await readFile(CONFIG_PATH, "utf-8");
+    raw = await readFile(configPath, "utf-8");
   } catch (err: any) {
     if (err?.code === "ENOENT") {
       // Config doesn't exist — silently use defaults
@@ -291,13 +293,13 @@ export async function loadConfig(): Promise<AppConfig> {
 
   try {
     const parsed = JSON.parse(raw);
-    debug(`config: loaded from ${CONFIG_PATH}`);
+    debug(`config: loaded from ${configPath}`);
     return mergeWithDefaults(parsed);
   } catch {
     // Parse error — backup corrupted file before resetting
-    const backupPath = CONFIG_PATH + ".bak";
+    const backupPath = configPath + ".bak";
     debug(`config: parse error, backing up to ${backupPath}`);
-    await copyFile(CONFIG_PATH, backupPath);
+    await copyFile(configPath, backupPath);
     console.error(
       `Warning: Config file was corrupted. Backup saved to ${backupPath}. Using defaults.`,
     );
@@ -308,8 +310,9 @@ export async function loadConfig(): Promise<AppConfig> {
 }
 
 export async function saveConfig(config: AppConfig): Promise<void> {
-  await mkdir(CONFIG_DIR, { recursive: true });
-  await writeFile(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf-8");
+  const configPath = getConfigPath();
+  await mkdir(getConfigDir(), { recursive: true });
+  await writeFile(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
 }
 
 export async function saveSelectedTools(toolNames: string[]): Promise<void> {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -9,9 +9,9 @@
 
 import { readdir, readFile, stat } from "fs/promises";
 import { join } from "path";
-import { homedir } from "os";
 import { fetchWithCache } from "./utils/http";
 import { debug } from "./logger";
+import { getConfigDir } from "./config";
 
 // ─── Manifest Types ─────────────────────────────────────────────────────────
 
@@ -412,9 +412,12 @@ export const REGISTRY_INDEX_URL =
   process.env.ASM_REGISTRY_URL ??
   "https://raw.githubusercontent.com/luongnv89/asm-registry/main/index.json";
 
-const REGISTRY_CACHE_PATH =
-  process.env.ASM_REGISTRY_CACHE ??
-  join(homedir(), ".config", "agent-skill-manager", "registry-cache.json");
+function getRegistryCachePath(): string {
+  return (
+    process.env.ASM_REGISTRY_CACHE ??
+    join(getConfigDir(), "registry-cache.json")
+  );
+}
 
 const REGISTRY_TTL_SECONDS = 3600; // 1 hour
 
@@ -489,7 +492,7 @@ export async function fetchRegistryIndex(options?: {
 }): Promise<RegistryIndex | null> {
   const data = await fetchWithCache<RegistryIndex>(
     REGISTRY_INDEX_URL,
-    REGISTRY_CACHE_PATH,
+    getRegistryCachePath(),
     {
       ttl: REGISTRY_TTL_SECONDS,
       noCache: options?.noCache,

--- a/src/skill-index.test.ts
+++ b/src/skill-index.test.ts
@@ -11,13 +11,16 @@ import {
   resolveIndexedSkillByName,
 } from "./skill-index";
 import type { IndexedSkillMatch } from "./skill-index";
-import { getSkillIndexResourcesPath, getBundledIndexDir } from "./config";
+import {
+  getSkillIndexResourcesPath,
+  getBundledIndexDir,
+  getIndexDir,
+} from "./config";
 import type { IndexedSkill } from "./utils/types";
 
-// These tests exercise loadAllIndices/searchSkills/etc. against the real
-// bundled index that ships with the package (data/skill-index/).
-// Since we can't easily patch ESM module exports, we test with whatever
-// indices exist in the real config+bundled dirs.
+// These tests exercise loadAllIndices/searchSkills/etc. against the bundled
+// index that ships with the package (data/skill-index/). The user index dir
+// is the vitest sandbox (ASM_CONFIG_DIR), so host ~/.config is not merged.
 
 describe("loadAllIndices", () => {
   it("returns an array", async () => {
@@ -239,6 +242,18 @@ describe("Index resource integrity", () => {
     const indices = await loadAllIndices();
     for (const idx of indices) {
       expect(idx.skillCount).toBeGreaterThan(0);
+    }
+  });
+
+  it("does not merge the host user skill-index over bundled data", () => {
+    const sandbox = process.env.ASM_CONFIG_DIR;
+    expect(sandbox).toBeTruthy();
+    expect(getIndexDir()).toBe(join(sandbox!, "skill-index"));
+    const hostHome = process.env.ASM_TEST_HOST_HOME;
+    if (hostHome) {
+      expect(getIndexDir()).not.toBe(
+        join(hostHome, ".config", "agent-skill-manager", "skill-index"),
+      );
     }
   });
 

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,25 @@
+/**
+ * Per-file vitest sandbox so in-process tests never touch the developer's
+ * real home or ~/.config/agent-skill-manager.
+ *
+ * HOME/USERPROFILE cover os.homedir() (scanner, uninstaller, ~ expansion).
+ * ASM_CONFIG_DIR is the explicit product override read by getConfigDir().
+ */
+import { afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const hostHome = process.env.HOME ?? process.env.USERPROFILE ?? "";
+const sandboxHome = mkdtempSync(join(tmpdir(), "asm-vitest-"));
+const sandboxConfigDir = join(sandboxHome, ".config", "agent-skill-manager");
+
+process.env.ASM_TEST_HOST_HOME = hostHome;
+process.env.HOME = sandboxHome;
+process.env.USERPROFILE = sandboxHome;
+process.env.ASM_CONFIG_DIR = sandboxConfigDir;
+mkdirSync(sandboxConfigDir, { recursive: true });
+
+afterAll(() => {
+  rmSync(sandboxHome, { recursive: true, force: true });
+});

--- a/src/utils/test-spawn.test.ts
+++ b/src/utils/test-spawn.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { spawnCollect } from "./test-spawn";
+
+describe("spawnCollect env sandbox", () => {
+  it("keeps inherited ASM_CONFIG_DIR when HOME is not redirected", async () => {
+    const res = await spawnCollect(
+      [
+        process.execPath,
+        "-e",
+        "process.stdout.write(process.env.ASM_CONFIG_DIR ?? '')",
+      ],
+      { env: { ...process.env } },
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toBe(process.env.ASM_CONFIG_DIR);
+  });
+
+  it("drops inherited ASM_CONFIG_DIR when HOME is redirected", async () => {
+    const res = await spawnCollect(
+      [
+        process.execPath,
+        "-e",
+        "process.stdout.write(process.env.ASM_CONFIG_DIR ?? '')",
+      ],
+      { env: { ...process.env, HOME: "/tmp/asm-other-home" } },
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toBe("");
+  });
+
+  it("preserves an explicit ASM_CONFIG_DIR even when HOME is redirected", async () => {
+    const res = await spawnCollect(
+      [
+        process.execPath,
+        "-e",
+        "process.stdout.write(process.env.ASM_CONFIG_DIR ?? '')",
+      ],
+      {
+        env: {
+          ...process.env,
+          HOME: "/tmp/asm-other-home",
+          ASM_CONFIG_DIR: "/tmp/asm-explicit-config",
+        },
+      },
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toBe("/tmp/asm-explicit-config");
+  });
+});

--- a/src/utils/test-spawn.ts
+++ b/src/utils/test-spawn.ts
@@ -72,8 +72,25 @@ function normalizeArgv(argv: readonly string[]): string[] {
  * it) makes the sandbox hold on Windows and changes nothing on POSIX.
  */
 function normalizeEnv<T extends { env?: NodeJS.ProcessEnv }>(opts: T): T {
+  let env = opts.env;
+  if (env) {
+    // Vitest setupFiles sets ASM_CONFIG_DIR for in-process tests. Spawned CLI
+    // helpers copy process.env and then redirect HOME; drop the inherited
+    // sandbox so the child uses $HOME/.config/agent-skill-manager unless the
+    // caller set ASM_CONFIG_DIR itself.
+    const redirectedHome = Boolean(env.HOME && env.HOME !== process.env.HOME);
+    const inheritedSandbox =
+      env.ASM_CONFIG_DIR !== undefined &&
+      env.ASM_CONFIG_DIR === process.env.ASM_CONFIG_DIR;
+    if (redirectedHome && inheritedSandbox) {
+      env = { ...env };
+      delete env.ASM_CONFIG_DIR;
+      opts = { ...opts, env };
+    }
+  }
+
   if (process.platform !== "win32") return opts;
-  const env = opts.env;
+  env = opts.env;
   if (!env?.HOME || env.HOME === process.env.HOME) return opts;
   if (env.USERPROFILE && env.USERPROFILE !== process.env.USERPROFILE) {
     return opts;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       // React site tests live beside the source under website-src/src
       "website-src/src/**/*.test.{js,jsx}",
     ],
+    setupFiles: ["src/test-setup.ts"],
     testTimeout: 30_000,
     hookTimeout: 30_000,
   },


### PR DESCRIPTION
Closes #436

## Summary

The in-process unit suite no longer reads or writes the developer's real `~/.config/agent-skill-manager/`. `getConfigDir()` honors `ASM_CONFIG_DIR`, vitest points `HOME`/`USERPROFILE`/`ASM_CONFIG_DIR` at a temp dir, and spawned CLI tests that redirect `HOME` drop the inherited sandbox so they still use `$HOME/.config/agent-skill-manager`.

## Approach

Option 2 — Lazy ASM_CONFIG_DIR plus vitest sandbox: replace module-load config path constants with getters, default bundles/registry cache under that root, and isolate vitest workers via `src/test-setup.ts`.

## Decision Record

- **Root cause:** `src/config.ts` captured `os.homedir()` into `HOME`/`CONFIG_DIR` at module load with no override, so in-process vitest imports read and write the real `~/.config/agent-skill-manager/`. `loadAllIndices()` then merged that user index over bundled data, which made `src/skill-index.test.ts` machine-dependent. `loadConfig()` on ENOENT also created the real `config.json`. Spawned CLI tests could redirect `HOME`; in-process modules could not.
- **Options considered:** Option 1 — Vitest HOME-only isolation; Option 2 — Lazy ASM_CONFIG_DIR plus vitest sandbox; Option 3 — Full filesystem-root DI
- **Options rejected:** Option 1 — Does not meet the AC that no test reads `homedir()` without an env/DI override in product code.; Option 3 — Rewires core path resolution across the product for a test-isolation goal.
- **Selected option:** Option 2 — Lazy ASM_CONFIG_DIR plus vitest sandbox
- **Residual risk:** Scanner/uninstaller still call `homedir()` at their own module load; they are covered only while vitest `setupFiles` sets `HOME` before those imports. A future test that imports those modules before setup, or spawns without `test-spawn`, could still miss the sandbox.
- **Reproduction:** `npx vitest run src/registry.test.ts src/config.test.ts src/bundler.test.ts` mutated host `registry-cache.json` (md5 changed) → fixed → `src/config.test.ts` (`getConfigDir`), `src/skill-index.test.ts` (no host index merge), `src/utils/test-spawn.test.ts`; post-fix `CI=true npm test` left `~/.config/agent-skill-manager` byte-identical

Analyzed at: `main @ e6a08d1` (2026-08-19)

## Changes

| File | Change |
|------|--------|
| `src/config.ts` | Lazy `getConfigDir()` from `ASM_CONFIG_DIR` or `homedir()`; path getters no longer freeze at import |
| `src/bundler.ts` | User bundle dir derived from `getConfigDir()` |
| `src/registry.ts` | Default registry cache path under `getConfigDir()` |
| `src/test-setup.ts` | Vitest sandbox: temp `HOME`/`USERPROFILE`/`ASM_CONFIG_DIR` |
| `vitest.config.ts` | `setupFiles: ["src/test-setup.ts"]` |
| `src/utils/test-spawn.ts` | Drop inherited `ASM_CONFIG_DIR` when a child redirects `HOME` |
| `src/config.test.ts` | Assert `ASM_CONFIG_DIR` override and host isolation |
| `src/skill-index.test.ts` | Assert user index is the sandbox, not the host dir |
| `src/utils/test-spawn.test.ts` | Spawn env inheritance cases |
| `CLAUDE.md` / `AGENTS.md` / `docs/AGENT_ENVIRONMENT.md` / `CHANGELOG.md` | Trap 2 now documents the sandbox instead of the hole |

## Test Results

- Unit tests: 2113 passed
- Integration tests: skipped
- E2e tests: skipped
- Build: passed (`npm run typecheck`)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `CI=true npm test` passes 2100/2100 on a machine with a populated `~/.config/agent-skill-manager/` | pass | Verified red: `npx vitest run src/registry.test.ts src/config.test.ts src/bundler.test.ts` mutated host `registry-cache.json` → fixed → `CI=true npm test` 2113/2113 (7 new tests; host index was populated, 60 files) |
| A test run leaves `~/.config/agent-skill-manager/` byte-identical — verified by hashing the directory before and after | pass | md5 map of 60 files identical before/after `CI=true npm test` on this machine |
| No test reads `homedir()` without an env/DI override | pass | `src/test-setup.ts` sets `HOME`/`USERPROFILE`/`ASM_CONFIG_DIR` before `src/` imports; `getConfigDir()` is the product override (`src/config.ts`) |
| `CI=true npm test` passes at 2100/2100 locally and in CI (baseline-green holds) | pass | Local 2113/2113 after the added tests; typecheck clean. CI will confirm on this PR. |

<!-- gitissue:qa v1 head=ec8c54646d445b8bad46599c8d889216220a70a7 profile=full cycles=1 review=clean tests=2113@ec8c54646d445b8bad46599c8d889216220a70a7 ui=none -->
