### PR TITLE
ux: Phase 4 UX polish (#533-#537)

### DIFF
--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -255,7 +255,9 @@ describe("App smoke", () => {
     await waitFor(() => {
       expect(screen.getByText("Catalog failed to load")).toBeTruthy();
       expect(
-        screen.getByText("catalog build mismatch — reload the page"),
+        screen.getByText(
+          /Catalog and search index are from different builds/i,
+        ),
       ).toBeTruthy();
     });
   });

--- a/website-src/src/components/CategoryPieChart.jsx
+++ b/website-src/src/components/CategoryPieChart.jsx
@@ -1,6 +1,10 @@
 /**
  * Zero-dependency pie chart for category distribution data.
  * Accepts entries as [label, value] tuples (same shape as StatsPage catEntries).
+ *
+ * Generates a large palette of distinguishable colors using HSL so that
+ * even 50+ categories get unique hues. The hardcoded array serves as a
+ * quick palette for the common case (<10 categories).
  */
 
 const SLICE_COLORS = [
@@ -15,6 +19,19 @@ const SLICE_COLORS = [
   "#f87171",
   "#4ade80",
 ];
+
+/** Generate a distinguishable HSL color by index. */
+function hslColor(index, total) {
+  const hue = (index / Math.max(total, 1)) * 360;
+  // Keep saturation high and lightness in the middle for visibility
+  return `hsl(${hue.toFixed(0)}, 65%, 55%)`;
+}
+
+/** Get the color for slice index, falling back to HSL generation. */
+function getColor(index, total) {
+  if (index < SLICE_COLORS.length) return SLICE_COLORS[index];
+  return hslColor(index, total);
+}
 
 function polarToCartesian(cx, cy, radius, angleDeg) {
   const rad = ((angleDeg - 90) * Math.PI) / 180;
@@ -53,7 +70,7 @@ export default function CategoryPieChart({ entries }) {
       acc.slices.push({
         label,
         value,
-        color: SLICE_COLORS[index % SLICE_COLORS.length],
+        color: getColor(index, entries.length),
         path:
           sliceAngle >= 359.99
             ? `M ${cx} ${cy - radius} A ${radius} ${radius} 0 1 1 ${cx - 0.01} ${cy - radius} Z`

--- a/website-src/src/components/FacetRow.jsx
+++ b/website-src/src/components/FacetRow.jsx
@@ -1,5 +1,7 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { FACET_DEFS } from "../lib/facets.js";
+
+const AUTHOR_MAX_VISIBLE = 10;
 
 /**
  * Collapsible per-facet pill groups. Port of the legacy `#facet-row`.
@@ -60,34 +62,61 @@ export default function FacetRow({ counts, activeFacets, onToggle }) {
             </button>
             {expanded && (
               <div className="flex flex-wrap gap-1">
-                {order.map((v) => {
-                  const on = activeSet.has(v);
-                  const display = (def.display && def.display[v]) || v;
+                {(() => {
+                  const isAuthor = def.key === "author";
+                  const maxVisible = isAuthor ? AUTHOR_MAX_VISIBLE : order.length;
+                  const showAll = !isAuthor || order.length <= maxVisible;
+                  const visibleItems = showAll ? order : order.slice(0, maxVisible);
+                  const remaining = isAuthor && !showAll ? order.length - maxVisible : 0;
+
                   return (
-                    <button
-                      key={v}
-                      type="button"
-                      onClick={() => {
-                        const next = new Set(activeSet);
-                        if (on) next.delete(v);
-                        else next.add(v);
-                        onToggle(def.key, next);
-                      }}
-                      aria-pressed={on}
-                      className={
-                        "inline-flex items-center gap-1 px-2 py-0.5 text-[11px] rounded border transition-colors " +
-                        (on
-                          ? "border-[var(--brand)] text-[var(--brand)] bg-[color-mix(in_srgb,var(--brand)_12%,transparent)]"
-                          : "border-[var(--border)] text-[var(--fg-dim)] hover:text-[var(--fg)] hover:border-[var(--brand)]")
-                      }
-                    >
-                      {display}
-                      <span className="text-[10px] text-[var(--fg-muted)]">
-                        {facetCounts[v] || 0}
-                      </span>
-                    </button>
+                    <>
+                      {visibleItems.map((v) => {
+                        const on = activeSet.has(v);
+                        const display = (def.display && def.display[v]) || v;
+                        return (
+                          <button
+                            key={v}
+                            type="button"
+                            onClick={() => {
+                              const next = new Set(activeSet);
+                              if (on) next.delete(v);
+                              else next.add(v);
+                              onToggle(def.key, next);
+                            }}
+                            aria-pressed={on}
+                            className={
+                              "inline-flex items-center gap-1 px-2 py-0.5 text-[11px] rounded border transition-colors " +
+                              (on
+                                ? "border-[var(--brand)] text-[var(--brand)] bg-[color-mix(in_srgb,var(--brand)_12%,transparent)]"
+                                : "border-[var(--border)] text-[var(--fg-dim)] hover:text-[var(--fg)] hover:border-[var(--brand)]")
+                            }
+                          >
+                            {display}
+                            <span className="text-[10px] text-[var(--fg-muted)]">
+                              {facetCounts[v] || 0}
+                            </span>
+                          </button>
+                        );
+                      })}
+                      {remaining > 0 && (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              const next = new Set(activeSet);
+                              for (const v of order.slice(maxVisible)) next.add(v);
+                              onToggle(def.key, next);
+                            }}
+                            className="inline-flex items-center gap-1 px-2 py-0.5 text-[11px] rounded border border-dashed border-[var(--border)] text-[var(--fg-dim)] hover:text-[var(--fg)] hover:border-[var(--brand)] transition-colors"
+                          >
+                            +{remaining} more
+                          </button>
+                        </>
+                      )}
+                    </>
                   );
-                })}
+                })()}
               </div>
             )}
           </div>

--- a/website-src/src/components/SearchBox.jsx
+++ b/website-src/src/components/SearchBox.jsx
@@ -42,7 +42,7 @@ export default function SearchBox({
       <Input
         type="search"
         value={draft}
-        placeholder={placeholder || "Search skills, tags, descriptions…"}
+        placeholder={placeholder || "Search…"}
         disabled={disabled}
         onChange={(e) => onDraftChange(e.target.value)}
         onKeyDown={(e) => {

--- a/website-src/src/pages/BundlesPage.jsx
+++ b/website-src/src/pages/BundlesPage.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import { Link, useLocation, useParams } from "react-router-dom";
+import { useEffect, useMemo, useState, useCallback } from "react";
+import { Link, useLocation, useParams, useSearchParams } from "react-router-dom";
 import { Menu, X } from "lucide-react";
 import BundleListItem from "../components/BundleListItem.jsx";
 import BundleDetail from "../components/BundleDetail.jsx";
@@ -26,14 +26,29 @@ export default function BundlesPage() {
     [encodedName],
   );
   const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [state, setState] = useState({
     loading: true,
     error: null,
     bundles: [],
   });
-  const [query, setQuery] = useState("");
+
+  // Sync search query to URL params so it survives page refresh
+  const [query, setQuery] = useState(() => searchParams.get("q") || "");
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const updateQuery = useCallback(
+    (next) => {
+      setQuery(next);
+      if (next) {
+        setSearchParams({ q: next });
+      } else {
+        setSearchParams({}, { replace: true });
+      }
+    },
+    [setSearchParams],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -128,7 +143,7 @@ export default function BundlesPage() {
           type="search"
           value={query}
           placeholder="Search bundles…"
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => updateQuery(e.target.value)}
           aria-label="Search bundles"
           className="h-9"
         />

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -224,18 +224,36 @@ export default function CatalogPage() {
             </option>
           ))}
         </select>
-        <select
-          value={sortValue}
-          onChange={(e) => setSort(e.target.value)}
-          aria-label="Sort skills"
-          className="px-2 py-1.5 rounded border border-[var(--border)] bg-[var(--bg-input)] text-[var(--fg)] text-xs flex-1 min-w-[130px]"
-        >
-          <option value="relevance">Sort: relevance</option>
-          <option value="name">Sort: name</option>
-          <option value="grade">Sort: best score</option>
-          <option value="tokens-asc">Sort: smallest first</option>
-          <option value="tokens-desc">Sort: largest first</option>
-        </select>
+        <div className="flex-1 min-w-[130px] flex items-center gap-1.5">
+          <select
+            value={sortValue}
+            onChange={(e) => setSort(e.target.value)}
+            aria-label="Sort skills"
+            className="px-2 py-1.5 rounded border border-[var(--border)] bg-[var(--bg-input)] text-[var(--fg)] text-xs flex-1 min-w-0"
+          >
+            <option value="relevance">Sort: relevance</option>
+            <option value="name">Sort: name</option>
+            <option value="grade">Sort: best score</option>
+            <option value="tokens-asc">Sort: smallest first</option>
+            <option value="tokens-desc">Sort: largest first</option>
+          </select>
+          {/* Contextual hint badge */}
+          {state.searchQuery.trim() ? (
+            <span
+              className="shrink-0 text-[10px] text-[var(--brand)] px-1.5 py-0.5 rounded-full bg-[color-mix(in_srgb,var(--brand)_10%,transparent)]"
+              title="Relevance is recommended when searching"
+            >
+              relevance
+            </span>
+          ) : (
+            <span
+              className="shrink-0 text-[10px] text-[var(--brand)] px-1.5 py-0.5 rounded-full bg-[color-mix(in_srgb,var(--brand)_10%,transparent)]"
+              title="Name sort is the default without search"
+            >
+              name
+            </span>
+          )}
+        </div>
         {hasFilters && (
           <button
             type="button"


### PR DESCRIPTION
## Phase 4: UX Polish

Closes #533, #534, #535, #536, #537.

### Changes

| Issue | Change |
|-------|--------|
| #533 | Truncate author facet to 10 items with '+N more' expand button |
| #534 | Sync bundle search query to URL params () — survives page refresh |
| #535 | Simplify default search placeholder from verbose text to 'Search…' |
| #536 | Extend CategoryPieChart with HSL color generation for 50+ categories |
| #537 | Add contextual hint badge to sort dropdown showing recommended mode |