### PR TITLE
refactor(stats): list top authors in error message for unknown author (#510)

### DIFF
--- a/src/commands/stats.test.ts
+++ b/src/commands/stats.test.ts
@@ -1,0 +1,167 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ParsedArgs } from "../cli";
+import type { RepoIndex } from "../utils/types";
+
+// Mock loadAllIndices before importing cmdStatsAuthor
+const mockIndices: RepoIndex[] = [
+  {
+    owner: "anthropic",
+    repo: "claude-skills",
+    url: "https://github.com/anthropic/claude-skills",
+    skillCount: 15,
+    skills: [
+      {
+        name: "test-skill-1",
+        description: "Test skill 1",
+        path: "skills/test-1",
+        tokenCount: 100,
+        verified: true,
+      },
+      {
+        name: "test-skill-2",
+        description: "Test skill 2",
+        path: "skills/test-2",
+        tokenCount: 200,
+        verified: false,
+      },
+    ],
+  },
+  {
+    owner: "anthropic",
+    repo: "other-skills",
+    url: "https://github.com/anthropic/other-skills",
+    skillCount: 8,
+    skills: [
+      {
+        name: "other-skill",
+        description: "Other skill",
+        path: "skills/other",
+        tokenCount: 150,
+        verified: true,
+      },
+    ],
+  },
+  {
+    owner: "luongnv89",
+    repo: "asm",
+    url: "https://github.com/luongnv89/asm",
+    skillCount: 5,
+    skills: [
+      {
+        name: "asm-skill",
+        description: "ASM skill",
+        path: "skills/asm",
+        tokenCount: 300,
+        verified: true,
+      },
+    ],
+  },
+  {
+    owner: "google",
+    repo: "gemini-skills",
+    url: "https://github.com/google/gemini-skills",
+    skillCount: 12,
+    skills: [
+      {
+        name: "gemini-skill",
+        description: "Gemini skill",
+        path: "skills/gemini",
+        tokenCount: 250,
+        verified: false,
+      },
+    ],
+  },
+  {
+    owner: "microsoft",
+    repo: "copilot-skills",
+    url: "https://github.com/microsoft/copilot-skills",
+    skillCount: 3,
+    skills: [
+      {
+        name: "copilot-skill",
+        description: "Copilot skill",
+        path: "skills/copilot",
+        tokenCount: 180,
+        verified: false,
+      },
+    ],
+  },
+];
+
+vi.mock("../skill-index", () => ({
+  loadAllIndices: vi.fn().mockResolvedValue(mockIndices),
+}));
+
+describe("cmdStatsAuthor", () => {
+  let stderrOutput: string;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    stderrOutput = "";
+    exitCode = undefined;
+    vi.spyOn(console, "error").mockImplementation((...args) => {
+      stderrOutput += args.map(String).join(" ") + "\n";
+    });
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code;
+      // @ts-expect-error — this function never returns, but TypeScript doesn't know that
+      throw new Error("process.exit called");
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("lists top available authors when author not found", async () => {
+    const { cmdStatsAuthor } = await import("./stats");
+
+    const args: ParsedArgs = {
+      input: "unknown-author",
+      subcommand: "author",
+      positional: ["unknown-author"],
+      flags: { json: false, "no-color": false, help: false },
+    };
+
+    try {
+      await cmdStatsAuthor(args);
+    } catch {
+      // process.exit is mocked to throw — expected
+    }
+
+    expect(exitCode).toBe(1);
+    expect(stderrOutput).toContain('Author "unknown-author" not found');
+    expect(stderrOutput).toContain("Available authors");
+    // Should list top authors sorted by skill count
+    // (skillCount field is metadata; computeAuthorStats counts from skills[])
+    expect(stderrOutput).toContain("anthropic (3 skills)");
+    expect(stderrOutput).toContain("luongnv89 (1 skills)");
+    expect(stderrOutput).toContain("google (1 skills)");
+    expect(stderrOutput).toContain("microsoft (1 skills)");
+    // Should NOT suggest the misleading "asm stats index"
+    expect(stderrOutput).not.toContain("asm stats index");
+  });
+
+  test("shows top 10 authors max", async () => {
+    const { cmdStatsAuthor } = await import("./stats");
+
+    const args: ParsedArgs = {
+      input: "nonexistent",
+      subcommand: "author",
+      positional: ["nonexistent"],
+      flags: { json: false, "no-color": false, help: false },
+    };
+
+    try {
+      await cmdStatsAuthor(args);
+    } catch {
+      // process.exit is mocked to throw — expected
+    }
+
+    // Count how many author lines are in the output
+    const authorLines = stderrOutput
+      .split("\n")
+      .filter((line) => line.match(/^\s+\w+.*skills/));
+    expect(authorLines.length).toBeLessThanOrEqual(10);
+  });
+});

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -226,7 +226,16 @@ export async function cmdStatsAuthor(args: ParsedArgs) {
 
   if (!author) {
     error(`Author "${owner}" not found in the skill index.`);
-    console.error(ansi.dim(`Run "asm stats index" to see all authors.`));
+    // List top available authors to help the user find the right one
+    const topAuthors = authorStats.slice(0, 10);
+    const authorList = topAuthors
+      .map((a) => `  ${a.owner} (${a.totalSkills} skills)`)
+      .join("\n");
+    console.error(
+      ansi.dim(
+        `Available authors (top 10 by skill count):\n${authorList}`,
+      ),
+    );
     process.exit(1);
   }
 

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -232,9 +232,7 @@ export async function cmdStatsAuthor(args: ParsedArgs) {
       .map((a) => `  ${a.owner} (${a.totalSkills} skills)`)
       .join("\n");
     console.error(
-      ansi.dim(
-        `Available authors (top 10 by skill count):\n${authorList}`,
-      ),
+      ansi.dim(`Available authors (top 10 by skill count):\n${authorList}`),
     );
     process.exit(1);
   }

--- a/src/security-auditor.ts
+++ b/src/security-auditor.ts
@@ -548,13 +548,7 @@ export function calculateVerdict(
 // Documentation files that should be excluded from security scanning.
 // These files contain examples and instructions that reference commands
 // (curl, exec, bash, etc.) but are not executable source code.
-const DOC_EXTENSIONS = new Set([
-  ".md",
-  ".txt",
-  ".rst",
-  ".adoc",
-  ".markdown",
-]);
+const DOC_EXTENSIONS = new Set([".md", ".txt", ".rst", ".adoc", ".markdown"]);
 
 // Names of common documentation files to always exclude.
 const DOC_FILENAMES = new Set([


### PR DESCRIPTION
Closes #510

## Summary

When `asm stats author <unknown>` is called with an author not in the index, the error message now lists the top 10 available authors (sorted by skill count) instead of suggesting `asm stats index` — which shows repository stats, not authors.

## Approach

Minimal change: when an author lookup fails, format and display the top 10 authors from the already-computed `authorStats` array. No new subcommand or API needed.

## Decision Record

- **Root cause:** The error message at `src/commands/stats.ts:229` suggested `asm stats index`, which displays repository-level statistics, not a list of available authors.
- **Options considered:** 
  - Option 1 — List top authors in the error message (selected)
  - Option 2 — Add `asm stats authors` subcommand to list all authors
  - Option 3 — Add `--list-authors` flag to `asm stats author`
- **Options rejected:** Option 2 — adds a new subcommand surface; Option 3 — adds a flag that only makes sense in error context
- **Selected option:** Option 1 — minimal, no new command surface, immediately helpful
- **Residual risk:** none identified
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle
- **Reproduction:** N/A (improvement, not a bug)

Analyzed at: `refactor/510-asm-stats-author-error-should-list` @ 0db2518 (2026-08-21)

## Changes

| File | Change |
|------|--------|
| `src/commands/stats.ts` | Replace misleading `asm stats index` suggestion with top 10 available authors |
| `src/commands/stats.test.ts` | New test file: 2 tests for `cmdStatsAuthor` error behavior |

## Test Results

- Unit tests: 2 passed
- Integration tests: 0 passed (skipped)
- E2e tests: 0 passed (skipped)
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Error message lists top 5-10 authors when an unknown author is requested | pass | `src/commands/stats.ts:228-237` — lists top 10 sorted by skill count |
| Provide a subcommand like `asm stats authors` that lists all authors | unverified | Not implemented — top-N in error is sufficient per issue scope |
| Error message should not suggest `asm stats index` | pass | `asm stats index` suggestion removed; replaced with inline author list |

<!-- gitissue:qa v1 head=0db25189026d1f3d21041b6da1e939912676b6fa profile=light cycles=1 review=clean tests=2@0db25189026d1f3d21041b6da1e939912676b6fa ui=none:clean@0db25189026d1f3d21041b6da1e939912676b6fa -->
