### PR TITLE
docs: document local security hook as advisory (#464)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,21 @@ Open a [feature request](https://github.com/luongnv89/asm/issues/new?template=fe
 - Use the Vitest (`npm test`)
 - Add tests for new logic, especially in `scanner.ts`, `config.ts`, `uninstaller.ts`, `auditor.ts`, and `cli.ts`
 
+## Pre-commit Hooks
+
+This project uses [pre-commit](https://pre-commit.com/) hooks to enforce code quality and security.
+
+Install them once after cloning:
+
+```bash
+pre-commit install
+```
+
+The hooks include formatting (Prettier), linting, type-checking, and a local security
+scan. The local security hook (`security-check`) is **advisory** — it requires `python3`
+and runs only at commit time. Contributors without `python3`, or those using
+`--no-verify`, bypass it silently. The [CI Security workflow](https://github.com/luongnv89/asm/actions/workflows/security.yml) is the **enforcing** gate; CI will fail the build if the security check does not pass.
+
 ## Pull Request Process
 
 1. Fill out the PR template


### PR DESCRIPTION
## Summary

Documents the local `security-check` pre-commit hook as advisory in `CONTRIBUTING.md`, clarifying that the CI Security workflow is the enforcing gate.

## Approach

Added a new **Pre-commit Hooks** section to `CONTRIBUTING.md` that:
- States the local `security-check` hook is advisory
- Documents the `python3` prerequisite
- Clarifies that CI is the enforcing gate

## Changes

| File | Change |
|------|--------|
| `CONTRIBUTING.md` | Added Pre-commit Hooks section (15 insertions) |

## Test Results

- `CI=true npm test`: 2174/2174 tests passed

## Acceptance Criteria Verification

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `CONTRIBUTING.md` states that the local hook is advisory and the Security workflow is enforcing | ✅ Pass |
| 2 | `CONTRIBUTING.md` documents the `python3` prerequisite for the local hook | ✅ Pass |
| 3 | `CI=true npm test` passes at 2100+/2100 locally and in CI (baseline-green holds) | ✅ Pass (2174/2174) |

Closes #464