### PR TITLE
chore: remove duplicated and stale documentation sources

### DIFF
--- a/docs/archive/README.backup.md
+++ b/docs/archive/README.backup.md
@@ -1,3 +1,5 @@
+<!-- Archived 2026-08-19 — stale duplicate of live README.md / CHANGELOG.md. Kept for history; see README.md and CHANGELOG.md for current facts. -->
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/logo/logo-full.svg" />

--- a/docs/archive/RELEASE_NOTES.md
+++ b/docs/archive/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+<!-- Archived 2026-08-19 — stale duplicate of live README.md / CHANGELOG.md. Kept for history; see README.md and CHANGELOG.md for current facts. -->
+
 ## v1.1.0 — 2026-03-11
 
 ### Features

--- a/docs/archive/TODOS.md
+++ b/docs/archive/TODOS.md
@@ -1,3 +1,5 @@
+<!-- Archived 2026-08-19 — stale duplicate of live README.md / CHANGELOG.md. Kept for history; see README.md and CHANGELOG.md for current facts. -->
+
 # TODOS
 
 Strategic roadmap for **agent-skill-manager** — the npm for AI skills.

--- a/docs/archive/prd.md
+++ b/docs/archive/prd.md
@@ -1,3 +1,5 @@
+<!-- Archived 2026-08-19 — stale duplicate of live README.md / CHANGELOG.md. Kept for history; see README.md and CHANGELOG.md for current facts. -->
+
 # Product Requirements Document — agent-skill-manager
 
 **Product:** agent-skill-manager (`asm`)

--- a/docs/archive/tasks.md
+++ b/docs/archive/tasks.md
@@ -1,3 +1,5 @@
+<!-- Archived 2026-08-19 — stale duplicate of live README.md / CHANGELOG.md. Kept for history; see README.md and CHANGELOG.md for current facts. -->
+
 # Development Tasks — agent-skill-manager
 
 **Source:** [prd.md](prd.md)


### PR DESCRIPTION
Closes #457. Part of epic #432 (modernization plan task 3.5).

## Summary

Archives five stale/duplicated root-level docs under `docs/archive/`:

| File | Why stale |
|------|-----------|
| `README.backup.md` | 1,237-line duplicate of live README; guaranteed to drift |
| `tasks.md` | Generated 2026-03-19, stale, superseded by current plan |
| `TODOS.md` | Roadmap from 2026-03-19, superseded by CHANGELOG |
| `prd.md` | PRD pinned to v1.10.0; tool is v2.15.0 |
| `RELEASE_NOTES.md` | Last entry v1.1.0 (2026-03-11); superseded by CHANGELOG.md |

Each archived file gets a one-line preamble marking it archived and pointing at the live `README.md` / `CHANGELOG.md`. Git history remains the backup.

## Acceptance criteria (#457)

- [x] `README.backup.md` no longer exists at the repo root
- [x] `tasks.md`, `TODOS.md`, `prd.md`, `RELEASE_NOTES.md` are deleted or moved under `docs/archive/`
- [x] No remaining root-level `.md` contradicts `README.md` or `CHANGELOG.md` on setup or release facts (the five named files are archived; no source files reference them)
- [x] `CI=true npm test` baseline-green holds — docs-only change; `npm run typecheck` and `npm run build` pass

Closes `F-DEAD-001`, `F-DEAD-003`, `F-DOCS-002`.