### PR TITLE
feat(index): add oliver-zehentleitner/keep-the-why to curated skill index (#469)

### DIFF
--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -513,6 +513,15 @@
       "description": "Three.js skills for AI agents — animation, geometry, lighting, shaders, materials, and more",
       "maintainer": "@cloudai-x",
       "enabled": true
+    },
+    {
+      "source": "github:oliver-zehentleitner/keep-the-why",
+      "url": "https://github.com/oliver-zehentleitner/keep-the-why",
+      "owner": "oliver-zehentleitner",
+      "repo": "keep-the-why",
+      "description": "Preserves the reasoning behind a codebase — architecture decisions, rejected alternatives, workarounds, incident learnings as versioned Markdown",
+      "maintainer": "@oliver-zehentleitner",
+      "enabled": true
     }
   ]
 }

--- a/data/skill-index/oliver-zehentleitner_keep-the-why.json
+++ b/data/skill-index/oliver-zehentleitner_keep-the-why.json
@@ -1,0 +1,149 @@
+{
+  "repoUrl": "https://github.com/oliver-zehentleitner/keep-the-why.git",
+  "owner": "oliver-zehentleitner",
+  "repo": "keep-the-why",
+  "updatedAt": "2026-08-20T23:10:12.025Z",
+  "skillCount": 1,
+  "skills": [
+    {
+      "name": "keep-the-why",
+      "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain. Use when implementing or reviewing a non-trivial change involving a design decision, workaround, incident fix, operational constraint, rejected alternative, or changed assumption; when documenting an existing or legacy codebase; during onboarding or a maintainer handover; or when interviewing a developer before their knowledge is lost (e.g. before they leave or retire); or when the user expresses frustration with, or reports a problem with, this skill itself. Identifies what the code cannot explain, asks focused questions instead of generic ones, and maintains concise, topic-based, version-controlled documentation readable by both humans and AI agents.",
+      "version": "0.9.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "modelInvocable": true,
+      "userInvocable": true,
+      "installUrl": "github:oliver-zehentleitner/keep-the-why:skills/keep-the-why",
+      "relPath": "skills/keep-the-why",
+      "verified": true,
+      "tokenCount": 7181,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-08-20T23:10:12.024Z",
+        "evaluatedVersion": "0.9.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 71,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-08-20T23:10:12.024Z",
+          "evaluatedVersion": "0.9.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 86,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 12,
+              "max": 14
+            }
+          ],
+          "evaluatedAt": "2026-08-20T23:10:12.024Z",
+          "evaluatedVersion": "0.9.0"
+        }
+      }
+    }
+  ],
+  "bundles": []
+}


### PR DESCRIPTION
Closes #469

## Summary

Add the `keep-the-why` repository to the ASM curated skill index. This skill preserves the reasoning behind a codebase — architecture decisions, rejected alternatives, workarounds, and incident learnings — as versioned Markdown captured as a byproduct of normal agent conversations.

## Approach

Minimal fix — add repo entry to `data/skill-index-resources.json` and regenerate the index via `npm run preindex`.

## Decision Record

- **Root cause:** The `keep-the-why` repository is a valuable skill for preserving architectural reasoning and should be available in the ASM curated index.
- **Options considered:** Option 1 — Add to curated index; Option 2 — Add to curated index with manual review; Option 3 — Add to curated index with test coverage
- **Options rejected:** Option 2 — Manual review adds marginal safety for a repo with standard layout; Option 3 — Existing test suite already covers the index loading pipeline generically
- **Selected option:** Option 1 — Add to curated index
- **Residual risk:** none identified
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `feat/469-add-oliver-zehentleitner-keep-the-why@59e370d` (2026-08-21)

## Changes

| File | Change |
|------|--------|
| `data/skill-index-resources.json` | Add new repo entry for oliver-zehentleitner/keep-the-why |
| `data/skill-index/oliver-zehentleitner_keep-the-why.json` | Generated index file (1 skill, 7181 tokens, score 71/C) |

## Test Results

- Unit tests: 2178 passed
- Integration tests: skipped
- E2e tests: skipped
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Add keep-the-why to curated skill index | pass | data/skill-index-resources.json entry added, preindex ran successfully |
| Skill is discoverable in ASM catalog | pass | Index file generated at data/skill-index/oliver-zehentleitner_keep-the-why.json |
| Skill has valid frontmatter and passes verification | pass | evalSummary overallScore: 71, verified: true |

<!-- gitissue:qa v1 head=59e370d0b5c8e5f3a2d1b4c7e9f0a3b6d8e1f4a7 profile=light cycles=1 review=clean ui=none@ -->
