### PR TITLE
fix(website): resolve all Phase 2 bug fixes from epic #516

### DIFF
--- a/website-src/src/__tests__/filter-sort.test.js
+++ b/website-src/src/__tests__/filter-sort.test.js
@@ -29,7 +29,6 @@ const base = () => ({
   activeRepo: "all",
   activeFacets: emptyFacetState(),
   sort: null,
-  page: 1,
 });
 
 describe("applyFilters", () => {
@@ -220,6 +219,20 @@ describe("anyFilterActive", () => {
   });
   it("returns false when state is clean", () => {
     expect(anyFilterActive(base())).toBe(false);
+  });
+  it("returns true when sort='grade' with no search (non-default)", () => {
+    expect(anyFilterActive({ ...base(), sort: "grade" })).toBe(true);
+  });
+  it("returns false when sort='name' with no search (matches default)", () => {
+    expect(anyFilterActive({ ...base(), sort: "name" })).toBe(false);
+  });
+  it("returns true when sort='relevance' with no search (non-default)", () => {
+    expect(anyFilterActive({ ...base(), sort: "relevance" })).toBe(true);
+  });
+  it("search query short-circuits: sort is ignored when search is active", () => {
+    expect(
+      anyFilterActive({ ...base(), searchQuery: "foo", sort: "relevance" }),
+    ).toBe(true);
   });
 });
 

--- a/website-src/src/components/SidebarDrawer.jsx
+++ b/website-src/src/components/SidebarDrawer.jsx
@@ -27,17 +27,21 @@ export default function SidebarDrawer({
   ariaLabel = "Sidebar",
 }) {
   useEffect(() => {
-    if (!open) return;
     const onKey = (e) => {
       if (e.key === "Escape") onClose?.();
     };
     window.addEventListener("keydown", onKey);
     // Prevent body scroll while the drawer is open.
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
+    if (open) {
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      return () => {
+        window.removeEventListener("keydown", onKey);
+        document.body.style.overflow = prev;
+      };
+    }
     return () => {
       window.removeEventListener("keydown", onKey);
-      document.body.style.overflow = prev;
     };
   }, [open, onClose]);
 

--- a/website-src/src/components/ui/badge.jsx
+++ b/website-src/src/components/ui/badge.jsx
@@ -4,6 +4,7 @@ import { cn } from "../../lib/cn.js";
 /**
  * shadcn/ui Badge — JSX port. Extra tone variants cover the legacy badge
  * palette (official / verified / featured / warn / tokens / cat / eval-*).
+ * Accepts both `tone` (primary) and `variant` (shim for compatibility).
  */
 const badgeVariants = cva(
   "inline-flex items-center gap-0.5 rounded border px-2 py-0.5 text-[10px] font-medium transition-colors",
@@ -31,8 +32,16 @@ const badgeVariants = cva(
   },
 );
 
-export function Badge({ className, tone, ...props }) {
-  return <span className={cn(badgeVariants({ tone }), className)} {...props} />;
+export function Badge({ className, tone, variant, ...props }) {
+  // Accept `variant` as an alias for `tone` (StatsPage passes variant="secondary").
+  // "secondary" maps to the default tone since no explicit tone was intended.
+  const resolvedTone = variant === "secondary" ? "default" : tone;
+  return (
+    <span
+      className={cn(badgeVariants({ tone: resolvedTone }), className)}
+      {...props}
+    />
+  );
 }
 
 export { badgeVariants };

--- a/website-src/src/hooks/useCatalog.jsx
+++ b/website-src/src/hooks/useCatalog.jsx
@@ -7,6 +7,7 @@ const CatalogContext = createContext({
   error: null,
   catalog: null,
   miniSearch: null,
+  searchError: null,
 });
 
 /**
@@ -26,6 +27,7 @@ export function CatalogProvider({ children }) {
     error: null,
     catalog: null,
     miniSearch: null,
+    searchError: null,
   });
 
   useEffect(() => {
@@ -54,7 +56,22 @@ export function CatalogProvider({ children }) {
             "Catalog and search index are from different builds. Clear your browser cache and reload the page.",
           );
         }
-        const miniSearch = MiniSearch.loadJS(parsedIndex, MINISEARCH_OPTIONS);
+        let miniSearch;
+        try {
+          miniSearch = MiniSearch.loadJS(parsedIndex, MINISEARCH_OPTIONS);
+        } catch (loadErr) {
+          // Catalog loaded but MiniSearch failed to initialize
+          // (e.g. corrupted index). Show catalog without search.
+          if (cancelled) return;
+          setState({
+            loading: false,
+            error: null,
+            catalog,
+            miniSearch: null,
+            searchError: "Search index failed to load. The catalog is still available without search.",
+          });
+          return;
+        }
         if (cancelled) return;
         setState({ loading: false, error: null, catalog, miniSearch });
       } catch (err) {
@@ -64,6 +81,7 @@ export function CatalogProvider({ children }) {
           error: err instanceof Error ? err.message : String(err),
           catalog: null,
           miniSearch: null,
+          searchError: null,
         });
       }
     })();

--- a/website-src/src/hooks/useCatalogState.js
+++ b/website-src/src/hooks/useCatalogState.js
@@ -41,7 +41,6 @@ export function useCatalogState() {
       activeRepo: params.get("repo") || "all",
       activeFacets: facets,
       sort: params.get("sort") || defaultSort(searchQuery),
-      page: parseInt(params.get("page"), 10) || 1,
     };
   }, [params]);
 
@@ -72,7 +71,6 @@ export function useCatalogState() {
         // When search toggles on, reset sort to relevance (matches legacy).
         if (q && !next.get("sort")) next.set("sort", "relevance");
         else if (!q && next.get("sort") === "relevance") next.delete("sort");
-        next.delete("page");
       });
     },
     [update],
@@ -83,7 +81,6 @@ export function useCatalogState() {
       update((next) => {
         if (cats.size > 0) next.set("cat", setToCsv(cats));
         else next.delete("cat");
-        next.delete("page");
       });
     },
     [update],
@@ -94,7 +91,6 @@ export function useCatalogState() {
       update((next) => {
         if (repo && repo !== "all") next.set("repo", repo);
         else next.delete("repo");
-        next.delete("page");
       });
     },
     [update],
@@ -107,7 +103,6 @@ export function useCatalogState() {
       update((next) => {
         if (values.size > 0) next.set(paramKey, setToCsv(values));
         else next.delete(paramKey);
-        next.delete("page");
       });
     },
     [update],
@@ -120,17 +115,6 @@ export function useCatalogState() {
         const def = defaultSort(q);
         if (sort && sort !== def) next.set("sort", sort);
         else next.delete("sort");
-        next.delete("page");
-      });
-    },
-    [update],
-  );
-
-  const setPage = useCallback(
-    (page) => {
-      update((next) => {
-        if (page && page > 1) next.set("page", String(page));
-        else next.delete("page");
       });
     },
     [update],
@@ -139,7 +123,7 @@ export function useCatalogState() {
   const clearAll = useCallback(() => {
     setParams(new URLSearchParams(), { replace: true });
     setSearchDraft("");
-  }, [setParams]);
+  }, [setParams, setSearchDraft]);
 
   return {
     state,
@@ -150,7 +134,6 @@ export function useCatalogState() {
     setActiveRepo,
     setFacet,
     setSort,
-    setPage,
     clearAll,
   };
 }

--- a/website-src/src/lib/filter-sort.js
+++ b/website-src/src/lib/filter-sort.js
@@ -162,6 +162,12 @@ export function anyFilterActive(state) {
   for (const k of Object.keys(state.activeFacets)) {
     if (state.activeFacets[k].size > 0) return true;
   }
+  // Check sort state — when sort differs from the search-aware default,
+  // the "Clear all" button should appear (issue #526).
+  const expectedDefault = state.searchQuery && state.searchQuery.trim()
+    ? "relevance"
+    : "name";
+  if (state.sort && state.sort !== expectedDefault) return true;
   return false;
 }
 

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -75,7 +75,7 @@ export default function CatalogPage() {
   );
   const location = useLocation();
 
-  const { loading, error, catalog, miniSearch } = useCatalog();
+  const { loading, error, catalog, miniSearch, searchError } = useCatalog();
   const {
     state,
     searchDraft,
@@ -101,6 +101,7 @@ export default function CatalogPage() {
     if (!catalog || !miniSearch || !state.searchQuery.trim()) {
       return { scoreById: null, terms: null };
     }
+    // If MiniSearch failed to initialize, the above guard catches it.
     const hits = miniSearch.search(state.searchQuery.trim());
     const scoreById = new Map();
     for (const h of hits) {
@@ -151,6 +152,13 @@ export default function CatalogPage() {
           Catalog failed to load
         </h2>
         <p className="text-sm text-[var(--fg-dim)] mt-2">{error}</p>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="mt-4 px-3 py-1.5 rounded border border-[var(--border)] bg-transparent text-[var(--fg)] hover:border-[var(--brand)] text-xs"
+        >
+          Reload page
+        </button>
       </div>
     );
   }
@@ -260,6 +268,11 @@ export default function CatalogPage() {
           )}
         </span>
       </div>
+      {searchError && (
+        <div className="mx-3 py-2 px-3 rounded bg-[var(--warn-bg)] border border-[var(--warn)] text-[var(--warn)] text-xs">
+          ⚠ {searchError}
+        </div>
+      )}
       <div
         className="flex-1 min-h-0 pr-1 -mr-1"
         role="list"


### PR DESCRIPTION
Closes #516

## Summary

Resolves all 5 Phase 2 (Bug Fixes & Data Integrity) issues from [Epic #516](https://github.com/luongnv89/asm/issues/516).

## Changes

| Issue | Title | Fix |
|-------|-------|-----|
| [#526](https://github.com/luongnv89/asm/issues/526) | M4: Fix anyFilterActive not checking sort state | Added sort-state check to `anyFilterActive()`; "Clear all" button now appears when sort differs from default |
| [#525](https://github.com/luongnv89/asm/issues/525) | m9: Fix Badge receiving undefined variant prop | Badge component now accepts `variant` prop as an alias for `tone` (maps "secondary" → "default") |
| [#523](https://github.com/luongnv89/asm/issues/523) | m11: Fix SidebarDrawer scroll lock not restoring on unmount | Moved overflow-save inside `if (open)` guard so cleanup always restores the original overflow value |
| [#522](https://github.com/luongnv89/asm/issues/522) | M5: Remove dead pagination code from useCatalogState | Removed unused `page` state field, `setPage` setter, and all `next.delete("page")` calls |
| [#524](https://github.com/luongnv89/asm/issues/524) | M7: Add MiniSearch initialization failure indicator | Wrapped `MiniSearch.loadJS()` in try/catch — shows visible warning banner when search index fails to load, catalog still works without search |

## Testing

- `npm run build` passes (full build)
- `npx vitest run src/__tests__/filter-sort.test.js` — 18/18 pass
- `npx vitest run src/__tests__/stats-page.test.js` — 4/4 pass
- Pre-existing test failure in `app-smoke.test.jsx` (unrelated to these changes)

## Part of

[Epic #516](https://github.com/luongnv89/asm/issues/516) — Phase 2: Bug Fixes & Data Integrity
