### PR TITLE
chore(lint): extend eslint to src/ (#439)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,24 @@ permissions:
 # a clean VM or a version matrix.
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint src/
+        run: npm run lint
+
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,14 @@ repos:
         files: \.(ts|tsx|js|jsx|json|css|scss|md)$
         exclude: ^(node_modules/|dist/|package-lock\.json)
 
+      - id: lint
+        name: lint
+        entry: npm run lint
+        language: system
+        files: ^src/
+        types: [ts, tsx]
+        pass_filenames: false
+
       - id: typecheck
         name: typecheck
         entry: npx tsc --noEmit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,7 @@ repos:
         name: lint
         entry: npm run lint
         language: system
-        files: ^src/
-        types: [ts, tsx]
+        files: ^(src/|eslint\.config\.js)
         pass_filenames: false
 
       - id: typecheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Infrastructure
 
+- Extend ESLint to `src/` with a root flat config, `npm run lint`, and a failing CI job ([#439](https://github.com/luongnv89/asm/issues/439))
 - Add `@vitest/coverage-v8` and `npm run test:coverage` for `src/`; record the first line/branch baseline in `CLAUDE.md` and bind M3 to `max(60%, baseline + 20pp)` ([#438](https://github.com/luongnv89/asm/issues/438))
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ npm run build        # tsx scripts/build.ts -> dist/ (gitignored)
 CI=true npm test     # unit suite — the command of record
 npm run test:coverage  # v8 coverage for src/ — measurement only, no fail gate
 npm run typecheck    # tsc --noEmit
+npm run lint         # eslint over src/
 npm run lint:site    # eslint over website-src/src
 npm run test:e2e     # tests/e2e/ — NOT covered by `npm test`
 npm start            # run the TUI from source

--- a/docs/AGENT_ENVIRONMENT.md
+++ b/docs/AGENT_ENVIRONMENT.md
@@ -40,7 +40,7 @@ npm install     # or `npm ci` for a lockfile-exact install (what CI uses)
 `postinstall` runs `node scripts/postinstall.cjs`. It short-circuits when
 `ASM_SKIP_POSTINSTALL` or `CI` is set, or when the install is not global.
 
-## The four commands of record
+## Commands of record
 
 | Command             | Observed result                                                                                          | Wall time |
 | ------------------- | -------------------------------------------------------------------------------------------------------- | --------- |
@@ -48,8 +48,9 @@ npm install     # or `npm ci` for a lockfile-exact install (what CI uses)
 | `CI=true npm test`  | **PASS** (exit 0) — Test Files `60 passed (60)`, Tests **`2100 passed (2100)`**, vitest Duration 90.72 s | ~91 s     |
 | `npm run typecheck` | **PASS** (exit 0) — `tsc --noEmit`, no output                                                            | ~2 s      |
 | `npm run lint:site` | **PASS** (exit 0) — eslint over `website-src/src/**/*.{js,jsx}`, no findings                             | ~1 s      |
+| `npm run lint`      | **PASS** (exit 0) — eslint over `src/` via the root flat config (#439)                                   | ~3 s      |
 
-`git status --porcelain` was unchanged before and after all four — no tracked
+`git status --porcelain` was unchanged before and after these commands — no tracked
 modifications, and the same set of untracked scratch files either side.
 `npm run build` writes only to `dist/`, which is gitignored.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -35,6 +35,7 @@ npx tsx bin/agent-skill-manager.ts --help
 ```bash
 npm test             # Run all tests
 npm run typecheck    # Type-check without emitting
+npm run lint         # ESLint over src/
 ```
 
 Verified results for `npm run build`, `CI=true npm test`, `npm run typecheck`,
@@ -57,6 +58,7 @@ The project uses [pre-commit](https://pre-commit.com/) with:
 - **check-yaml / check-json** — validates config files
 - **check-added-large-files** — prevents accidental large file commits
 - **prettier** — auto-formats TS, JS, JSON, CSS, and MD files
+- **lint** — runs `npm run lint` (ESLint over `src/`)
 - **typecheck** — runs `tsc --noEmit` on staged TypeScript files
 
 Install hooks locally:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,70 @@
+import js from "@eslint/js";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+/**
+ * ESLint flat config for the TypeScript product tree (`src/`).
+ *
+ * Website JS/JSX stays on `website-src/eslint.config.js` via `npm run lint:site`.
+ * Stylistic rules are omitted — Prettier owns formatting.
+ *
+ * `@typescript-eslint/no-explicit-any` is explicitly off: `tsc --noEmit`
+ * already enforces `strict`/`noImplicitAny`, and replacing ~200 existing
+ * annotations is a follow-up, not this gate. Do not add file-scope
+ * `eslint-disable`.
+ */
+export default tseslint.config(
+  {
+    ignores: [
+      "dist/**",
+      "node_modules/**",
+      "website/**",
+      "website-src/**",
+      "data/**",
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+  {
+    files: ["src/**/*.tsx"],
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      react,
+      "react-hooks": reactHooks,
+    },
+    settings: { react: { version: "18.0" } },
+    rules: {
+      ...react.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off",
+      "react/prop-types": "off",
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tsx": "^4",
         "typescript": "^5",
+        "typescript-eslint": "^8.67.0",
         "vite": "^6.4.3",
         "vitest": "^2"
       },
@@ -1891,6 +1892,301 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.67.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -7379,6 +7675,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -7983,6 +8292,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "preindex": "tsx scripts/preindex.ts",
     "refresh:repo-bundles": "tsx scripts/refresh-repo-bundles.ts",
     "build:website": "tsx scripts/build-catalog.ts && npm run build:site",
+    "lint": "eslint src/",
     "lint:site": "eslint --config website-src/eslint.config.js 'website-src/src/**/*.{js,jsx}'",
     "prepublishOnly": "npm run build",
     "postinstall": "node scripts/postinstall.cjs"
@@ -99,6 +100,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tsx": "^4",
     "typescript": "^5",
+    "typescript-eslint": "^8.67.0",
     "vite": "^6.4.3",
     "vitest": "^2"
   }

--- a/src/bundler.test.ts
+++ b/src/bundler.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { mkdtemp, writeFile, mkdir, readdir, rm, readFile } from "fs/promises";
-import { join, resolve, dirname } from "path";
-import { fileURLToPath } from "url";
+import { mkdtemp, writeFile, readdir, rm } from "fs/promises";
+import { join } from "path";
 import { tmpdir } from "os";
 import {
   validateBundle,
@@ -14,13 +13,8 @@ import {
   listPredefinedBundles,
   removeBundle,
   getBundleDir,
-  ensureBundleDir,
 } from "./bundler";
 import type { BundleManifest, BundleSkillRef, SkillInfo } from "./utils/types";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const PREDEFINED_BUNDLE_DIR = resolve(__dirname, "..", "data", "bundles");
 
 // ─── Test Helpers ──────────────────────────────────────────────────────────
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -7,7 +7,6 @@ import {
   beforeEach,
   afterEach,
   beforeAll,
-  afterAll,
 } from "vitest";
 import {
   parseArgs,
@@ -28,7 +27,6 @@ import {
   lstat,
   readlink,
   realpath,
-  symlink,
   chmod,
 } from "fs/promises";
 import { tmpdir, homedir } from "os";
@@ -708,7 +706,7 @@ describe("CLI integration: --machine output", () => {
   });
 
   test("update --machine produces valid v1 envelope", async () => {
-    const { stdout, exitCode } = await runCLI(
+    const { stdout } = await runCLI(
       "update",
       "nonexistent-skill-12345",
       "--machine",
@@ -1096,11 +1094,8 @@ describe("CLI integration: audit", () => {
   });
 
   test("audit duplicates is the default subcommand", async () => {
-    const { stdout: defaultOut, exitCode: code1 } = await runCLI("audit");
-    const { stdout: explicitOut, exitCode: code2 } = await runCLI(
-      "audit",
-      "duplicates",
-    );
+    const { exitCode: code1 } = await runCLI("audit");
+    const { exitCode: code2 } = await runCLI("audit", "duplicates");
     expect(code1).toBe(0);
     expect(code2).toBe(0);
     // Both should produce similar output (may differ in timestamp)
@@ -2589,7 +2584,7 @@ describe("readLine", () => {
 
 describe("CLI integration: verbose flag", () => {
   test("list -V produces verbose output on stderr", async () => {
-    const { stdout, stderr, exitCode } = await runCLI("list", "-V");
+    const { stderr, exitCode } = await runCLI("list", "-V");
     expect(exitCode).toBe(0);
     expect(stderr).toContain("[verbose]");
     expect(stderr).toMatch(/\+\d+ms/);
@@ -4012,7 +4007,7 @@ metadata:
     const linkB = join(providerDir, "test-link-skill-b");
 
     try {
-      const { stdout, stderr, exitCode } = await runCLI(
+      const { stdout, exitCode } = await runCLI(
         "link",
         multiDir,
         "--force",
@@ -5343,7 +5338,7 @@ describe("CLI integration: bundle modify", () => {
     await writeFile(filePath, JSON.stringify(bundleData, null, 2));
 
     try {
-      const { stderr, exitCode } = await runCLI(
+      const { exitCode } = await runCLI(
         "bundle",
         "modify",
         filePath,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,12 +32,10 @@ import {
   executeRemoval,
   getExistingTargets,
   buildRelocationInfo,
-  findRelocationTarget,
 } from "./uninstaller";
 import {
   formatSkillTable,
   formatGroupedTable,
-  formatSkillDetail,
   formatSkillInspect,
   formatSearchResults,
   formatAvailableSearchResults,
@@ -95,7 +93,7 @@ import {
   isScopedName,
   resolveFromRegistry,
 } from "./registry";
-import type { RegistryManifest, ResolutionSource } from "./registry";
+import type { ResolutionSource } from "./registry";
 import { buildManifest } from "./exporter";
 import { readManifestFile, importSkills, renderConflictDiff } from "./importer";
 import type {
@@ -222,9 +220,6 @@ import type {
   SecurityAuditReport,
   AppConfig,
   SkillStateFile,
-  RepoStatsReport,
-  AuthorStatsReport,
-  IndexStatsReport,
   GetResult,
   GetSecurityVerdict,
   GetTier,
@@ -3639,7 +3634,7 @@ async function cmdInstall(args: ParsedArgs) {
     // Step 5: Scan for skills
     console.info(stepHeader("Scanning for skills"));
     const { join: joinPath } = await import("path");
-    let results: InstallResult[] = [];
+    const results: InstallResult[] = [];
 
     // Effective path: explicit --path flag takes precedence over URL-derived subpath
     const effectivePath = args.flags.path || source.subpath;
@@ -7145,25 +7140,6 @@ async function cmdPublish(args: ParsedArgs) {
       );
     }
   } catch (err: any) {
-    const errorResult: import("./utils/types").PublishResult = {
-      success: false,
-      manifest: null,
-      prUrl: null,
-      error: err.message,
-      securityVerdict: "pass",
-      securityReport: {
-        scannedAt: new Date().toISOString(),
-        skillName: "",
-        skillPath: "",
-        source: null,
-        codeScans: [],
-        permissions: [],
-        totalFiles: 0,
-        totalLines: 0,
-        verdict: "safe",
-        verdictReason: "",
-      },
-    };
     if (args.flags.machine) {
       restoreConsole?.();
       console.log(

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -13,7 +13,6 @@ import { setVerbose } from "./logger";
 import { homedir } from "os";
 import { resolve, join, dirname } from "path";
 import { writeFile, readFile, rm, mkdir } from "fs/promises";
-import { mkdtempSync } from "fs";
 import { tmpdir } from "os";
 
 const HOME = homedir();
@@ -167,7 +166,9 @@ describe("config backup on corruption", () => {
     // Remove backup if it exists
     try {
       await rm(backupPath);
-    } catch {}
+    } catch {
+      /* ignore missing path */
+    }
   });
 
   afterEach(async () => {
@@ -179,12 +180,16 @@ describe("config backup on corruption", () => {
     } else {
       try {
         await rm(configPath);
-      } catch {}
+      } catch {
+        /* ignore missing path */
+      }
     }
     // Clean up backup
     try {
       await rm(backupPath);
-    } catch {}
+    } catch {
+      /* ignore missing path */
+    }
   });
 
   it("creates .bak and warns on corrupted config", async () => {
@@ -212,7 +217,9 @@ describe("config backup on corruption", () => {
   it("silently creates defaults for missing config", async () => {
     try {
       await rm(configPath);
-    } catch {}
+    } catch {
+      /* ignore missing path */
+    }
 
     const config = await loadConfig();
 
@@ -224,7 +231,9 @@ describe("config backup on corruption", () => {
     try {
       await readFile(backupPath);
       backupExists = true;
-    } catch {}
+    } catch {
+      /* ignore missing path */
+    }
     expect(backupExists).toBe(false);
 
     // Should NOT have warned
@@ -318,7 +327,9 @@ describe("selectedTools preference", () => {
     } else {
       try {
         await rm(configPath);
-      } catch {}
+      } catch {
+        /* ignore missing path */
+      }
     }
   });
 
@@ -387,7 +398,9 @@ describe("mergeWithDefaults priority-order insertion", () => {
     } else {
       try {
         await rm(configPath);
-      } catch {}
+      } catch {
+        /* ignore missing path */
+      }
     }
   });
 

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -18,13 +18,8 @@ import {
   formatDoctorJSON,
   formatDoctorMachine,
 } from "./doctor";
-import type {
-  DoctorReport,
-  CheckResult,
-  CheckStatus,
-  _DoctorExecOverrides,
-} from "./doctor";
-import type { AppConfig, LockFile } from "./utils/types";
+import type { DoctorReport, CheckResult, _DoctorExecOverrides } from "./doctor";
+import type { LockFile } from "./utils/types";
 import { getDefaultConfig } from "./config";
 
 function makeReport(overrides: Partial<DoctorReport> = {}): DoctorReport {

--- a/src/eval/runner.test.ts
+++ b/src/eval/runner.test.ts
@@ -154,7 +154,6 @@ describe("runner error wrapping", () => {
   it("wraps non-Error throws with String coercion", async () => {
     const result = await runProvider(
       makeProvider(async () => {
-        // eslint-disable-next-line no-throw-literal
         throw "string error";
       }),
       CTX,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -30,14 +30,7 @@
  *                          schema. Downstream issues can add it later.
  */
 
-import {
-  readFile,
-  writeFile,
-  stat,
-  copyFile,
-  access,
-  readdir,
-} from "fs/promises";
+import { readFile, writeFile, stat, copyFile, readdir } from "fs/promises";
 import { join, resolve, basename, isAbsolute } from "path";
 import type { ProviderEvalReport } from "./eval/summary";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
@@ -1330,7 +1323,7 @@ function appendFrontmatterKey(
 ): string {
   const existing = new RegExp(`^${key}:\\s*`, "m");
   if (existing.test(fmStr)) return fmStr;
-  const quoted = /[:#{}\[\],&*?|<>=!%@`"']/.test(value)
+  const quoted = /[:#{}[\],&*?|<>=!%@`"']/.test(value)
     ? JSON.stringify(value)
     : value;
   const separator = fmStr.length === 0 || fmStr.endsWith("\n") ? "" : "\n";

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { checkHealth } from "./health";
 import type { SkillInfo } from "./utils/types";
-import { mkdtemp, writeFile, mkdir, rm } from "fs/promises";
+import { mkdtemp, writeFile, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -1,14 +1,6 @@
 import { createDirSymlink } from "./utils/fs";
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
-import {
-  mkdtemp,
-  writeFile,
-  mkdir,
-  rm,
-  readlink,
-  lstat,
-  symlink,
-} from "fs/promises";
+import { mkdtemp, writeFile, mkdir, rm, readlink, lstat } from "fs/promises";
 import { existsSync } from "fs";
 import { join, relative, resolve, isAbsolute, basename, dirname } from "path";
 import { tmpdir } from "os";
@@ -2234,7 +2226,6 @@ describe("linkExistingSkill", () => {
   test("creates a symlink from existing install to target provider", async () => {
     const config = makeConfig();
     const claudeDir = join(tempDir, "claude-skills");
-    const codexDir = join(tempDir, "codex-skills");
     const skillDir = await createSkillInProvider(claudeDir, "code-review");
 
     const targetPath = await linkExistingSkill(
@@ -2257,7 +2248,6 @@ describe("linkExistingSkill", () => {
   test("overwrites existing symlink with force=true", async () => {
     const config = makeConfig();
     const claudeDir = join(tempDir, "claude-skills");
-    const codexDir = join(tempDir, "codex-skills");
     const claudeSkillDir = await createSkillInProvider(
       claudeDir,
       "code-review",
@@ -2295,7 +2285,6 @@ describe("linkExistingSkill", () => {
   test("throws when target exists and force is false", async () => {
     const config = makeConfig();
     const claudeDir = join(tempDir, "claude-skills");
-    const codexDir = join(tempDir, "codex-skills");
     const skillDir = await createSkillInProvider(claudeDir, "code-review");
 
     // First link

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -5,7 +5,6 @@ import {
   readdir,
   readFile,
   rm,
-  rename,
   cp,
   access,
   stat,

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -60,7 +60,6 @@ import {
   realpath,
   rename,
   rm,
-  symlink,
   writeFile,
   readdir,
 } from "fs/promises";

--- a/src/library.ts
+++ b/src/library.ts
@@ -268,24 +268,6 @@ async function persistLibraryLock(
   await writeTextFileAtomically(path, JSON.stringify(lock, null, 2) + "\n");
 }
 
-async function mutateLibraryLock<T>(
-  path: string,
-  mutate: (
-    lock: LibraryLockFile,
-  ) =>
-    | Promise<{ changed: boolean; result?: T }>
-    | { changed: boolean; result?: T },
-): Promise<T | undefined> {
-  return withFileMutationLock(path, async () => {
-    const lock = await readLibraryLockFile(path);
-    const { changed, result } = await mutate(lock);
-    if (changed) {
-      await persistLibraryLock(lock, path);
-    }
-    return result;
-  });
-}
-
 function validateSourceSkillFrontmatter(
   frontmatter: Record<string, string>,
 ): { name: string; version: string } | { reason: string } {

--- a/src/linker.test.ts
+++ b/src/linker.test.ts
@@ -5,15 +5,7 @@ import {
   createLink,
   discoverLinkableSkills,
 } from "./linker";
-import {
-  mkdtemp,
-  writeFile,
-  mkdir,
-  rm,
-  lstat,
-  readlink,
-  symlink,
-} from "fs/promises";
+import { mkdtemp, writeFile, mkdir, rm, lstat, readlink } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 

--- a/src/publisher.test.ts
+++ b/src/publisher.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
+import { mkdtemp, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import {

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -5,7 +5,7 @@
  * optionally opens a PR against luongnv89/asm-registry via the gh CLI.
  */
 
-import { readFile, stat, realpath } from "fs/promises";
+import { readFile, realpath } from "fs/promises";
 import { join, resolve, relative } from "path";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
 import { auditSkillSecurity } from "./security-auditor";
@@ -25,14 +25,16 @@ import { runCommand } from "./utils/spawn";
  */
 export function stripControlChars(s: string): string {
   // Remove ANSI escape sequences (CSI, OSC, etc.)
-  // eslint-disable-next-line no-control-regex
   return (
     s
+      // eslint-disable-next-line no-control-regex -- ANSI CSI
       .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "")
+      // eslint-disable-next-line no-control-regex -- ANSI OSC
       .replace(/\x1b\][^\x07]*\x07/g, "")
+      // eslint-disable-next-line no-control-regex -- remaining ESC
       .replace(/\x1b[^[\]]/g, "")
       // Remove remaining ASCII control characters (0x00-0x1F, 0x7F) except \n and \t
-      // eslint-disable-next-line no-control-regex
+      // eslint-disable-next-line no-control-regex -- ASCII controls
       .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
   );
 }

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, writeFile, mkdir, rm } from "fs/promises";
 import { join } from "path";
-import { tmpdir } from "os";
+import { tmpdir, homedir } from "os";
 import {
   validateManifest,
   levenshtein,
@@ -724,7 +724,7 @@ describe("resolveFromRegistry", () => {
   it("returns empty result when index is null (fetch failure)", async () => {
     // Remove any stale cache so fetchWithCache cannot fall back to it
     const cachePath = join(
-      require("os").homedir(),
+      homedir(),
       ".config",
       "agent-skill-manager",
       "registry-cache.json",

--- a/src/security-auditor.test.ts
+++ b/src/security-auditor.test.ts
@@ -4,7 +4,6 @@ import { mkdtemp, writeFile, mkdir, rm } from "fs/promises";
 import { join, dirname } from "path";
 import { tmpdir } from "os";
 import {
-  analyzeSource,
   scanCode,
   analyzePermissions,
   calculateVerdict,

--- a/src/security-auditor.ts
+++ b/src/security-auditor.ts
@@ -656,16 +656,12 @@ function formatNumber(n: number): string {
 }
 
 function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex -- ANSI CSI
   return s.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
 function visibleLength(s: string): number {
   return stripAnsi(s).length;
-}
-
-function padVisible(s: string, width: number): string {
-  const vLen = visibleLength(s);
-  return vLen < width ? s + " ".repeat(width - vLen) : s;
 }
 
 function deduplicateMatches(matches: CodeScanMatch[]): CodeScanMatch[] {

--- a/src/skill-index.test.ts
+++ b/src/skill-index.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { mkdtemp, writeFile, rm, readdir } from "fs/promises";
+import { describe, expect, it } from "vitest";
+import { readdir } from "fs/promises";
 import { join } from "path";
-import { tmpdir } from "os";
 import {
   searchSkills,
   getAllIndexedSkills,

--- a/src/skill-state.test.ts
+++ b/src/skill-state.test.ts
@@ -7,7 +7,6 @@ import {
   writeFile,
   readFile,
   access,
-  symlink,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
@@ -26,7 +25,7 @@ import {
   disabledFilePath,
 } from "./skill-state";
 import { groupBySource } from "./cli";
-import type { SkillInfo, SkillStateFile } from "./utils/types";
+import type { SkillInfo } from "./utils/types";
 
 type NameDir = { name: string; dirName: string };
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -14,7 +14,6 @@ import type {
   RepoStatsReport,
   AuthorStatsReport,
   IndexStatsReport,
-  IndexedSkill,
   TokenBudgetReport,
   TokenBudgetGroup,
   ResidentSkillCost,
@@ -531,7 +530,7 @@ export function computeAuthorStats(indices: RepoIndex[]): AuthorStatsReport[] {
 
   // Sort top skills by token count (descending) and keep top 10
   const results: AuthorStatsReport[] = [];
-  for (const [owner, author] of authorMap) {
+  for (const [_owner, author] of authorMap) {
     const sortedSkills = author.topSkills
       .sort((a, b) => b.name.localeCompare(a.name))
       .slice(0, 10);

--- a/src/uninstaller.test.ts
+++ b/src/uninstaller.test.ts
@@ -1,5 +1,5 @@
 import { createDirSymlink } from "./utils/fs";
-import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // ─── Module mocks for EXDEV cp fallback test (issue #283) ────────────────────
 // `vi.mock` is hoisted and file-level, so route through `vi.hoisted` so we can
@@ -48,7 +48,6 @@ import {
   lstat,
   realpath,
   rm,
-  symlink,
   readdir,
 } from "fs/promises";
 
@@ -381,7 +380,7 @@ describe("executeRemoval with symlinkTo", () => {
         agentsBlocks: [],
       };
 
-      const log = await executeRemoval(plan, keptDir);
+      await executeRemoval(plan, keptDir);
 
       const stats = await lstat(dupLink);
       expect(stats.isSymbolicLink()).toBe(true);

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -14,7 +14,7 @@ import { homedir } from "os";
 import { debug } from "./logger";
 import { readLock, writeLockEntry } from "./utils/lock";
 import { fetchRegistryIndex } from "./registry";
-import type { RegistryManifest, RegistryIndex } from "./registry";
+import type { RegistryIndex } from "./registry";
 import type { LockEntry } from "./utils/types";
 import { auditSkillSecurity } from "./security-auditor";
 import type { SecurityVerdict } from "./utils/types";

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, writeFile, readFile, rm, mkdir } from "fs/promises";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, rm, mkdir } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import { fetchWithCache } from "./http";

--- a/src/utils/lock.test.ts
+++ b/src/utils/lock.test.ts
@@ -19,7 +19,7 @@ vi.mock("fs/promises", async (importOriginal) => {
   };
 });
 
-import { mkdtemp, writeFile, rm, readFile, mkdir, readdir } from "fs/promises";
+import { mkdtemp, writeFile, rm, readFile, readdir } from "fs/promises";
 import { execSync } from "child_process";
 import { join } from "path";
 import { tmpdir } from "os";

--- a/src/utils/test-spawn.ts
+++ b/src/utils/test-spawn.ts
@@ -2,9 +2,8 @@ import {
   spawnSync as nodeSpawnSync,
   spawn as nodeSpawn,
 } from "node:child_process";
-import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
 import { createRequire } from "node:module";
 import type {
   SpawnSyncOptions,


### PR DESCRIPTION
Closes #439

## Summary

ESLint now covers the TypeScript product tree. A root flat config lints `src/`, `npm run lint` is the command of record, and CI fails when it is not clean. Existing `any` annotations are baselined in the config; there are no file-scope `eslint-disable` comments.

## Approach

Option 1 — Root flat config, lint script, CI gate, fix src/: add `typescript-eslint` on ESLint 9, lint `src/` with recommended rules (React Hooks scoped to TSX), turn `@typescript-eslint/no-explicit-any` off as an explicit baseline, fix remaining unused/empty/control-regex findings, and add a failing `lint` job in CI plus a pre-commit hook.

## Decision Record

- **Root cause:** ESLint was installed but only invoked as `lint:site` over `website-src/src` JS/JSX. The TypeScript `src/` tree had no lint script, no root flat config, no `typescript-eslint` parser, and no CI lint job — `tsc --noEmit` was the only static gate and it was pre-commit-only.
- **Options considered:** Option 1 — Root flat config, lint script, CI gate, fix src/; Option 2 — Warn-only baseline file; Option 3 — Wait for eslint 10 (#446) then lint src/
- **Options rejected:** Option 2 — A warn-only job is not a failing gate and baselines rot; Option 3 — Leaves the product tree unlinted and does not close F-CI-003
- **Selected option:** Option 1 — Root flat config, lint script, CI gate, fix src/
- **Residual risk:** `@typescript-eslint/no-explicit-any` remains off (~200 existing annotations). Type-aware (`parserOptions.project`) rules are not enabled. #446 should stay on ESLint 9 until that bump.

Analyzed at: `refactor/439-extend-eslint-to-src @ 94065fd` (2026-08-19)

## Changes

| File | Change |
|------|--------|
| `eslint.config.js` | Root flat config for `src/**/*.{ts,tsx}`; React Hooks on TSX only |
| `package.json` | Add `lint` script and `typescript-eslint` |
| `package-lock.json` | Lock `typescript-eslint` 8.x |
| `.github/workflows/ci.yml` | Failing `lint` job running `npm run lint` |
| `.pre-commit-config.yaml` | Commit-stage `npm run lint` when `src/` or the config changes |
| `src/**` | Unused-import/dead-helper cleanup; line-level `no-control-regex` only |
| `CLAUDE.md`, `docs/DEVELOPMENT.md`, `docs/AGENT_ENVIRONMENT.md`, `CHANGELOG.md` | Document `npm run lint` |

## Test Results

- Unit tests: 2113 passed (`CI=true npm test`)
- Integration tests: skipped
- E2e tests: skipped
- Build: passed (`npm run typecheck`; `npm run lint` exit 0; `npm run lint:site` exit 0)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `npm run lint` exits 0 across `src/` with no blanket `eslint-disable` at file scope | pass | `package.json` script `eslint src/`; `npm run lint` exit 0; remaining disables are `eslint-disable-next-line no-control-regex` in `src/publisher.ts`, `src/security-auditor.ts`, `src/utils/checkbox-picker.test.ts` |
| The lint step is a failing gate in `.github/workflows/ci.yml` | pass | `.github/workflows/ci.yml` job `lint` step `Lint src/` runs `npm run lint` |
| `CI=true npm test` passes at ≥ 2099/2100 locally and 2100/2100 in CI (baseline-green holds) | pass | Local `CI=true npm test` → 2113/2113 on `6152d80` |

<!-- gitissue:qa v1 head=6152d80f1158d423e1928dbc94a454675721166d profile=full cycles=1 review=clean tests=2113@6152d80f1158d423e1928dbc94a454675721166d ui=none -->
