### PR TITLE
fix: use evaluateSkillContentSync in enrich-index.ts (#508)

### DIFF
--- a/scripts/enrich-index.ts
+++ b/scripts/enrich-index.ts
@@ -24,7 +24,7 @@ import { resolve, join, dirname } from "path";
 import { readFile } from "fs/promises";
 import { cloneToTemp, cleanupTemp, parseSource } from "../src/installer";
 import { estimateTokenCount } from "../src/utils/token-count";
-import { evaluateSkillContent } from "../src/evaluator";
+import { evaluateSkillContentSync } from "../src/evaluator";
 import type { RepoIndex, SkillEvalSummary } from "../src/utils/types";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -58,7 +58,7 @@ async function enrichSkill(
 
   let evalSummary: SkillEvalSummary | undefined;
   try {
-    const report = evaluateSkillContent({
+    const report = evaluateSkillContentSync({
       content,
       skillPath: relPath || "skill",
       skillMdPath,


### PR DESCRIPTION
Closes #508

## Summary

Fix TypeScript compilation errors in `scripts/enrich-index.ts` where `evaluateSkillContent()` was called without `await`.

## Approach

Replaced `evaluateSkillContent` (async) with `evaluateSkillContentSync` (sync). The enrich script only has file content — no filesystem access for the async-only scorers (PII detection, script linting) — so the sync version is the correct choice.

## Changes

- `scripts/enrich-index.ts`: import `evaluateSkillContentSync` instead of `evaluateSkillContent`
- `scripts/enrich-index.ts`: replace the function call with the sync variant

## Test Results

- `npm run typecheck`: 0 errors (was 5)
- `npm test`: 2224/2225 passed (1 pre-existing failure in `doctor.test.ts` unrelated to this change)

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| `npm run typecheck` completes with zero errors | ✓ |
| `evaluateSkillContent` replaced with `evaluateSkillContentSync` | ✓ |
| The `categories` mapping correctly types the callback parameter `c` | ✓ (no longer an `any` since report is now `EvaluationReport`) |

<!-- gitissue:qa v1 -->