### PR TITLE
chore(hooks): move unit suite from pre-commit to pre-push (#440)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
         types: [text]
         files: \.(ts|tsx|js|jsx|json|css|scss|md)$
         exclude: ^(node_modules/|dist/|package-lock\.json)
+        stages: [pre-commit]
 
       - id: lint
         name: lint
@@ -33,6 +34,7 @@ repos:
         language: system
         files: ^(src/|eslint\.config\.js)
         pass_filenames: false
+        stages: [pre-commit]
 
       - id: typecheck
         name: typecheck
@@ -40,15 +42,16 @@ repos:
         language: system
         types: [ts, tsx]
         pass_filenames: false
+        stages: [pre-commit]
 
+      # ── Push stage ──────────────────────────────────────────────────────────
       - id: unit-tests
         name: unit tests
         entry: npx vitest run src/
         language: system
         pass_filenames: false
-        stages: [pre-commit]
+        stages: [pre-push]
 
-      # ── Push stage ──────────────────────────────────────────────────────────
       - id: build
         name: build
         entry: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Infrastructure
 
+- Move the full unit suite from the pre-commit hook to pre-push; keep prettier, lint, typecheck, and the local security check as the fast commit subset ([#440](https://github.com/luongnv89/asm/issues/440))
 - Extend ESLint to `src/` with a root flat config, `npm run lint`, and a failing CI job ([#439](https://github.com/luongnv89/asm/issues/439))
 - Add `@vitest/coverage-v8` and `npm run test:coverage` for `src/`; record the first line/branch baseline in `CLAUDE.md` and bind M3 to `max(60%, baseline + 20pp)` ([#438](https://github.com/luongnv89/asm/issues/438))
 

--- a/docs/AGENT_ENVIRONMENT.md
+++ b/docs/AGENT_ENVIRONMENT.md
@@ -148,22 +148,23 @@ fire. To get both:
 pre-commit install --hook-type pre-commit --hook-type pre-push
 ```
 
-- **Commit stage:** the upstream `pre-commit-hooks` set (trailing-whitespace,
-  end-of-file-fixer, check-yaml, check-json, check-added-large-files), the local
-  security check, prettier, `tsc --noEmit`, and `npx vitest run src/`.
-- **Push stage:** `npm run build`,
-  `npx vitest run tests/e2e/node-e2e.test.ts` — plus everything above that is
-  not pinned to the commit stage, which is most of it. Only `security-check` and
-  `unit-tests` carry an explicit `stages: [pre-commit]`. prettier and
-  `tsc --noEmit` declare no `stages:` here, and all five upstream hooks also run
-  at push (trailing-whitespace, end-of-file-fixer and check-added-large-files
-  declare `stages: [pre-commit, pre-push, manual]` in the upstream manifest;
-  check-yaml and check-json declare none, which likewise means every stage).
+- **Commit stage (fast subset):** the upstream `pre-commit-hooks` set
+  (trailing-whitespace, end-of-file-fixer, check-yaml, check-json,
+  check-added-large-files), the local security check, prettier, `npm run lint`,
+  and `tsc --noEmit`. `security-check`, prettier, `lint`, and `typecheck` are
+  pinned to `stages: [pre-commit]`.
+- **Push stage:** `npx vitest run src/` (`unit-tests`), `npm run build`, and
+  `npx vitest run tests/e2e/node-e2e.test.ts`. Those three local hooks carry
+  `stages: [pre-push]`. The five upstream hooks also run at push
+  (trailing-whitespace, end-of-file-fixer and check-added-large-files declare
+  `stages: [pre-commit, pre-push, manual]` in the upstream manifest; check-yaml
+  and check-json declare none, which likewise means every stage).
 
-The `unit-tests` hook runs the same non-hermetic suite described above, so on a
-machine with a drifted skill index it can block a commit for a reason unrelated
-to the change. Confirm the failure is the known baseline one before working
-around it.
+The `unit-tests` hook runs the same suite described above (`npx vitest run
+src/`). It lives at pre-push so a no-op commit is not gated on the ~91 s run;
+CI remains the enforcing gate. On a machine with a drifted skill index it can
+still block a push for a reason unrelated to the change. Confirm the failure
+is the known baseline one before working around it.
 
 ## See also
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -57,14 +57,16 @@ The project uses [pre-commit](https://pre-commit.com/) with:
 - **end-of-file-fixer** — ensures files end with a newline
 - **check-yaml / check-json** — validates config files
 - **check-added-large-files** — prevents accidental large file commits
-- **prettier** — auto-formats TS, JS, JSON, CSS, and MD files
-- **lint** — runs `npm run lint` (ESLint over `src/`)
-- **typecheck** — runs `tsc --noEmit` on staged TypeScript files
+- **prettier** — auto-formats TS, JS, JSON, CSS, and MD files (commit)
+- **lint** — runs `npm run lint` (ESLint over `src/`) (commit)
+- **typecheck** — runs `tsc --noEmit` on staged TypeScript files (commit)
+- **unit-tests** — `npx vitest run src/` (push)
+- **build** / **e2e-node** — production build and node e2e (push)
 
-Install hooks locally:
+Install both hook stages; a plain `pre-commit install` skips pre-push:
 
 ```bash
-pre-commit install
+pre-commit install --hook-type pre-commit --hook-type pre-push
 ```
 
 ## Debugging


### PR DESCRIPTION
Closes #440

## Summary

The full `npx vitest run src/` suite no longer runs on every commit. It now lives at pre-push with build and e2e, while commit keeps the fast subset (prettier, lint, typecheck, local security check). CI still runs the unit suite on every PR.

## Approach

Move unit-tests hook to pre-push — pin prettier, lint, and typecheck to pre-commit so the inner loop stays usable.

## Decision Record

- **Root cause:** `.pre-commit-config.yaml` pinned `unit-tests` (`npx vitest run src/`, ~91 s) to `stages: [pre-commit]` with `pass_filenames: false`, so every commit — including no-op and unrelated files — paid the full suite on top of prettier and `tsc`.
- **Options considered:** Option 1 — move `unit-tests` stages only; Option 2 — move `unit-tests` to pre-push and pin prettier/lint/typecheck to pre-commit; Option 3 — also add `default_install_hook_types` so a plain `pre-commit install` gets push hooks.
- **Options rejected:** Option 1 — leaves prettier/lint/tsc re-running at push by default; Option 3 — changes install semantics beyond the issue (plain install skipping pre-push is already documented).
- **Selected option:** Option 2 — move unit-tests hook to pre-push
- **Residual risk:** developers who only ran `pre-commit install` still miss pre-push hooks (including the relocated suite); install both stages as documented. CI remains the enforcing gate.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/440-move-the-full-suite-from-pre-commit @ f3ad6c8` (2026-08-19)

## Changes

| File | Change |
|------|--------|
| `.pre-commit-config.yaml` | Move `unit-tests` to `stages: [pre-push]`; pin prettier, lint, typecheck to `[pre-commit]` |
| `docs/AGENT_ENVIRONMENT.md` | Document commit vs push hook split |
| `docs/DEVELOPMENT.md` | List push hooks; install both hook types |
| `CHANGELOG.md` | Unreleased infrastructure note for #440 |

## Test Results

- Unit tests: 2113 passed
- Integration tests: skipped
- E2e tests: skipped (hook config only)
- Build: skipped (no product compile)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| A no-op commit completes in under 20 seconds end to end | pass | `git commit --allow-empty` after the change: 0.31s real; commit-stage log shows unit-tests absent; empty commit reset (`git reset --hard HEAD~1`) and not pushed |
| The full suite still runs at pre-push, and CI remains the enforcing gate | pass | `.pre-commit-config.yaml:48-53` `unit-tests` `stages: [pre-push]`; `.github/workflows/ci.yml:66` still runs `npx vitest run src/` |
| `CI=true npm test` passes at 2100/2100 locally and in CI (baseline-green holds) | pass | `CI=true npm test` locally: 2113/2113 (current baseline after #436–#439; was 2100 at audit commit `ad961d2`) |

<!-- gitissue:qa v1 head=f3ad6c8e18c7abb43e73a6c559ab4585d922b56c profile=light cycles=1 review=clean tests=2113@f3ad6c8e18c7abb43e73a6c559ab4585d922b56c ui=none -->