### PR TITLE
a11y: Phase 5 accessibility & code quality (#538-#543)

### DIFF
--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -255,7 +255,9 @@ describe("App smoke", () => {
     await waitFor(() => {
       expect(screen.getByText("Catalog failed to load")).toBeTruthy();
       expect(
-        screen.getByText("catalog build mismatch — reload the page"),
+        screen.getByText(
+          /Catalog and search index are from different builds/i,
+        ),
       ).toBeTruthy();
     });
   });

--- a/website-src/src/__tests__/minisearch-options.test.js
+++ b/website-src/src/__tests__/minisearch-options.test.js
@@ -51,4 +51,37 @@ describe("minisearch options parity", () => {
       categoriesStr: 1,
     });
   });
+
+  it("JS copy content matches TS source (no silent drift)", () => {
+    // Strip the TS export prefix and trailing semicolon from the source,
+    // then compare the object literal body with the JS file.
+    const tsSrc = readFileSync(
+      resolve(__dirname, "../../../scripts/minisearch-options.ts"),
+      "utf8",
+    );
+    const jsSrc = readFileSync(
+      resolve(__dirname, "../lib/minisearch-options.js"),
+      "utf8",
+    );
+
+    // Extract the object literal from the TS source (between `{` and `};`)
+    const tsMatch = tsSrc.match(/MINISEARCH_OPTIONS\s*=\s*\{([\s\S]*?)\};/);
+    expect(tsMatch).not.toBeNull();
+    const tsBody = tsMatch[1].trim();
+
+    // Extract the object literal from the JS source
+    const jsMatch = jsSrc.match(/MINISEARCH_OPTIONS\s*=\s*\{([\s\S]*?)\};/);
+    expect(jsMatch).not.toBeNull();
+    const jsBody = jsMatch[1].trim();
+
+    // Normalize: strip TS type annotations, trailing commas, and extra whitespace
+    const normalize = (s) =>
+      s
+        .replace(/\s*as\s+string\[\]/g, "") // strip `as string[]` type annotations
+        .replace(/,\s*(\}|\])/g, "$1") // remove trailing commas
+        .replace(/\s+/g, " ")
+        .trim();
+
+    expect(normalize(tsBody)).toBe(normalize(jsBody));
+  });
 });

--- a/website-src/src/components/Header.jsx
+++ b/website-src/src/components/Header.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, NavLink } from "react-router-dom";
 import { useCatalog } from "../hooks/useCatalog.jsx";
+import { formatStars } from "../lib/utils.js";
 import BundleCartButton from "./BundleCartButton.jsx";
 
 /**
@@ -32,12 +33,6 @@ function applyTheme(next) {
  * from the loaded catalog.
  */
 const REPO_URL = "https://github.com/luongnv89/asm";
-
-function formatStars(n) {
-  if (typeof n !== "number" || n <= 0) return null;
-  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
-  return String(n);
-}
 
 export default function Header({ onOpenBundleBuilder }) {
   const { catalog } = useCatalog();

--- a/website-src/src/components/SearchBox.jsx
+++ b/website-src/src/components/SearchBox.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, forwardRef } from "react";
 import { Search, X } from "lucide-react";
 import { Input } from "./ui/input.jsx";
 import { Button } from "./ui/button.jsx";
@@ -14,12 +14,13 @@ import { Button } from "./ui/button.jsx";
  */
 const DEBOUNCE_MS = 150;
 
-export default function SearchBox({
+const SearchBoxInner = forwardRef(function SearchBox({
   draft,
   onDraftChange,
   onCommit,
   disabled,
   placeholder,
+  inputRef,
 }) {
   const timerRef = useRef(null);
 
@@ -40,6 +41,7 @@ export default function SearchBox({
         className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[var(--fg-muted)]"
       />
       <Input
+        ref={inputRef}
         type="search"
         value={draft}
         placeholder={placeholder || "Search skills, tags, descriptions…"}
@@ -74,4 +76,6 @@ export default function SearchBox({
       )}
     </div>
   );
-}
+});
+
+export default SearchBoxInner;

--- a/website-src/src/components/SkillDetail.jsx
+++ b/website-src/src/components/SkillDetail.jsx
@@ -1,19 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { Star } from "lucide-react";
-import { formatTokens } from "../lib/utils.js";
+import { formatStars, formatTokens } from "../lib/utils.js";
 import CopyButton from "./CopyButton.jsx";
 import EvalScoreBreakdown from "./EvalScoreBreakdown.jsx";
 import AddToBundleButton from "./AddToBundleButton.jsx";
 import { Badge } from "./ui/badge.jsx";
 import { Card } from "./ui/card.jsx";
-
-/** Format a star count for display: "1200" → "1.2k". */
-function formatStars(n) {
-  if (typeof n !== "number" || n <= 0) return null;
-  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
-  return String(n);
-}
 
 /**
  * Reusable skill detail view. Rendered in the right pane of the

--- a/website-src/src/components/SkillListItem.jsx
+++ b/website-src/src/components/SkillListItem.jsx
@@ -6,18 +6,12 @@ import AddToBundleButton from "./AddToBundleButton.jsx";
 import { cn } from "../lib/cn.js";
 import {
   evalScoreClass,
+  formatStars,
   formatTokens,
   highlightMatches,
   encodeSkillId,
   skillRelPath,
 } from "../lib/utils.js";
-
-/** Format a star count for display: "1200" → "1.2k". */
-function formatStars(n) {
-  if (typeof n !== "number" || n <= 0) return null;
-  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
-  return String(n);
-}
 
 /**
  * Compact sidebar row for a skill. Inherits the badge/eval-tone/
@@ -134,7 +128,7 @@ function SkillListItem({
             <Wrench className="h-3 w-3" aria-hidden="true" />
           </Badge>
         )}
-        {skill.categories?.slice(0, 2).map((c) => (
+        {(skill.categories || []).slice(0, 2).map((c) => (
           <Badge key={c} tone="cat">
             {c}
           </Badge>

--- a/website-src/src/lib/utils.js
+++ b/website-src/src/lib/utils.js
@@ -40,6 +40,14 @@ export function skillRelPath(installUrl) {
   return rest.slice(idx2 + 1);
 }
 
+// Format a star count for display: "1200" → "1.2k". Shared across
+// SkillListItem, SkillDetail, and Header.
+export function formatStars(n) {
+  if (typeof n !== "number" || n <= 0) return null;
+  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+  return String(n);
+}
+
 // Format an estimated token count as "~N tokens" / "~1.2k tokens" /
 // "~12k tokens". Mirrors src/utils/token-count.ts:formatTokenCount so the
 // website + CLI agree.

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useRef, useEffect } from "react";
 import { useParams, Link, useLocation } from "react-router-dom";
 import { Menu, X } from "lucide-react";
 import { List, useDynamicRowHeight } from "react-window";
@@ -89,6 +89,22 @@ export default function CatalogPage() {
   } = useCatalogState();
 
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const searchBoxRef = useRef(null);
+
+  // Keyboard shortcut: "/" or Ctrl+K to focus search box
+  useEffect(() => {
+    function handler(e) {
+      const tag = (e.target && e.target.tagName) || "";
+      // Ignore if focused in an input/textarea/contenteditable
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if ((e.key === "/" || (e.key === "k" && (e.metaKey || e.ctrlKey))) && !e.altKey && !e.shiftKey) {
+        e.preventDefault();
+        searchBoxRef.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
 
   // Measure each rendered row so skill items with extra badges or a long
   // owner/repo line aren't clipped. `key` changes invalidate the cache
@@ -191,6 +207,7 @@ export default function CatalogPage() {
         </Button>
       </div>
       <SearchBox
+        ref={searchBoxRef}
         draft={searchDraft}
         onDraftChange={setSearchDraft}
         onCommit={setSearchQuery}
@@ -267,7 +284,16 @@ export default function CatalogPage() {
       >
         {filtered.length === 0 ? (
           <div className="py-8 text-center text-[var(--fg-dim)] text-sm">
-            <div className="text-2xl mb-1">✨</div>
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              className="w-8 h-8 mx-auto mb-1 text-[var(--fg-muted)]"
+              aria-hidden="true"
+            >
+              <path d="M12 2l2.4 7.2h7.6l-6 4.8 2.4 7.2-6-4.8-6 4.8 2.4-7.2-6-4.8h7.6z" />
+            </svg>
             <p>No skills match your filters</p>
           </div>
         ) : (


### PR DESCRIPTION
## Phase 5: Accessibility & Code Quality

Closes #538, #539, #540, #542, #543. (#541 already done —  present in index.html.)

### Changes

| Issue | Change |
|-------|--------|
| #538 | Harmonize categories undefined handling —  |
| #539 | Replace sparkle emoji (✨) with inline SVG star icon for consistent rendering |
| #540 | Extract  to shared  — was duplicated in 3 files |
| #542 | Add keyboard shortcut ( or /) to focus search box |
| #543 | Add content-parity test verifying JS copy matches TS source exactly |