### PR TITLE
docs: realign README and CONTRIBUTING with shipped code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing! This guide will help you get started.
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) >= 18.0.0 (with npm >= 9)
+- [Node.js](https://nodejs.org/) >= 22 (with npm >= 9)
 - [Git](https://git-scm.com/)
 
 ### Development Setup

--- a/README.md
+++ b/README.md
@@ -565,14 +565,21 @@ Multiple `asm` binaries on `PATH` can shadow a fresh upgrade.
 | `asm eval <skill>` | Score skill quality |
 | `asm eval-providers list` | List eval providers |
 | `asm stats` | Aggregate installed skill metrics |
-| `asm stats --tokens` | Attention budget: resident vs body tokens |
 | `asm stats repo <repo>` | Per-repo indexed skill stats |
 | `asm stats author <owner>` | Per-author indexed skill stats |
 | `asm stats index` | Indexed catalog stats summary |
 | `asm activate <skill>` | Link a library skill into a provider |
 | `asm deactivate <skill>` | Remove a library activation symlink |
-| `asm library list               | update` | Manage centrally installed library skills |
+| `asm library` | Manage centrally installed library skills |
+| `asm library list` | List local library skills |
+| `asm library update <skill>` | Update one local library skill |
+| `asm library update --all` | Update all local library skills |
 | `asm export` | Export inventory as JSON |
+| `asm import <file>` | Import skills from exported manifest |
+| `asm outdated` | Show outdated skills |
+| `asm update [name...]` | Update outdated skills |
+| `asm disable <target>` | Disable skill(s) without uninstalling |
+| `asm enable <target>` | Re-enable disabled skill(s) |
 | `asm index ingest <repo>` | Index a skill repo |
 | `asm index search <query>` | Search indexed skills |
 | `asm index list` | List indexed repos |
@@ -588,6 +595,7 @@ Multiple `asm` binaries on `PATH` can shadow a fresh upgrade.
 | `asm config path` | Print config path |
 | `asm config reset` | Reset to defaults |
 | `asm config edit` | Open config in `$EDITOR` |
+| `asm doctor` | Run environment health checks and diagnostics |
 
 ### Global options
 
@@ -595,12 +603,15 @@ Multiple `asm` binaries on `PATH` can shadow a fresh upgrade.
 -h, --help             Show help
 -v, --version          Print version
 --json                 JSON output
+--machine              Stable machine-readable JSON envelope (v1)
 -s, --scope <scope>    global, project, or both
 --sort <field>         name, version, or location
+--flat                 Show one row per tool instance (list, search)
 --model-invocable      Only skills the model can invoke
 --user-invocable       Only skills the user can invoke
 -y, --yes              Skip confirmations
 --no-color             Disable ANSI colors
+-V, --verbose          Show debug output
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ Multiple `asm` binaries on `PATH` can shadow a fresh upgrade.
 --json                 JSON output
 --machine              Stable machine-readable JSON envelope (v1)
 -s, --scope <scope>    global, project, or both
+-p, --tool <name>      Filter by tool (list, search)
 --sort <field>         name, version, or location
 --flat                 Show one row per tool instance (list, search)
 --model-invocable      Only skills the model can invoke


### PR DESCRIPTION
Closes #465

## Summary

This PR completes task 4.7 from the modernization plan by aligning the README documentation with the actual shipped CLI commands.

## Changes

### README.md

**Added missing commands to CLI Commands table:**
- `asm import <file>` — Import skills from exported manifest
- `asm outdated` — Show outdated skills
- `asm update [name...]` — Update outdated skills
- `asm disable <target>` — Disable skill(s) without uninstalling
- `asm enable <target>` — Re-enable disabled skill(s)
- `asm doctor` — Run environment health checks

**Fixed broken rows:**
- `asm library` — Was a broken merged row `asm library list               | update`; now split into proper rows
- `asm stats --tokens` — Removed (it's a `--tokens` flag on `asm stats`, not a separate command)

**Added missing global options:**
- `--flat` — Show one row per tool instance (list, search)
- `--machine` — Stable machine-readable JSON envelope (v1)
- `-V, --verbose` — Show debug output

### CONTRIBUTING.md

- Updated Node.js prerequisite from `>= 18.0.0` to `>= 22` to match `package.json` engines field

## Verification

- `CI=true npm test` — 2180/2180 tests pass
- All documented commands verified against `asm --help` output
- All documented flags verified against individual command help output
