### PR TITLE
test: characterization tests for the TUI container and views

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,0 +1,482 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "ink-testing-library";
+import type { SkillInfo, AppConfig, AuditReport } from "./utils/types";
+
+// ── Hermetic stubs for the domain modules the App container orchestrates ───
+// The container's job is to wire these together and drive view transitions via
+// keyboard. We stub the domain modules so the test asserts container behavior,
+// not real scanner/auditor/uninstaller I/O.
+//
+// vi.mock factories are hoisted above all top-level code, so the mock fns and
+// the return data they close over must live inside a single vi.hoisted() block.
+const mocks = vi.hoisted(() => {
+  const SKILLS: SkillInfo[] = [
+    {
+      name: "skill-one",
+      version: "1.0.0",
+      description: "First skill.",
+      creator: "tester",
+      license: "MIT",
+      compatibility: "",
+      allowedTools: [],
+      dirName: "skill-one",
+      path: "/tmp/skill-one",
+      originalPath: "/tmp/skill-one",
+      location: "global",
+      scope: "global",
+      provider: "claude",
+      providerLabel: "Claude",
+      isSymlink: false,
+      symlinkTarget: null,
+      realPath: "/tmp/skill-one",
+      fileCount: 1,
+    },
+    {
+      name: "skill-two",
+      version: "2.0.0",
+      description: "Second skill.",
+      creator: "tester",
+      license: "MIT",
+      compatibility: "",
+      allowedTools: [],
+      dirName: "skill-two",
+      path: "/tmp/skill-two",
+      originalPath: "/tmp/skill-two",
+      location: "project",
+      scope: "project",
+      provider: "codex",
+      providerLabel: "Codex",
+      isSymlink: false,
+      symlinkTarget: null,
+      realPath: "/tmp/skill-two",
+      fileCount: 2,
+    },
+  ];
+
+  const EMPTY_AUDIT: AuditReport = {
+    scannedAt: "2026-08-19T00:00:00.000Z",
+    totalSkills: 2,
+    duplicateGroups: [],
+    totalDuplicateInstances: 0,
+  };
+
+  const CONFIG: AppConfig = {
+    version: 1,
+    providers: [
+      {
+        name: "claude",
+        label: "Claude",
+        global: "/g/claude",
+        project: "/p/claude",
+        enabled: true,
+      },
+      {
+        name: "codex",
+        label: "Codex",
+        global: "/g/codex",
+        project: "/p/codex",
+        enabled: true,
+      },
+    ],
+    customPaths: [],
+    preferences: { defaultScope: "both", defaultSort: "name" },
+  };
+
+  return {
+    SKILLS,
+    EMPTY_AUDIT,
+    CONFIG,
+    scanAllSkills: vi.fn(async () => SKILLS),
+    searchSkills: vi.fn((skills: SkillInfo[]) => skills),
+    sortSkills: vi.fn((skills: SkillInfo[]) => skills),
+    detectDuplicates: vi.fn(() => EMPTY_AUDIT),
+    loadConfig: vi.fn(async () => CONFIG),
+    saveConfig: vi.fn(async () => {}),
+    getConfigPath: vi.fn(() => "/tmp/config.json"),
+    buildFullRemovalPlan: vi.fn(() => ({
+      directories: [],
+      ruleFiles: [],
+      agentsBlocks: [],
+    })),
+    buildRemovalPlan: vi.fn(() => ({
+      directories: [],
+      ruleFiles: [],
+      agentsBlocks: [],
+    })),
+    executeRemoval: vi.fn(async () => {}),
+    getExistingTargets: vi.fn(async () => ["/tmp/target"]),
+  };
+});
+
+vi.mock("./scanner", () => ({
+  scanAllSkills: mocks.scanAllSkills,
+  searchSkills: mocks.searchSkills,
+  sortSkills: mocks.sortSkills,
+}));
+
+vi.mock("./auditor", () => ({
+  detectDuplicates: mocks.detectDuplicates,
+}));
+
+vi.mock("./config", () => ({
+  loadConfig: mocks.loadConfig,
+  saveConfig: mocks.saveConfig,
+  getConfigPath: mocks.getConfigPath,
+}));
+
+vi.mock("./uninstaller", () => ({
+  buildFullRemovalPlan: mocks.buildFullRemovalPlan,
+  buildRemovalPlan: mocks.buildRemovalPlan,
+  executeRemoval: mocks.executeRemoval,
+  getExistingTargets: mocks.getExistingTargets,
+}));
+
+// Mock ink's render so main()'s waitUntilExit resolves immediately instead of
+// blocking on a real interactive terminal. The real render is exercised by the
+// App-level tests above; here we only characterize the bootstrap/restore path.
+const inkRenderMock = vi.hoisted(() => ({
+  render: vi.fn(() => ({
+    rerender: vi.fn(),
+    unmount: vi.fn(),
+    waitUntilExit: vi.fn(async () => {}),
+    clear: vi.fn(),
+    write: vi.fn(),
+  })),
+}));
+vi.mock("ink", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("ink");
+  return { ...actual, render: inkRenderMock.render };
+});
+
+// Import App AFTER the mocks are in place.
+const { App } = await import("./index");
+
+const { CONFIG } = mocks;
+const tick = () => new Promise<void>((r) => setTimeout(r, 60));
+
+describe("App container", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the dashboard with the scanned skill list on mount", async () => {
+    const { lastFrame, unmount } = render(<App initialConfig={CONFIG} />);
+    await tick();
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("agent-skill-manager");
+    expect(frame).toContain("skill-one");
+    expect(frame).toContain("skill-two");
+    expect(frame).toContain("Total: 2");
+    unmount();
+  });
+
+  it("opens the help view on '?' from the dashboard and closes it on '?' again", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    expect(lastFrame()).toContain("Navigate");
+    stdin.write("?");
+    await tick();
+    expect(lastFrame()).toContain("Keyboard Shortcuts");
+    stdin.write("?");
+    await tick();
+    expect(lastFrame()).toContain("Navigate");
+    unmount();
+  });
+
+  it("opens the help view on '?' and closes it on Esc", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    stdin.write("?");
+    await tick();
+    expect(lastFrame()).toContain("Keyboard Shortcuts");
+    stdin.write("\u001b"); // Esc
+    await tick();
+    expect(lastFrame()).toContain("Navigate");
+    unmount();
+  });
+
+  it("opens the config view on 'c' and returns to dashboard on Esc", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    stdin.write("c");
+    await tick();
+    const configFrame = lastFrame() ?? "";
+    expect(configFrame).toContain("Configuration");
+    // Config owns its Esc handling; closing it calls onClose → saveConfig + dashboard.
+    stdin.write("\u001b"); // Esc
+    await tick();
+    expect(lastFrame()).toContain("Navigate");
+    unmount();
+  });
+
+  it("opens the audit view on 'a' and returns to dashboard on its Esc", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    stdin.write("a");
+    await tick();
+    // The audit (Duplicates) view renders its own panel, not the search prompt.
+    const auditFrame = lastFrame() ?? "";
+    expect(auditFrame).not.toContain("press / to search...");
+    stdin.write("\u001b"); // Esc — DuplicatesView onClose → dashboard
+    await tick();
+    expect(lastFrame()).toContain("Navigate");
+    unmount();
+  });
+
+  it("moves the cursor down with j and opens the detail view on Enter", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    // Cursor starts on skill-one (index 0). Move to skill-two.
+    stdin.write("j");
+    await tick();
+    stdin.write("\r"); // Enter → detail
+    await tick();
+    const detailFrame = lastFrame() ?? "";
+    expect(detailFrame).toContain("skill-two");
+    expect(detailFrame).toContain("Esc Back d Uninstall");
+    unmount();
+  });
+
+  it("enters search mode on '/' and exits on Esc", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    stdin.write("/");
+    await tick();
+    expect(lastFrame()).toContain("type to search...");
+    stdin.write("\u001b"); // Esc → leave search mode
+    await tick();
+    expect(lastFrame()).toContain("press / to search...");
+    unmount();
+  });
+
+  it("cycles the sort order on 's'", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    // Starts on name → [name]. After 's' it becomes [version].
+    stdin.write("s");
+    await tick();
+    expect(lastFrame()).toContain("[version]");
+    unmount();
+  });
+
+  it("cycles the scope on Tab", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    // Starts on both. Tab cycles to global.
+    stdin.write("\t");
+    await tick();
+    expect(lastFrame()).toContain("Global");
+    unmount();
+  });
+
+  it("opens the confirm view on 'd' for the selected skill", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    stdin.write("d");
+    await tick();
+    const confirmFrame = lastFrame() ?? "";
+    expect(confirmFrame).toContain("Uninstall:");
+    expect(confirmFrame).toContain("skill-one");
+    unmount();
+  });
+
+  it("navigates to the detail view then opens confirm on 'd' from detail", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    stdin.write("\r"); // Enter → detail
+    await tick();
+    expect(lastFrame()).toContain("Esc Back d Uninstall");
+    stdin.write("d"); // 'd' in detail view → showConfirm
+    await tick();
+    const confirmFrame = lastFrame() ?? "";
+    expect(confirmFrame).toContain("Uninstall:");
+    unmount();
+  });
+
+  it("exits the detail view on Esc back to the dashboard", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    stdin.write("\r"); // Enter → detail
+    await tick();
+    expect(lastFrame()).toContain("Esc Back d Uninstall");
+    stdin.write("\u001b"); // Esc → dashboard
+    await tick();
+    expect(lastFrame()).toContain("Navigate");
+    unmount();
+  });
+
+  it("refreshes the skill list on 'r'", async () => {
+    const { stdin, unmount } = render(<App initialConfig={CONFIG} />);
+    await tick();
+    const callsBefore = mocks.scanAllSkills.mock.calls.length;
+    stdin.write("r");
+    await tick();
+    expect(mocks.scanAllSkills.mock.calls.length).toBeGreaterThan(callsBefore);
+    unmount();
+  });
+
+  it("moves the cursor up with k and stays in bounds", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    stdin.write("k"); // up from index 0 — clamped
+    await tick();
+    stdin.write("\r"); // Enter → detail of skill-one (still at 0)
+    await tick();
+    expect(lastFrame()).toContain("skill-one");
+    unmount();
+  });
+
+  it("pages down with PageDown and opens detail on Enter", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    stdin.write("\u001b[6~"); // PageDown
+    await tick();
+    stdin.write("\r"); // Enter → detail
+    await tick();
+    // Two skills; PageDown moves to the last one.
+    expect(lastFrame()).toContain("Esc Back d Uninstall");
+    unmount();
+  });
+
+  it("submits a search query and returns to the dashboard", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    stdin.write("/");
+    await tick();
+    expect(lastFrame()).toContain("type to search...");
+    // Type a query then Enter to submit (onSearchSubmit path, lines 329-332).
+    stdin.write("skill-one");
+    stdin.write("\r");
+    await tick();
+    // Submitting search leaves search mode and applies the query as a filter.
+    expect(lastFrame()).not.toContain("type to search...");
+    unmount();
+  });
+
+  it("confirms an uninstall and returns to the dashboard after removal", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <App initialConfig={CONFIG} />,
+    );
+    await tick();
+    // Open the confirm view for skill-one.
+    stdin.write("d");
+    await tick();
+    expect(lastFrame()).toContain("Uninstall:");
+    // The @inkjs/ui Select defaults to "Cancel". Move up to "Yes, uninstall"
+    // then press Enter to fire onResult(true) → handleConfirmResult(true).
+    stdin.write("\u001b[A"); // up arrow → "Yes, uninstall"
+    await tick();
+    stdin.write("\r"); // Enter → confirm
+    await tick();
+    await tick();
+    // The confirmed path calls executeRemoval then returns to dashboard.
+    expect(mocks.executeRemoval).toHaveBeenCalled();
+    expect(lastFrame()).toContain("Navigate");
+    unmount();
+  });
+});
+
+// ── main() bootstrap smoke test ────────────────────────────────────────────
+// main() is the TUI entry point: it loads config, enters the alt-screen buffer,
+// renders <App>, and restores the buffer on exit. We mock ink's render so
+// waitUntilExit resolves immediately, exercising the bootstrap + restore path
+// without spawning a real interactive terminal.
+describe("main()", () => {
+  it("loads config, renders the app, and restores the alt-screen buffer on exit", async () => {
+    const { main } = await import("./index");
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    // Capture the process listeners so we can assert they were registered.
+    const onSpy = vi.spyOn(process, "on");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      // no-op: prevent actual exit
+    }) as never);
+
+    await main();
+
+    // loadConfig was called (mocked) — the config path is exercised.
+    expect(mocks.loadConfig).toHaveBeenCalled();
+    // The alt-screen enter sequence was written to stdout.
+    expect(writeSpy).toHaveBeenCalledWith("\u001b[?1049h");
+    // The exit listener was registered for restore-on-exit.
+    expect(onSpy).toHaveBeenCalledWith("exit", expect.any(Function));
+    // The leave-alt-screen sequence is written by restore() in the finally.
+    expect(writeSpy).toHaveBeenCalledWith("\u001b[?1049l");
+
+    writeSpy.mockRestore();
+    onSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("restores the alt-screen buffer and exits on SIGINT/SIGTERM", async () => {
+    const { main } = await import("./index");
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    // Capture the SIGINT/SIGTERM listeners main() registers.
+    const signalListeners: Record<
+      string,
+      ((...a: unknown[]) => void) | undefined
+    > = {};
+    const onSpy = vi.spyOn(process, "on").mockImplementation(((
+      event: string,
+      cb: (...a: unknown[]) => void,
+    ) => {
+      if (event === "SIGINT" || event === "SIGTERM") {
+        signalListeners[event] = cb;
+      }
+      return process;
+    }) as never);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      // no-op
+    }) as never);
+
+    await main();
+
+    // Trigger the SIGINT handler — it restores the buffer and calls
+    // process.exit(130). restore() is idempotent (guarded by a `restored`
+    // flag, already set by the finally), so we assert the exit code, not a
+    // second leave-sequence write.
+    signalListeners.SIGINT?.();
+    expect(exitSpy).toHaveBeenCalledWith(130);
+
+    // Trigger the SIGTERM handler — exits 143.
+    signalListeners.SIGTERM?.();
+    expect(exitSpy).toHaveBeenCalledWith(143);
+
+    writeSpy.mockRestore();
+    onSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/src/views/config.test.tsx
+++ b/src/views/config.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { ConfigView } from "./config";
+import type { AppConfig } from "../utils/types";
+
+const ENTER = "\r";
+const ESC = "\u001b";
+const ARROW_DOWN = "\u001b[B";
+const ARROW_UP = "\u001b[A";
+
+function makeConfig(over: Partial<AppConfig> = {}): AppConfig {
+  return {
+    version: 1,
+    providers: [
+      {
+        name: "claude",
+        label: "Claude Code",
+        global: "/global/claude",
+        project: "/proj/claude",
+        enabled: true,
+      },
+      {
+        name: "codex",
+        label: "Codex",
+        global: "/global/codex",
+        project: "/proj/codex",
+        enabled: false,
+      },
+    ],
+    customPaths: [],
+    preferences: { defaultScope: "both", defaultSort: "name" },
+    ...over,
+  };
+}
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 50));
+
+describe("ConfigView", () => {
+  it("renders the configuration panel with each provider row and its status", () => {
+    const config = makeConfig();
+    const { lastFrame } = render(
+      <ConfigView config={config} onClose={vi.fn()} onOpenEditor={vi.fn()} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Configuration");
+    expect(frame).toContain("Claude Code");
+    expect(frame).toContain("Codex");
+    expect(frame).toContain("Tools (Enter to toggle, e to edit config file):");
+    expect(frame).toContain("Enter Toggle e Edit file Esc Save & close");
+    // First provider enabled, second disabled.
+    expect(frame).toContain("✔ ON");
+    expect(frame).toContain("✘ OFF");
+  });
+
+  it("shows the project path for the selected (first) row", () => {
+    const { lastFrame } = render(
+      <ConfigView
+        config={makeConfig()}
+        onClose={vi.fn()}
+        onOpenEditor={vi.fn()}
+      />,
+    );
+    expect(lastFrame()).toContain("Project: /proj/claude");
+  });
+
+  it("renders custom paths when present", () => {
+    const config = makeConfig({
+      customPaths: [{ path: "/custom/x", label: "Custom X", scope: "global" }],
+    });
+    const { lastFrame } = render(
+      <ConfigView config={config} onClose={vi.fn()} onOpenEditor={vi.fn()} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Custom Paths:");
+    expect(frame).toContain("Custom X: /custom/x (global)");
+  });
+
+  it("toggles the selected provider on Enter", async () => {
+    const onClose = vi.fn();
+    const config = makeConfig();
+    const { stdin, unmount } = render(
+      <ConfigView config={config} onClose={onClose} onOpenEditor={vi.fn()} />,
+    );
+    await tick();
+    // First provider starts ON; Enter flips it OFF.
+    stdin.write(ENTER);
+    await tick();
+    expect(onClose).not.toHaveBeenCalled();
+    // Confirm by closing with Esc and inspecting the emitted config.
+    stdin.write(ESC);
+    await tick();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    const emitted = onClose.mock.calls[0][0] as AppConfig;
+    expect(emitted.providers[0].enabled).toBe(false);
+    unmount();
+  });
+
+  it("moves the selection down with the down arrow", async () => {
+    const onClose = vi.fn();
+    const { stdin, lastFrame, unmount } = render(
+      <ConfigView
+        config={makeConfig()}
+        onClose={onClose}
+        onOpenEditor={vi.fn()}
+      />,
+    );
+    await tick();
+    // Initially the first provider (Claude Code) is selected → its project path shows.
+    expect(lastFrame()).toContain("Project: /proj/claude");
+    stdin.write(ARROW_DOWN);
+    await tick();
+    // Now the second provider (Codex) is selected → its project path shows.
+    expect(lastFrame()).toContain("Project: /proj/codex");
+    unmount();
+  });
+
+  it("wraps selection up from the first to the last row", async () => {
+    const { stdin, lastFrame, unmount } = render(
+      <ConfigView
+        config={makeConfig()}
+        onClose={vi.fn()}
+        onOpenEditor={vi.fn()}
+      />,
+    );
+    await tick();
+    expect(lastFrame()).toContain("Project: /proj/claude");
+    stdin.write(ARROW_UP);
+    await tick();
+    expect(lastFrame()).toContain("Project: /proj/codex");
+    unmount();
+  });
+
+  it("invokes onOpenEditor when e is pressed", async () => {
+    const onOpenEditor = vi.fn();
+    const { stdin, unmount } = render(
+      <ConfigView
+        config={makeConfig()}
+        onClose={vi.fn()}
+        onOpenEditor={onOpenEditor}
+      />,
+    );
+    await tick();
+    stdin.write("e");
+    await tick();
+    expect(onOpenEditor).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("passes the current edit state to onClose on Esc", async () => {
+    const onClose = vi.fn();
+    const { stdin, unmount } = render(
+      <ConfigView
+        config={makeConfig()}
+        onClose={onClose}
+        onOpenEditor={vi.fn()}
+      />,
+    );
+    await tick();
+    stdin.write(ESC);
+    await tick();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    const emitted = onClose.mock.calls[0][0] as AppConfig;
+    expect(emitted.providers).toHaveLength(2);
+    unmount();
+  });
+});

--- a/src/views/confirm.test.tsx
+++ b/src/views/confirm.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { ConfirmView } from "./confirm";
+import type { SkillInfo } from "../utils/types";
+
+function makeSkill(over: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    name: "sample-skill",
+    version: "1.0.0",
+    description: "A sample skill.",
+    creator: "tester",
+    license: "MIT",
+    compatibility: "",
+    allowedTools: [],
+    dirName: "sample-skill",
+    path: "/tmp/sample-skill",
+    originalPath: "/tmp/sample-skill",
+    location: "global",
+    scope: "global",
+    provider: "claude",
+    providerLabel: "Claude Code",
+    isSymlink: false,
+    symlinkTarget: null,
+    realPath: "/tmp/sample-skill",
+    fileCount: 1,
+    ...over,
+  };
+}
+
+describe("ConfirmView", () => {
+  it("renders the uninstall title with the skill name", () => {
+    const { lastFrame } = render(
+      <ConfirmView
+        skill={makeSkill({ name: "dangerous-skill" })}
+        targets={["/tmp/dangerous-skill"]}
+        onResult={vi.fn()}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Uninstall: dangerous-skill");
+  });
+
+  it("lists the target paths that will be removed", () => {
+    const targets = ["/path/a", "/path/b", "/path/c"];
+    const { lastFrame } = render(
+      <ConfirmView skill={makeSkill()} targets={targets} onResult={vi.fn()} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("The following will be removed:");
+    for (const t of targets) {
+      expect(frame).toContain(t);
+    }
+  });
+
+  it("shows a no-files-found message when targets is empty", () => {
+    const { lastFrame } = render(
+      <ConfirmView skill={makeSkill()} targets={[]} onResult={vi.fn()} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("(no files found to remove)");
+  });
+
+  it("renders the confirm and cancel choices", () => {
+    const { lastFrame } = render(
+      <ConfirmView skill={makeSkill()} targets={["/x"]} onResult={vi.fn()} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Yes, uninstall");
+    expect(frame).toContain("Cancel");
+  });
+});

--- a/src/views/dashboard.test.tsx
+++ b/src/views/dashboard.test.tsx
@@ -1,0 +1,232 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "ink-testing-library";
+import { DashboardHeader, DashboardFooter } from "./dashboard";
+import type { SkillInfo, AppConfig } from "../utils/types";
+
+function makeSkill(over: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    name: "sample-skill",
+    version: "1.0.0",
+    description: "A sample skill.",
+    creator: "tester",
+    license: "MIT",
+    compatibility: "",
+    allowedTools: [],
+    dirName: "sample-skill",
+    path: "/tmp/sample-skill",
+    originalPath: "/tmp/sample-skill",
+    location: "global",
+    scope: "global",
+    provider: "claude",
+    providerLabel: "Claude Code",
+    isSymlink: false,
+    symlinkTarget: null,
+    realPath: "/tmp/sample-skill",
+    fileCount: 1,
+    ...over,
+  };
+}
+
+function makeConfig(over: Partial<AppConfig> = {}): AppConfig {
+  return {
+    version: 1,
+    providers: [
+      {
+        name: "claude",
+        label: "Claude",
+        global: "/a",
+        project: "/b",
+        enabled: true,
+      },
+      {
+        name: "codex",
+        label: "Codex",
+        global: "/c",
+        project: "/d",
+        enabled: true,
+      },
+    ],
+    customPaths: [],
+    preferences: { defaultScope: "both", defaultSort: "name" },
+    ...over,
+  };
+}
+
+// ink lays the stats row out in a bordered row Box, so multi-token fields like
+// "Total: 3 (2 unique)" can wrap across rendered lines. Collapse whitespace so
+// assertions are layout-agnostic.
+function collapse(frame: string): string {
+  return frame.replace(/\s+/g, " ");
+}
+
+describe("DashboardHeader", () => {
+  it("renders the app title and aggregate stats from the skill list", () => {
+    const skills = [
+      makeSkill({ dirName: "a", scope: "global" }),
+      makeSkill({ dirName: "b", scope: "project" }),
+      makeSkill({
+        dirName: "a",
+        scope: "global",
+        isSymlink: true,
+        provider: "codex",
+      }),
+    ];
+    const { lastFrame } = render(
+      <DashboardHeader
+        config={makeConfig()}
+        skills={skills}
+        duplicateCount={1}
+        sort="name"
+        scope="both"
+        searchMode={false}
+        searchQuery=""
+        onSearchChange={() => {}}
+        onSearchSubmit={() => {}}
+      />,
+    );
+    const frame = collapse(lastFrame() ?? "");
+    expect(frame).toContain("agent-skill-manager");
+    // The stats row wraps inside a bordered Box at 80 cols, so assert each label
+    // and its computed value separately. Aggregate is: total=3, unique=2,
+    // global=2, project=1, symlinks=1, providers=2, dupes=1.
+    expect(frame).toContain("Total: 3");
+    expect(frame).toContain("unique");
+    expect(frame).toContain("Global:");
+    expect(frame).toContain("Project:");
+    expect(frame).toContain("Symlinks:");
+    expect(frame).toContain("Tools:");
+    expect(frame).toContain("Dupes:");
+    // The values column-group renders as "2 1 1 2 1" after the labels (global
+    // 2, project 1, symlinks 1, tools 2, dupes 1).
+    expect(frame).toContain("2 1 1 2 1");
+  });
+
+  it("renders the sort label with the active sort bracketed", () => {
+    const { lastFrame } = render(
+      <DashboardHeader
+        config={makeConfig()}
+        skills={[]}
+        duplicateCount={0}
+        sort="version"
+        scope="both"
+        searchMode={false}
+        searchQuery=""
+        onSearchChange={() => {}}
+        onSearchSubmit={() => {}}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    // buildSortLabel: "(s) Sort: name  [version]  location"
+    expect(frame).toContain("[version]");
+    expect(frame).toContain("Sort:");
+  });
+
+  it("highlights the active scope tab and dims the others", () => {
+    const { lastFrame } = render(
+      <DashboardHeader
+        config={makeConfig()}
+        skills={[]}
+        duplicateCount={0}
+        sort="name"
+        scope="project"
+        searchMode={false}
+        searchQuery=""
+        onSearchChange={() => {}}
+        onSearchSubmit={() => {}}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Global");
+    expect(frame).toContain("Project");
+    expect(frame).toContain("Both");
+  });
+
+  it("shows the search prompt when not in search mode", () => {
+    const { lastFrame } = render(
+      <DashboardHeader
+        config={makeConfig()}
+        skills={[]}
+        duplicateCount={0}
+        sort="name"
+        scope="both"
+        searchMode={false}
+        searchQuery=""
+        onSearchChange={() => {}}
+        onSearchSubmit={() => {}}
+      />,
+    );
+    expect(lastFrame()).toContain("press / to search...");
+  });
+
+  it("shows the current query when a filter is set but search mode is off", () => {
+    const { lastFrame } = render(
+      <DashboardHeader
+        config={makeConfig()}
+        skills={[]}
+        duplicateCount={0}
+        sort="name"
+        scope="both"
+        searchMode={false}
+        searchQuery="my-filter"
+        onSearchChange={() => {}}
+        onSearchSubmit={() => {}}
+      />,
+    );
+    expect(lastFrame()).toContain("my-filter");
+    expect(lastFrame()).not.toContain("press / to search...");
+  });
+
+  it("truncates the scope description when more than 3 providers are enabled", () => {
+    const config = makeConfig({
+      providers: [
+        { name: "a", label: "Alpha", global: "/a", project: "", enabled: true },
+        { name: "b", label: "Beta", global: "/b", project: "", enabled: true },
+        { name: "c", label: "Gamma", global: "/c", project: "", enabled: true },
+        { name: "d", label: "Delta", global: "/d", project: "", enabled: true },
+        {
+          name: "e",
+          label: "Epsilon",
+          global: "/e",
+          project: "",
+          enabled: false,
+        },
+      ],
+    });
+    const { lastFrame } = render(
+      <DashboardHeader
+        config={config}
+        skills={[]}
+        duplicateCount={0}
+        sort="name"
+        scope="both"
+        searchMode={false}
+        searchQuery=""
+        onSearchChange={() => {}}
+        onSearchSubmit={() => {}}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    // 4 enabled → "Alpha, Beta +2"
+    expect(frame).toContain("Alpha, Beta +2");
+    expect(frame).not.toContain("Epsilon");
+  });
+});
+
+describe("DashboardFooter", () => {
+  it("renders the keybinding hint line", () => {
+    const { lastFrame } = render(<DashboardFooter />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Navigate");
+    expect(frame).toContain("View");
+    expect(frame).toContain("Uninstall");
+    expect(frame).toContain("Audit");
+    expect(frame).toContain("Filter");
+    expect(frame).toContain("Scope");
+    expect(frame).toContain("Sort");
+    expect(frame).toContain("Refresh");
+    expect(frame).toContain("Config");
+    expect(frame).toContain("Quit");
+    expect(frame).toContain("Help");
+  });
+});

--- a/src/views/help.test.tsx
+++ b/src/views/help.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "ink-testing-library";
+import { HelpView } from "./help";
+
+describe("HelpView", () => {
+  it("renders the keyboard shortcuts panel with all keybindings", () => {
+    const { lastFrame } = render(<HelpView />);
+    const frame = lastFrame() ?? "";
+
+    expect(frame).toContain("Keyboard Shortcuts");
+    expect(frame).toContain("Press ? or Esc to close");
+
+    // Every keybinding row is present (characterization — do not silently lose one).
+    const expectedKeys = [
+      "↑ / k",
+      "↓ / j",
+      "Enter",
+      "d",
+      "a",
+      "/",
+      "Esc",
+      "Tab",
+      "s",
+      "r",
+      "c",
+      "?",
+      "q",
+    ];
+    for (const key of expectedKeys) {
+      expect(frame).toContain(key);
+    }
+
+    // A representative action label for each binding.
+    expect(frame).toContain("Move up");
+    expect(frame).toContain("Move down");
+    expect(frame).toContain("View skill details");
+    expect(frame).toContain("Uninstall skill");
+    expect(frame).toContain("Audit duplicates");
+    expect(frame).toContain("Search / filter");
+    expect(frame).toContain("Cycle scope");
+    expect(frame).toContain("Cycle sort order");
+    expect(frame).toContain("Refresh / rescan skills");
+    expect(frame).toContain("Open configuration");
+    expect(frame).toContain("Toggle this help");
+    expect(frame).toContain("Quit");
+  });
+
+  it("renders the version string from the version module", () => {
+    const { lastFrame } = render(<HelpView />);
+    expect(lastFrame()).toBeTruthy();
+  });
+});

--- a/src/views/skill-detail.test.tsx
+++ b/src/views/skill-detail.test.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "ink-testing-library";
+import { SkillDetailView } from "./skill-detail";
+import type { SkillInfo } from "../utils/types";
+
+function makeSkill(over: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    name: "sample-skill",
+    version: "2.3.4",
+    description: "A sample skill that does things.",
+    creator: "tester",
+    license: "MIT",
+    compatibility: "claude>=1.0",
+    allowedTools: ["Read", "Grep", "Bash"],
+    dirName: "sample-skill",
+    path: "/tmp/sample-skill",
+    originalPath: "/tmp/sample-skill",
+    location: "global",
+    scope: "global",
+    provider: "claude",
+    providerLabel: "Claude Code",
+    isSymlink: false,
+    symlinkTarget: null,
+    realPath: "/tmp/sample-skill",
+    fileCount: 5,
+    effort: "medium",
+    ...over,
+  };
+}
+
+describe("SkillDetailView", () => {
+  it("renders the skill name as the centered title", () => {
+    const { lastFrame } = render(<SkillDetailView skill={makeSkill()} />);
+    expect(lastFrame()).toContain("sample-skill");
+  });
+
+  it("renders the core metadata rows", () => {
+    const { lastFrame } = render(<SkillDetailView skill={makeSkill()} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Name:");
+    expect(frame).toContain("Version:");
+    expect(frame).toContain("2.3.4");
+    expect(frame).toContain("Creator:");
+    expect(frame).toContain("tester");
+    expect(frame).toContain("License:");
+    expect(frame).toContain("MIT");
+    expect(frame).toContain("Compatibility:");
+    expect(frame).toContain("claude>=1.0");
+    expect(frame).toContain("Effort:");
+    expect(frame).toContain("medium");
+    expect(frame).toContain("Location:");
+    expect(frame).toContain("Path:");
+    expect(frame).toContain("/tmp/sample-skill");
+    expect(frame).toContain("Scope:");
+    expect(frame).toContain("global");
+    expect(frame).toContain("Tool:");
+    expect(frame).toContain("Claude Code");
+  });
+
+  it("shows the provided file count", () => {
+    const { lastFrame } = render(
+      <SkillDetailView skill={makeSkill({ fileCount: 42 })} />,
+    );
+    expect(lastFrame()).toContain("Files:");
+    expect(lastFrame()).toContain("42");
+  });
+
+  it("renders 'no' for the symlink row when the skill is not a symlink", () => {
+    const { lastFrame } = render(<SkillDetailView skill={makeSkill()} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Symlink:");
+    expect(frame).toContain("no");
+  });
+
+  it("renders the symlink target when the skill is a symlink", () => {
+    const { lastFrame } = render(
+      <SkillDetailView
+        skill={makeSkill({ isSymlink: true, symlinkTarget: "/real/path" })}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("yes → /real/path");
+  });
+
+  it("renders the description, word-wrapped", () => {
+    const { lastFrame } = render(<SkillDetailView skill={makeSkill()} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Description:");
+    expect(frame).toContain("A sample skill that does things.");
+  });
+
+  it("renders '(no description)' when the skill has none", () => {
+    const { lastFrame } = render(
+      <SkillDetailView skill={makeSkill({ description: "" })} />,
+    );
+    expect(lastFrame()).toContain("(no description)");
+  });
+
+  it("lists allowed tools", () => {
+    const { lastFrame } = render(<SkillDetailView skill={makeSkill()} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Allowed Tools:");
+    expect(frame).toContain("Read");
+    expect(frame).toContain("Grep");
+    expect(frame).toContain("Bash");
+  });
+
+  it("warns that a Bash skill can execute shell commands", () => {
+    const { lastFrame } = render(
+      <SkillDetailView skill={makeSkill({ allowedTools: ["Bash"] })} />,
+    );
+    expect(lastFrame()).toContain("execute shell commands");
+  });
+
+  it("warns that a Write/Edit skill can modify files", () => {
+    const { lastFrame } = render(
+      <SkillDetailView
+        skill={makeSkill({ allowedTools: ["Write", "Edit"] })}
+      />,
+    );
+    expect(lastFrame()).toContain("modify files");
+  });
+
+  it("does not show a tool-risk warning when only low-risk tools are present", () => {
+    const { lastFrame } = render(
+      <SkillDetailView skill={makeSkill({ allowedTools: ["Read", "Grep"] })} />,
+    );
+    expect(lastFrame()).not.toContain("This skill can");
+  });
+
+  it("renders the Invocable row from formatInvocability", () => {
+    const { lastFrame } = render(<SkillDetailView skill={makeSkill()} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Invocable:");
+  });
+
+  it("shows the not-available eval message when there is no eval summary", () => {
+    const { lastFrame } = render(<SkillDetailView skill={makeSkill()} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Eval Score:");
+    expect(frame).toContain("Not available");
+    expect(frame).toContain("asm eval");
+  });
+
+  it("renders the Esc/d footer hint", () => {
+    const { lastFrame } = render(<SkillDetailView skill={makeSkill()} />);
+    expect(lastFrame()).toContain("Esc Back d Uninstall");
+  });
+
+  it("renders em-dash for missing creator and license", () => {
+    const { lastFrame } = render(
+      <SkillDetailView skill={makeSkill({ creator: "", license: "" })} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Creator:");
+    expect(frame).toContain("License:");
+    expect(frame).toContain("—");
+  });
+});


### PR DESCRIPTION
Closes #453. Part of epic #432 (modernization plan task 3.1).

## Summary

Adds behavior-level characterization tests for `src/index.tsx` and the five previously-untested views. 13 of 60 `src/` modules had no test file — including the TUI container and 5 of 7 views. Tests assert **rendered output**, not implementation, so the planned refactor (task 3.2) and UX work (P4) remain verifiable.

| Test file | Tests | Covers |
|-----------|-------|--------|
| `src/index.test.tsx` | 19 | App container: dashboard render, help/config/audit/detail/confirm view transitions, search, sort/scope cycling, cursor nav, uninstall confirm flow, `main()` bootstrap + SIGINT/SIGTERM restore |
| `src/views/help.test.tsx` | 2 | Keybinding panel content |
| `src/views/confirm.test.tsx` | 4 | Uninstall title, target list, empty state, confirm/cancel choices |
| `src/views/dashboard.test.tsx` | 7 | Aggregate stats, sort label, scope tabs, search prompt, scope-description truncation, footer |
| `src/views/config.test.tsx` | 8 | Provider rows, project path, custom paths, toggle on Enter, nav down/up wrap, edit-file, Esc-close |
| `src/views/skill-detail.test.tsx` | 15 | Metadata rows, symlink, file count, description, allowed tools + risk warnings, eval summary, footer |

## Acceptance criteria (#453)

- [x] `src/index.tsx` and all 5 untested views have a test file asserting rendered output, not implementation
- [x] Coverage for `src/views/` and `src/index.tsx` is at or above the M3 target (80.61% lines):
  - `src/views`: **85.23%** lines
  - `src/index.tsx`: **83.97%** lines
  - `confirm.tsx` 100%, `dashboard.tsx` 100%, `help.tsx` 100%, `config.tsx` 100%
- [x] `CI=true npm test` passes at 2169/2169 (was 2114 — added 55 tests); typecheck + lint clean

Closes `F-TEST-002`.