### PR TITLE
feat: add grok, omp, and reasonix built-in providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Features
 
+- Add built-in providers for Oh My Pi (`omp`, `~/.omp/agent/skills`), Grok CLI (`grok`, `~/.grok/skills`), and Reasonix (`reasonix`, `~/.reasonix/skills`), inserted after `pi` in default priority order (22 providers total)
 - Add `asm get <skill>` — a zero-residency reference tier that resolves a skill through the installed / library / index / registry ladder (plus any `asm install` shorthand) and writes its `SKILL.md` body to stdout without installing anything; remote fetches run the same pre-install security scan, reported on stderr and under `--json` ([#422](https://github.com/luongnv89/asm/issues/422)) — @luongnv89
 - Add the `skill-install-improved` bundled skill — installs an improved variant of one skill instead of the published one: resolves the target by local path, repo, or skill name, runs `skill-auto-improver` on a throwaway `mktemp -d` copy so the user's own files are never modified, installs the improved directory, and reports the before/after scores and the provenance it was improved from ([#418](https://github.com/luongnv89/asm/issues/418)) — @luongnv89
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # CLI to install and manage agent skills
 
-**agent-skill-manager** (`asm`) is a scriptable CLI built for AI agents and automation — install, search, audit, and organize skills across Claude Code, Codex, Cursor, and 16 more tools. Every command supports `--json` and `--yes` for non-interactive use. An optional TUI (`asm`) is available for local browsing.
+**agent-skill-manager** (`asm`) is a scriptable CLI built for AI agents and automation — install, search, audit, and organize skills across Claude Code, Codex, Cursor, and 19 more tools. Every command supports `--json` and `--yes` for non-interactive use. An optional TUI (`asm`) is available for local browsing.
 
 [**Get Started**](#getting-started) · [**Browse 4,300+ skills**](https://luongnv.com/asm/#/skills) · [**Full docs**](#documentation)
 
@@ -25,7 +25,7 @@
 
 | Pain                      | Without `asm`                                                                                                           | With `asm`                                                                 |
 | ------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| Scattered installs        | Same skill copied into `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/rules/` — different versions, no single view | One `asm list` across all 19 providers and scopes                          |
+| Scattered installs        | Same skill copied into `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/rules/` — different versions, no single view | One `asm list` across all 22 providers and scopes                          |
 | No inventory              | `ls` through hidden dirs; no idea what is installed, duplicated, or outdated                                            | `asm search`, `asm inspect`, `asm stats`, `asm audit`                      |
 | Invisible context cost    | Every installed skill's description is resident in the agent's prompt on every message, whether or not it ever fires    | `asm stats --tokens`, `asm audit residency`                                |
 | Install just to read once | Installing is the only way to get a skill in front of an agent — and it stays resident forever afterwards               | `asm get <skill>` prints the body and installs nothing                     |
@@ -38,7 +38,7 @@
 |                     |                                                                                |
 | ------------------- | ------------------------------------------------------------------------------ |
 | **Catalog**         | 4,394 skills from 54 repos — [browse online](https://luongnv.com/asm/#/skills) |
-| **Providers**       | 19 agents (Claude, Codex, Cursor, Windsurf, Copilot, …)                        |
+| **Providers**       | 22 agents (Claude, Codex, Cursor, Windsurf, Copilot, …)                        |
 | **Agent-ready CLI** | `--json`, `--yes`, `--machine` on list, search, install, audit, eval           |
 | **Security**        | Pre-install scan for shell exec, network access, credential exposure           |
 | **License**         | MIT — no accounts, no telemetry                                                |
@@ -276,7 +276,7 @@ MIT licensed. No accounts or paywalls.
 Yes. Commands return structured JSON (`--json`), accept non-interactive flags (`--yes`, `--machine`), and map to discrete actions an agent can chain — list inventory, search catalog, install, audit, uninstall.
 
 **Which agents are supported?**
-19 providers: Claude Code, Codex, OpenClaw, Cursor, Windsurf, Cline, Roo Code, Continue, GitHub Copilot, Aider, OpenCode, Zed, Augment, Amp, Gemini CLI, Google Antigravity, Pi, Hermes, and a generic Agents provider. Disable any via `asm config edit`.
+22 providers: Claude Code, Codex, OpenClaw, Cursor, Windsurf, Cline, Roo Code, Continue, GitHub Copilot, Aider, OpenCode, Zed, Augment, Amp, Gemini CLI, Google Antigravity, Pi, Oh My Pi, Grok CLI, Reasonix, Hermes, and a generic Agents provider. Disable any via `asm config edit`.
 
 **What about the TUI?**
 Run `asm` with no args for an optional local browser. The CLI is the primary interface for scripts, CI, and agent tool calls.
@@ -504,7 +504,7 @@ asm install github:anthropics/skills --all
 <details>
 <summary><strong>Supported agent tools</strong></summary>
 
-19 built-in providers, all enabled by default. Disable via `asm config edit`.
+22 built-in providers, all enabled by default. Disable via `asm config edit`.
 
 | Tool               | Global Path                       | Project Path            |
 | ------------------ | --------------------------------- | ----------------------- |
@@ -526,6 +526,9 @@ asm install github:anthropics/skills --all
 | Gemini CLI         | `~/.gemini/skills/`               | `.gemini/skills/`       |
 | Google Antigravity | `~/.antigravity/skills/`          | `.antigravity/skills/`  |
 | Pi                 | `~/.pi/skills/`                   | `.pi/skills/`           |
+| Oh My Pi           | `~/.omp/agent/skills/`            | `.omp/skills/`          |
+| Grok CLI           | `~/.grok/skills/`                 | `.grok/skills/`         |
+| Reasonix           | `~/.reasonix/skills/`             | `.reasonix/skills/`     |
 | Hermes             | `~/.hermes/skills/`               | `.hermes/skills/`       |
 
 Add custom providers in config.
@@ -834,6 +837,27 @@ On first run, config is created at `~/.config/agent-skill-manager/config.json`:
       "enabled": true
     },
     {
+      "name": "omp",
+      "label": "Oh My Pi",
+      "global": "~/.omp/agent/skills",
+      "project": ".omp/skills",
+      "enabled": true
+    },
+    {
+      "name": "grok",
+      "label": "Grok CLI",
+      "global": "~/.grok/skills",
+      "project": ".grok/skills",
+      "enabled": true
+    },
+    {
+      "name": "reasonix",
+      "label": "Reasonix",
+      "global": "~/.reasonix/skills",
+      "project": ".reasonix/skills",
+      "enabled": true
+    },
+    {
       "name": "hermes",
       "label": "Hermes",
       "global": "~/.hermes/skills",
@@ -947,7 +971,7 @@ On first run, config is created at `~/.config/agent-skill-manager/config.json`:
 }
 ```
 
-- All 19 providers are enabled by default
+- All 22 providers are enabled by default
 - Set `"enabled": false` to skip a provider you don't use
 - Add arbitrary directories via `customPaths`
 - Manage via `asm config show|path|reset|edit` or press `c` in the TUI

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -23,12 +23,12 @@ describe("getDefaultConfig", () => {
     expect(config.version).toBe(1);
   });
 
-  it("returns 19 default providers", () => {
+  it("returns 22 default providers", () => {
     const config = getDefaultConfig();
-    expect(config.providers).toHaveLength(19);
+    expect(config.providers).toHaveLength(22);
   });
 
-  it("includes all 19 default providers in priority order", () => {
+  it("includes all 22 default providers in priority order", () => {
     const config = getDefaultConfig();
     const names = config.providers.map((p) => p.name);
     expect(names).toEqual([
@@ -36,6 +36,9 @@ describe("getDefaultConfig", () => {
       "codex",
       "opencode",
       "pi",
+      "omp",
+      "grok",
+      "reasonix",
       "hermes",
       "openclaw",
       "agents",
@@ -54,9 +57,9 @@ describe("getDefaultConfig", () => {
     ]);
   });
 
-  it("all 19 providers are enabled by default", () => {
+  it("all 22 providers are enabled by default", () => {
     const config = getDefaultConfig();
-    expect(config.providers).toHaveLength(19);
+    expect(config.providers).toHaveLength(22);
     expect(config.providers.every((p) => p.enabled)).toBe(true);
   });
 
@@ -200,7 +203,7 @@ describe("config backup on corruption", () => {
 
     // Should return defaults
     expect(config.version).toBe(1);
-    expect(config.providers).toHaveLength(19);
+    expect(config.providers).toHaveLength(22);
 
     // Should have created backup
     const backup = await readFile(backupPath, "utf-8");
@@ -451,6 +454,58 @@ describe("mergeWithDefaults priority-order insertion", () => {
 
     expect(piIdx).toBeGreaterThan(opencodeIdx);
     expect(piIdx).toBeLessThan(hermesIdx);
+  });
+
+  it("inserts omp, grok, and reasonix between pi and hermes on upgrade", async () => {
+    // Simulate an existing user upgrading from the 19-provider defaults:
+    // their saved config has every current built-in except omp/grok/reasonix.
+    await mkdir(dirname(configPath), { recursive: true });
+    const legacyNames = [
+      "claude",
+      "codex",
+      "opencode",
+      "pi",
+      "hermes",
+      "openclaw",
+      "agents",
+      "cursor",
+      "copilot",
+      "windsurf",
+      "antigravity",
+      "gemini",
+      "cline",
+      "roocode",
+      "continue",
+      "aider",
+      "zed",
+      "augment",
+      "amp",
+    ];
+    const partial = {
+      version: 1,
+      providers: legacyNames.map((name) => ({
+        name,
+        label: name,
+        global: `~/.${name}/skills`,
+        project: `.${name}/skills`,
+        enabled: true,
+      })),
+      preferences: { defaultScope: "both", defaultSort: "name" },
+    };
+    await writeFile(configPath, JSON.stringify(partial), "utf-8");
+
+    const config = await loadConfig();
+    const names = config.providers.map((p) => p.name);
+    const piIdx = names.indexOf("pi");
+    const ompIdx = names.indexOf("omp");
+    const grokIdx = names.indexOf("grok");
+    const reasonixIdx = names.indexOf("reasonix");
+    const hermesIdx = names.indexOf("hermes");
+
+    expect(ompIdx).toBe(piIdx + 1);
+    expect(grokIdx).toBe(piIdx + 2);
+    expect(reasonixIdx).toBe(piIdx + 3);
+    expect(hermesIdx).toBe(piIdx + 4);
   });
 
   it("preserves user-added custom providers in place when adding new defaults", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,27 @@ const DEFAULT_PROVIDERS: ProviderConfig[] = [
     enabled: true,
   },
   {
+    name: "omp",
+    label: "Oh My Pi",
+    global: "~/.omp/agent/skills",
+    project: ".omp/skills",
+    enabled: true,
+  },
+  {
+    name: "grok",
+    label: "Grok CLI",
+    global: "~/.grok/skills",
+    project: ".grok/skills",
+    enabled: true,
+  },
+  {
+    name: "reasonix",
+    label: "Reasonix",
+    global: "~/.reasonix/skills",
+    project: ".reasonix/skills",
+    enabled: true,
+  },
+  {
     name: "hermes",
     label: "Hermes",
     global: "~/.hermes/skills",

--- a/website-src/src/pages/DocsPage.jsx
+++ b/website-src/src/pages/DocsPage.jsx
@@ -516,7 +516,7 @@ metadata:
       <section className="doc-section">
         <h2>Supported Agent Tools</h2>
         <p>
-          <code>asm</code> ships with 19 built-in providers, all enabled by
+          <code>asm</code> ships with 22 built-in providers, all enabled by
           default:
         </p>
         <table>
@@ -570,6 +570,17 @@ metadata:
             />
             <ToolRow tool="Pi" g="~/.pi/skills/" p=".pi/skills/" />
             <ToolRow
+              tool="Oh My Pi"
+              g="~/.omp/agent/skills/"
+              p=".omp/skills/"
+            />
+            <ToolRow tool="Grok CLI" g="~/.grok/skills/" p=".grok/skills/" />
+            <ToolRow
+              tool="Reasonix"
+              g="~/.reasonix/skills/"
+              p=".reasonix/skills/"
+            />
+            <ToolRow
               tool="Zed"
               g="~/.config/zed/prompt_overrides/"
               p=".zed/rules/"
@@ -598,7 +609,7 @@ metadata:
         <p>
           Config file is created at{" "}
           <code>~/.config/agent-skill-manager/config.json</code> on first run
-          with 19 default providers.
+          with 22 default providers.
         </p>
         <table>
           <thead>

--- a/website-src/src/pages/LandingPage.jsx
+++ b/website-src/src/pages/LandingPage.jsx
@@ -10,7 +10,7 @@ import { prefersReducedMotion } from "../lib/motion.js";
 
 const REPO_URL = "https://github.com/luongnv89/asm";
 const NPM_CMD = "npm install -g agent-skill-manager";
-const PROVIDER_COUNT = 19;
+const PROVIDER_COUNT = 22;
 
 /**
  * Marketing landing page (route `/`). The catalog lives at `/skills`.
@@ -373,7 +373,7 @@ function Solution() {
     {
       icon: "05",
       head: "Works with every major agent",
-      body: "19 providers built in: Claude Code, Codex, Cursor, Windsurf, Cline, Roo, Continue, Copilot, Aider, Zed, Gemini CLI, and more. Add custom ones in seconds.",
+      body: "22 providers built in: Claude Code, Codex, Cursor, Windsurf, Cline, Roo, Continue, Copilot, Aider, Zed, Gemini CLI, and more. Add custom ones in seconds.",
     },
     {
       icon: "06",


### PR DESCRIPTION
## Description

`asm list` / `asm install` can now target Oh My Pi, Grok CLI, and Reasonix without adding custom provider entries. Existing configs pick the three names up on upgrade, inserted after `pi` and before `hermes`.

Oh My Pi uses `~/.omp/agent/skills` (not `~/.omp/skills` and not Pi's `~/.pi/skills`).

## Related Issue

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Focused `npx vitest run src/config.test.ts`: 30/30. The new upgrade case asserts a saved 19-provider config gains `omp` / `grok` / `reasonix` between `pi` and `hermes`. `src/views/config.test.tsx` still passes (8/8).

`npm run typecheck` and `npm run lint` fail on this checkout independently of this change (`src/commands/stats.test.ts` IndexedSkill/`no-color` errors; typescript-eslint vs TS 7). Not addressed here.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required until the next `agent-skill-manager` release. After publish, confirm `asm config show` includes the three names on a fresh or upgraded config, and that `asm list -p grok|omp|reasonix` scans the documented global paths. Rollback: disable the providers in config, or revert this commit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
