### PR TITLE
chore(node): raise Node floor to 22 and retarget CI matrix (#444)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        # Vitest 4 requires Node >=20. Product engines stay >=18 until #444.
-        node-version: [20, 22]
+        # Node 18/20 are EOL; floor is >=22 (see package.json engines / #444).
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
@@ -107,8 +107,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        # Vitest 4 requires Node >=20. Product engines stay >=18 until #444.
-        node-version: [20, 22]
+        # Node 18/20 are EOL; floor is >=22 (see package.json engines / #444).
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
@@ -142,8 +142,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        # Vitest 4 requires Node >=20. Product engines stay >=18 until #444.
-        node-version: [20, 22]
+        # Node 18/20 are EOL; floor is >=22 (see package.json engines / #444).
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/luongnv89/asm/stargazers"><img src="https://img.shields.io/github/stars/luongnv89/asm.svg?style=social" alt="GitHub stars" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License" /></a>
   <a href="https://github.com/luongnv89/asm/actions"><img src="https://github.com/luongnv89/asm/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/Node.js-%E2%89%A5%2018-339933.svg" alt="Node.js" /></a>
+  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/Node.js-%E2%89%A5%2022-339933.svg" alt="Node.js" /></a>
 </p>
 
 # CLI to install and manage agent skills
@@ -112,7 +112,7 @@ asm search "code review" --json
 
 Alternative install: `curl -sSL https://raw.githubusercontent.com/luongnv89/asm/main/install.sh | bash`
 
-Node.js 18+ required. Optional TUI: run `asm` with no arguments.
+Node.js 22+ required. Optional TUI: run `asm` with no arguments.
 
 ## Common tasks
 
@@ -1034,7 +1034,7 @@ asm/
 <details>
 <summary><strong>Tech stack</strong></summary>
 
-- **Runtime:** Node.js 18+
+- **Runtime:** Node.js 22+
 - **Language:** TypeScript + TSX
 - **Build:** esbuild
 - **TUI:** [Ink](https://github.com/vadimdemedes/ink) + [@inkjs/ui](https://github.com/vadimdemedes/ink-ui)

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "vite": "$vite"
   },
   "engines": {
-    "node": ">=18 <23",
+    "node": ">=22 <27",
     "npm": ">=9"
   },
   "keywords": [

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -96,7 +96,7 @@ describe("checkGhAuthenticated", () => {
 });
 
 describe("checkNodeVersion", () => {
-  test("returns pass for node >= 18", async () => {
+  test("returns pass for node >= 22", async () => {
     const result = await checkNodeVersion();
     expect(result.status).toBe("pass");
     expect(result.name).toBe("Node.js version");
@@ -463,12 +463,21 @@ describe("checkNodeVersion — mocked paths", () => {
     expect(result.message).toContain("requires");
   });
 
-  test("returns pass for node >= 18", async () => {
+  test("returns fail for node 20 (below the raised >= 22 floor)", async () => {
     const result = await checkNodeVersion({
       execFn: mockExec("v20.11.1\n"),
     });
+    expect(result.status).toBe("fail");
+    expect(result.message).toContain("20.11.1");
+    expect(result.message).toContain("requires");
+  });
+
+  test("returns pass for node >= 22", async () => {
+    const result = await checkNodeVersion({
+      execFn: mockExec("v22.11.0\n"),
+    });
     expect(result.status).toBe("pass");
-    expect(result.message).toBe("20.11.1");
+    expect(result.message).toBe("22.11.0");
   });
 });
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -183,7 +183,7 @@ export async function checkNodeVersion(
     });
     const version = stdout.trim().replace(/^v/, "");
     const major = parseInt(version.split(".")[0], 10);
-    if (major >= 18) {
+    if (major >= 22) {
       return {
         name: "Node.js version",
         status: "pass",
@@ -193,7 +193,7 @@ export async function checkNodeVersion(
     return {
       name: "Node.js version",
       status: "fail",
-      message: `${version} (requires >= 18.0)`,
+      message: `${version} (requires >= 22.0)`,
       fix: "Upgrade Node.js: https://nodejs.org",
     };
   } catch {
@@ -201,7 +201,7 @@ export async function checkNodeVersion(
       name: "Node.js version",
       status: "fail",
       message: "node not found",
-      fix: "Install Node.js >= 18: https://nodejs.org",
+      fix: "Install Node.js >= 22: https://nodejs.org",
     };
   }
 }


### PR DESCRIPTION
Closes #444

## Summary

Node 18 (EOL 2025-04-30) and Node 20 (EOL 2026-04-30) are both end-of-life; the installed runtime is v26.7.0, which sits outside the declared `>=18 <23` range. This raises the Node floor to 22 (LTS, EOL 2027-04-30), widens the ceiling to `<27` so Node 24 and 26 are admitted, and retargets the CI matrix to the two current LTS lines — `22` and `24`.

## Approach

Move the four places that asserted Node 18 together to the new floor of 22, in one atomic change:

- `package.json` `engines.node`: `>=18 <23` → `>=22 <27`
- `.github/workflows/ci.yml`: three matrices `[20, 22]` → `[22, 24]`; update the three stale `#444`-deferred comments
- `README.md`: badge + two prose floors → `Node.js 22+`
- `src/doctor.ts`: `checkNodeVersion` threshold and both user-facing messages/fix hints → `>=22`

The floor of 22 was chosen because it is the oldest line still in support (maintenance until 2027-04-30), matching the existing floor+ceiling convention. The ceiling `<27` admits the two versions the issue names as excluded (Node 24 LTS, EOL 2028-04-30; Node 26 LTS-from-Oct-2026, EOL 2029-04-30) while excluding nothing that is currently released.

## Decision Record

- **Selected option (balanced):** raise floor to Node 22, ceiling `<27`, CI matrix `[22, 24]`.
- **Rejected — keep Node 18 floor, only raise ceiling:** rejected because Node 18 is EOL (2025-04-30) and the issue explicitly calls removing it the highest-impact change; a ceiling-only fix leaves an EOL floor in place.
- **Rejected — raise floor to Node 24 only (skip 22):** rejected because Node 20 and 18 are the EOL versions, but Node 22 remains in LTS support until 2027-04-30; skipping it would over-constrain contributors on the still-supported 22 line without safety benefit, and the CI matrix should test the declared floor.

## Changes

| File | Change |
|------|--------|
| `package.json` | `engines.node` floor `18`→`22`, ceiling `<23`→`<27` |
| `.github/workflows/ci.yml` | three matrices `[20, 22]`→`[22, 24]`; updated three `#444`-deferred comments |
| `README.md` | badge `≥18`→`≥22`; two prose floors `Node.js 18+`→`Node.js 22+` |
| `src/doctor.ts` | `checkNodeVersion` threshold `18`→`22`; two messages/fix hints `>= 18`→`>= 22` |
| `src/doctor.test.ts` | mocked pass case `v20`→`v22`; added regression test asserting Node 20 now fails below the new floor |

## Test Results

- Unit suite: `2114 passed` / 62 files (`npx vitest run src/`)
- `doctor.test.ts`: 47 passed (incl. new `returns fail for node 20 (below the raised >= 22 floor)` regression test)
- `tsc --noEmit`: clean
- `npm run build`: success, entrypoint `node --check` OK
- Pre-commit hooks (prettier, lint, typecheck, yaml/json, security hardening): all passed
- Remote pre-push hook (e2e tests): passed

## Acceptance Criteria

- [x] `package.json` `engines.node` declares a floor with a future EOL date and a ceiling that admits Node 24 and 26 (high) — `>=22 <27`
- [x] The CI matrix contains no EOL Node version and the suite passes on every remaining entry (high) — matrix `[22, 24]`; suite green locally on v26 (within range), CI will run on 22 and 24
- [x] `README.md:15`, `:115`, `:1037` and `src/doctor.ts:204` all state the new floor — badge `≥22`, prose `Node.js 22+`×2, doctor `>= 22`×3 sites

<!-- gitissue:qa v1 head=98a9c3651f6b0ad745f23122df6a3a7aa94b56db profile=full qa_cycles=1 complexity=medium outcome=clean -->
