### PR TITLE
chore(deps): record wave W1 security patches (#441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security
+
+- Close Wave W1 high advisories already resolved in the lockfile: `postcss` 8.5.26, `brace-expansion` 1.1.18, `js-yaml` 4.3.1, `nanoid` 3.3.18 ([#441](https://github.com/luongnv89/asm/issues/441))
+
 ### Infrastructure
 
 - Move the full unit suite from the pre-commit hook to pre-push; keep prettier, lint, typecheck, and the local security check as the fast commit subset ([#440](https://github.com/luongnv89/asm/issues/440))


### PR DESCRIPTION
Closes #441

## Summary

Wave W1's four patch-level advisory targets (`postcss` 8.5.26, `brace-expansion` 1.1.18, `js-yaml` 4.3.1, `nanoid` 3.3.18) already landed on `main` as a side-effect of #437 / PR #471. This PR records that closure in the changelog and does not remutate `package-lock.json`.

## Approach

Option 1 — Verify and close: confirm the four packages stay off the high-advisory list and close #441 without a new lockfile commit.

## Decision Record

- **Root cause:** W1's four patch-level advisory targets are already at patched versions on main as a side-effect of landing #437 (`c928ff8` inside PR #471): postcss 8.5.26, brace-expansion 1.1.18, js-yaml 4.3.1, nanoid 3.3.18. Live `npm audit` reports zero high/critical advisories for those packages. Remaining work is verify-and-close, not a second lockfile wave — AC2's "only these four subtrees" isolation was already violated by the mixed vite-override commit and cannot be reconstructed without a revert.
- **Options considered:** Option 1 — Verify and close; Option 2 — Restate W1 as its own commit; Option 3 — Fold leftover W1 into #442
- **Options rejected:** Option 2 — History rewrite / revert of a merged security commit.; Option 3 — There is no remaining W1 version delta to fold.
- **Selected option:** Option 1 — Verify and close
- **Residual risk:** AC2's dedicated-subtree commit was never produced; document that W1 landed inside #437. Do not re-touch these four packages in #442/#443.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `main @ 04165f3` (2026-08-19)

## Changes

| File | Change |
|------|--------|
| `CHANGELOG.md` | Record W1 advisory closures under Unreleased → Security |

## Test Results

- Unit tests: 2113 passed
- Integration tests: skipped
- E2e tests: passed (pre-push hook)
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `npm audit` reports zero advisories for `postcss`, `brace-expansion`, `js-yaml`, `nanoid` (high) | pass | Live `npm audit --json`: none of the four names appear in `vulnerabilities`; `metadata.vulnerabilities.high` is 0. Lockfile versions: postcss 8.5.26, brace-expansion 1.1.18, js-yaml 4.3.1, nanoid 3.3.18 |
| `package-lock.json` is committed with only these four packages' subtrees changed (high) | unverified | W1 versions already shipped inside #437 / PR #471 mixed with a vite override; reconstructing an isolated subtree commit would require reverting a merged security landing |
| `CI=true npm test` passes at 2100/2100 locally and in CI (baseline-green holds) (high) | pass | `CI=true npm test` → 2113/2113 at `4bbb8d9` (suite grew past the 2100 baseline) |

<!-- gitissue:qa v1 head=4bbb8d9fad8e65484e3a65db989dfcaaccedf650 profile=light cycles=1 review=clean tests=2113@4bbb8d9fad8e65484e3a65db989dfcaaccedf650 ui=none -->
