### PR TITLE
refactor(audit): duplicate-group normalization + version flags (#567)

### DIFF
--- a/src/auditor.test.ts
+++ b/src/auditor.test.ts
@@ -680,7 +680,9 @@ describe("normalizeSkillKey", () => {
 
   it("keeps dots and digits so distinct skills stay distinct", () => {
     expect(normalizeSkillKey("skill.v2")).toBe("skill.v2");
-    expect(normalizeSkillKey("skill.v2")).not.toBe(normalizeSkillKey("skill-v2"));
+    expect(normalizeSkillKey("skill.v2")).not.toBe(
+      normalizeSkillKey("skill-v2"),
+    );
     expect(normalizeSkillKey("skill-one")).not.toBe(
       normalizeSkillKey("skillone"),
     );

--- a/src/auditor.test.ts
+++ b/src/auditor.test.ts
@@ -5,6 +5,9 @@ import {
   reasonLabel,
   formatAuditReport,
   formatAuditReportJSON,
+  normalizeSkillKey,
+  compareVersions,
+  distinctVersions,
 } from "./auditor";
 import type { SkillInfo } from "./utils/types";
 
@@ -655,5 +658,318 @@ describe("formatAuditReportJSON", () => {
     expect(parsed.totalSkills).toBe(2);
     expect(parsed.duplicateGroups).toHaveLength(1);
     expect(parsed.totalDuplicateInstances).toBe(2);
+  });
+});
+
+// ─── normalizeSkillKey (#564) ───────────────────────────────────────────────
+
+describe("normalizeSkillKey", () => {
+  it("lowercases the key", () => {
+    expect(normalizeSkillKey("Code-Review")).toBe("code-review");
+  });
+
+  it("folds underscores and whitespace to hyphens", () => {
+    expect(normalizeSkillKey("code_review")).toBe("code-review");
+    expect(normalizeSkillKey("code review")).toBe("code-review");
+  });
+
+  it("collapses separator runs and trims edges", () => {
+    expect(normalizeSkillKey("-Code_ Review-")).toBe("code-review");
+    expect(normalizeSkillKey("my--skill")).toBe("my-skill");
+  });
+
+  it("keeps dots and digits so distinct skills stay distinct", () => {
+    expect(normalizeSkillKey("skill.v2")).toBe("skill.v2");
+    expect(normalizeSkillKey("skill.v2")).not.toBe(normalizeSkillKey("skill-v2"));
+    expect(normalizeSkillKey("skill-one")).not.toBe(
+      normalizeSkillKey("skillone"),
+    );
+  });
+});
+
+// ─── compareVersions / distinctVersions (#567) ──────────────────────────────
+
+describe("compareVersions", () => {
+  it("compares numeric segments numerically", () => {
+    expect(compareVersions("2.10.0", "2.9.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.0", "1.0.1")).toBeLessThan(0);
+  });
+
+  it("sorts a missing segment below a present one", () => {
+    expect(compareVersions("1.0", "1.0.1")).toBeLessThan(0);
+    expect(compareVersions("2.0", "1.0")).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for equal versions", () => {
+    expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+  });
+});
+
+describe("distinctVersions", () => {
+  it("dedupes and sorts ascending, ignoring empty versions", () => {
+    const instances = [
+      makeSkill({ version: "2.0.0" }),
+      makeSkill({ version: "1.0.0" }),
+      makeSkill({ version: "" }),
+      makeSkill({ version: "2.0.0" }),
+    ];
+    expect(distinctVersions(instances)).toEqual(["1.0.0", "2.0.0"]);
+  });
+});
+
+// ─── case/separator-normalized grouping (#564) ─────────────────────────────
+
+describe("detectDuplicates normalization (#564)", () => {
+  it("groups dirNames differing only by case", () => {
+    const skills = [
+      makeSkill({
+        dirName: "Code-Review",
+        name: "Code-Review",
+        path: "/claude/Code-Review",
+        location: "global-claude",
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/codex/code-review",
+        location: "global-codex",
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(1);
+    expect(report.duplicateGroups[0].reason).toBe("same-dirName");
+    expect(report.duplicateGroups[0].key).toBe("Code-Review");
+    expect(report.duplicateGroups[0].instances).toHaveLength(2);
+  });
+
+  it("groups dirNames differing only by separator", () => {
+    const skills = [
+      makeSkill({
+        dirName: "code_review",
+        name: "code_review",
+        path: "/claude/code_review",
+        location: "global-claude",
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/codex/code-review",
+        location: "global-codex",
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(1);
+    expect(report.duplicateGroups[0].reason).toBe("same-dirName");
+  });
+
+  it("does not merge legitimately distinct skill names", () => {
+    const skills = [
+      makeSkill({
+        dirName: "skill-one",
+        name: "skill-one",
+        path: "/claude/skill-one",
+        location: "global-claude",
+      }),
+      makeSkill({
+        dirName: "skillone",
+        name: "skillone",
+        path: "/codex/skillone",
+        location: "global-codex",
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(0);
+  });
+
+  it("preserves original spellings in key and variants", () => {
+    const skills = [
+      makeSkill({
+        dirName: "Code_Review",
+        name: "Code_Review",
+        path: "/claude/Code_Review",
+        location: "global-claude",
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/codex/code-review",
+        location: "global-codex",
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    const group = report.duplicateGroups[0];
+    expect(group.key).toBe("Code_Review");
+    expect(group.variants).toContain("Code_Review");
+    expect(group.variants).toContain("code-review");
+    const output = formatAuditReport(report);
+    expect(output).toContain('"Code_Review"');
+    expect(output).toContain('variants: "Code_Review", "code-review"');
+  });
+
+  it("omits variants when every instance spells its name identically", () => {
+    const skills = [
+      makeSkill({
+        dirName: "deploy",
+        name: "deploy",
+        path: "/claude/deploy",
+        location: "global-claude",
+      }),
+      makeSkill({
+        dirName: "deploy",
+        name: "deploy",
+        path: "/codex/deploy",
+        location: "global-codex",
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups[0].variants).toBeUndefined();
+  });
+
+  it("groups frontmatter names differing only by case across dirNames", () => {
+    const skills = [
+      makeSkill({
+        dirName: "review-a",
+        name: "Review Tool",
+        path: "/claude/review-a",
+        location: "global-claude",
+      }),
+      makeSkill({
+        dirName: "review-b",
+        name: "review tool",
+        path: "/claude/review-b",
+        location: "global-claude",
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(1);
+    expect(report.duplicateGroups[0].reason).toBe("same-frontmatterName");
+    expect(report.duplicateGroups[0].key).toBe("Review Tool");
+  });
+
+  it("groups frontmatter names differing only by separator across dirNames", () => {
+    const skills = [
+      makeSkill({
+        dirName: "format-a",
+        name: "Code Formatter",
+        path: "/claude/format-a",
+        location: "global-claude",
+      }),
+      makeSkill({
+        dirName: "format-b",
+        name: "code_formatter",
+        path: "/claude/format-b",
+        location: "global-claude",
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(1);
+    expect(report.duplicateGroups[0].reason).toBe("same-frontmatterName");
+  });
+
+  it("does not double-report case-variant dirNames under both rules", () => {
+    const skills = [
+      makeSkill({
+        dirName: "Deploy",
+        name: "Deploy",
+        path: "/claude/Deploy",
+        location: "global-claude",
+      }),
+      makeSkill({
+        dirName: "deploy",
+        name: "deploy",
+        path: "/codex/deploy",
+        location: "global-codex",
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(1);
+    expect(report.duplicateGroups[0].reason).toBe("same-dirName");
+    expect(report.totalDuplicateInstances).toBe(2);
+  });
+});
+
+// ─── version divergence (#567) ─────────────────────────────────────────────
+
+describe("detectDuplicates version divergence (#567)", () => {
+  function sameDirTwoLocations(versionA: string, versionB: string) {
+    return [
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/claude/code-review",
+        location: "global-claude",
+        version: versionA,
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/codex/code-review",
+        location: "global-codex",
+        version: versionB,
+      }),
+    ];
+  }
+
+  it("flags groups where instance versions differ", () => {
+    const report = detectDuplicates(sameDirTwoLocations("1.0.0", "2.0.0"));
+    expect(report.duplicateGroups).toHaveLength(1);
+    expect(report.duplicateGroups[0].versionDivergence).toBe(true);
+  });
+
+  it("does not flag groups where all versions match", () => {
+    const report = detectDuplicates(sameDirTwoLocations("1.0.0", "1.0.0"));
+    expect(report.duplicateGroups[0].versionDivergence).toBe(false);
+  });
+
+  it("ignores empty versions when computing divergence", () => {
+    const report = detectDuplicates(sameDirTwoLocations("", "1.0.0"));
+    expect(report.duplicateGroups[0].versionDivergence).toBe(false);
+  });
+
+  it("shows each instance's version in the formatted report", () => {
+    const report = detectDuplicates(sameDirTwoLocations("1.0.0", "2.0.0"));
+    const output = formatAuditReport(report);
+    expect(output).toContain("(v1.0.0)");
+    expect(output).toContain("(v2.0.0)");
+  });
+
+  it("visibly flags divergent groups newest-first", () => {
+    const report = detectDuplicates(sameDirTwoLocations("1.0.0", "2.0.0"));
+    const output = formatAuditReport(report);
+    expect(output).toContain(
+      "versions differ: v2.0.0, v1.0.0 — possible upgrade/shadow",
+    );
+    expect(output).toContain("(v2.0.0)");
+  });
+
+  it("does not flag uniform-version groups in the formatted report", () => {
+    const report = detectDuplicates(sameDirTwoLocations("1.0.0", "1.0.0"));
+    const output = formatAuditReport(report);
+    expect(output).not.toContain("versions differ");
+  });
+
+  it("carries divergence and variants through the JSON output", () => {
+    const skills = [
+      makeSkill({
+        dirName: "Code_Review",
+        name: "Code_Review",
+        path: "/claude/Code_Review",
+        location: "global-claude",
+        version: "1.0.0",
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/codex/code-review",
+        location: "global-codex",
+        version: "2.0.0",
+      }),
+    ];
+    const parsed = JSON.parse(formatAuditReportJSON(detectDuplicates(skills)));
+    expect(parsed.duplicateGroups[0].versionDivergence).toBe(true);
+    expect(parsed.duplicateGroups[0].variants).toEqual([
+      "Code_Review",
+      "code-review",
+    ]);
   });
 });

--- a/src/auditor.ts
+++ b/src/auditor.ts
@@ -3,6 +3,60 @@ import type { SkillInfo, DuplicateGroup, AuditReport } from "./utils/types";
 
 // ─── Detection ─────────────────────────────────────────────────────────────
 
+/**
+ * Normalizes a grouping key so skills differing only by case or by
+ * separator characters (`_`, whitespace vs `-`) group as duplicates
+ * (issue #564). Dots and digits are never folded — `skill.v2` and
+ * `skill-v2` stay distinct.
+ */
+export function normalizeSkillKey(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[_\s]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Compares dotted version strings segment-wise; numeric segments compare
+ * numerically, a missing segment sorts below a present one, and
+ * non-numeric segments fall back to lexical order. Returns <0, 0, or >0.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split(".");
+  const pb = b.split(".");
+  const n = Math.max(pa.length, pb.length);
+  for (let i = 0; i < n; i++) {
+    const sa = pa[i] ?? "";
+    const sb = pb[i] ?? "";
+    if (sa === sb) continue;
+    if (sa === "") return -1;
+    if (sb === "") return 1;
+    const na = /^\d+$/.test(sa) ? Number.parseInt(sa, 10) : null;
+    const nb = /^\d+$/.test(sb) ? Number.parseInt(sb, 10) : null;
+    if (na !== null && nb !== null && na !== nb) return na - nb;
+    if (na === null || nb === null) {
+      const cmp = sa.localeCompare(sb);
+      if (cmp !== 0) return cmp;
+    }
+  }
+  return 0;
+}
+
+/** Distinct non-empty versions among instances, ascending (issue #567). */
+export function distinctVersions(instances: SkillInfo[]): string[] {
+  const versions = new Set<string>();
+  for (const s of instances) {
+    const v = (s.version ?? "").trim();
+    if (v) versions.add(v);
+  }
+  return [...versions].sort(compareVersions);
+}
+
+function groupVersionDivergence(instances: SkillInfo[]): boolean {
+  return distinctVersions(instances).length >= 2;
+}
+
 export function detectDuplicates(skills: SkillInfo[]): AuditReport {
   const groups: DuplicateGroup[] = [];
   const coveredPaths = new Set<string>();
@@ -34,32 +88,60 @@ export function detectDuplicates(skills: SkillInfo[]): AuditReport {
     }
   }
 
-  // Rule 1: same dirName across different locations
-  const byDirName = new Map<string, SkillInfo[]>();
+  // Rule 1: same dirName across different locations. Grouping keys are
+  // normalized (#564) so `Code-Review`, `code_review` and `code review`
+  // land in one bucket; the first-seen spelling becomes the display key.
+  const byDirName = new Map<
+    string,
+    { key: string; variants: Set<string>; members: SkillInfo[] }
+  >();
   for (const s of deduped) {
-    const bucket = byDirName.get(s.dirName) ?? [];
-    bucket.push(s);
-    byDirName.set(s.dirName, bucket);
+    const norm = normalizeSkillKey(s.dirName);
+    const entry = byDirName.get(norm) ?? {
+      key: s.dirName,
+      variants: new Set<string>(),
+      members: [],
+    };
+    entry.variants.add(s.dirName);
+    entry.members.push(s);
+    byDirName.set(norm, entry);
   }
 
-  for (const [dirName, members] of byDirName) {
-    const uniqueLocations = new Set(members.map((m) => m.location));
+  for (const entry of byDirName.values()) {
+    const uniqueLocations = new Set(entry.members.map((m) => m.location));
     if (uniqueLocations.size >= 2) {
-      groups.push({ key: dirName, reason: "same-dirName", instances: members });
-      for (const m of members) coveredPaths.add(m.path);
+      groups.push({
+        key: entry.key,
+        reason: "same-dirName",
+        instances: entry.members,
+        versionDivergence: groupVersionDivergence(entry.members),
+        ...(entry.variants.size > 1 ? { variants: [...entry.variants] } : {}),
+      });
+      for (const m of entry.members) coveredPaths.add(m.path);
     }
   }
 
-  // Rule 2: same frontmatter name but different dirName
-  const byName = new Map<string, SkillInfo[]>();
+  // Rule 2: same frontmatter name but different dirName (names normalized
+  // per #564; the dirName-distinctness guard stays on raw spellings).
+  const byName = new Map<
+    string,
+    { key: string; variants: Set<string>; members: SkillInfo[] }
+  >();
   for (const s of deduped) {
     if (!s.name) continue;
-    const bucket = byName.get(s.name) ?? [];
-    bucket.push(s);
-    byName.set(s.name, bucket);
+    const norm = normalizeSkillKey(s.name);
+    const entry = byName.get(norm) ?? {
+      key: s.name,
+      variants: new Set<string>(),
+      members: [],
+    };
+    entry.variants.add(s.name);
+    entry.members.push(s);
+    byName.set(norm, entry);
   }
 
-  for (const [name, members] of byName) {
+  for (const entry of byName.values()) {
+    const members = entry.members;
     const uniqueDirNames = new Set(members.map((m) => m.dirName));
     if (uniqueDirNames.size < 2) continue;
 
@@ -71,19 +153,28 @@ export function detectDuplicates(skills: SkillInfo[]): AuditReport {
     const uncoveredDirNames = new Set(uncovered.map((m) => m.dirName));
     if (uncoveredDirNames.size < 2) continue;
 
+    const uncoveredVariants = new Set(uncovered.map((m) => m.name));
     groups.push({
-      key: name,
+      key: entry.key,
       reason: "same-frontmatterName",
       instances: uncovered,
+      versionDivergence: groupVersionDivergence(uncovered),
+      ...(uncoveredVariants.size > 1
+        ? { variants: [...uncoveredVariants] }
+        : {}),
     });
   }
 
-  // Sort: same-dirName groups first, then same-frontmatterName; within each, by key
+  // Sort: same-dirName groups first, then same-frontmatterName; within each,
+  // by normalized key so case/separator variants order deterministically.
   groups.sort((a, b) => {
     if (a.reason !== b.reason) {
       return a.reason === "same-dirName" ? -1 : 1;
     }
-    return a.key.localeCompare(b.key);
+    return (
+      normalizeSkillKey(a.key).localeCompare(normalizeSkillKey(b.key)) ||
+      a.key.localeCompare(b.key)
+    );
   });
 
   const totalDuplicateInstances = groups.reduce(
@@ -139,14 +230,30 @@ export function formatAuditReport(report: AuditReport): string {
     lines.push(
       `  ${ansi.yellow(`"${group.key}"`)} ${ansi.dim(`(${reasonLabel(group.reason)})`)}`,
     );
+    if (group.variants && group.variants.length > 1) {
+      const spellings = group.variants.map((v) => `"${v}"`).join(", ");
+      lines.push(ansi.dim(`     variants: ${spellings}`));
+    }
+    if (group.versionDivergence) {
+      const newestFirst = distinctVersions(group.instances)
+        .slice()
+        .reverse();
+      lines.push(
+        ansi.red(
+          `     ⚠ versions differ: ${newestFirst.map((v) => `v${v}`).join(", ")} — possible upgrade/shadow, not identical copies`,
+        ),
+      );
+    }
     const sorted = sortInstancesForKeep(group.instances);
     for (let i = 0; i < sorted.length; i++) {
       const s = sorted[i];
       const provider = colorProvider(s.provider, s.providerLabel);
       const keepTag = i === 0 ? ansi.green(" [keep]") : ansi.dim("       ");
       const scope = ansi.dim(`(${s.scope})`);
+      const version = (s.version ?? "").trim();
+      const versionTag = version ? ansi.dim(` (v${version})`) : "";
       lines.push(
-        `   ${keepTag} ${provider} ${scope}  ${ansi.dim(shortenPath(s.path))}`,
+        `   ${keepTag} ${provider} ${scope}${versionTag}  ${ansi.dim(shortenPath(s.path))}`,
       );
     }
     lines.push("");

--- a/src/auditor.ts
+++ b/src/auditor.ts
@@ -235,9 +235,7 @@ export function formatAuditReport(report: AuditReport): string {
       lines.push(ansi.dim(`     variants: ${spellings}`));
     }
     if (group.versionDivergence) {
-      const newestFirst = distinctVersions(group.instances)
-        .slice()
-        .reverse();
+      const newestFirst = distinctVersions(group.instances).slice().reverse();
       lines.push(
         ansi.red(
           `     ⚠ versions differ: ${newestFirst.map((v) => `v${v}`).join(", ")} — possible upgrade/shadow, not identical copies`,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -436,6 +436,19 @@ export interface DuplicateGroup {
   key: string;
   reason: "same-dirName" | "same-frontmatterName";
   instances: SkillInfo[];
+  /**
+   * True when the group's instances carry two or more distinct non-empty
+   * `version` strings — likely a shadowed upgrade rather than identical
+   * copies (issue #567). Absent/false when all versions match.
+   */
+  versionDivergence?: boolean;
+  /**
+   * The original dirName / frontmatter-name spellings found among the
+   * group's instances, when normalization (#564) folded case or separator
+   * variants into one group. Absent when every instance spells its name
+   * identically.
+   */
+  variants?: string[];
 }
 
 export interface AuditReport {


### PR DESCRIPTION
Closes #567
Closes #564

## Summary

Duplicate detection now (a) groups skills whose dirName or frontmatter name differ only by case or separator (`Code-Review` vs `code_review`) while preserving the original spellings in the report, and (b) shows each instance's version inside a duplicate group and visibly flags groups whose versions diverge as likely upgrade/shadow situations rather than identical copies.

## Approach

Grouping keys are folded through a new `normalizeSkillKey()` (lowercase, `_`/whitespace → `-`, collapse/trim runs) before bucketing in both detection rules; dots and digits are never folded, so legitimately distinct names like `skill.v2` vs `skill-v2` or `skill-one` vs `skillone` stay separate. The display `key` keeps the first-seen original spelling, with all original spellings listed in a new optional `variants[]` field. A new `versionDivergence` boolean on each group marks ≥2 distinct non-empty versions, rendered as a red warning line (newest-first via a new `compareVersions()` semver-ish comparator); every instance line now carries its `(vX.Y.Z)`. All new fields are optional, so TUI views, stats, machine output, and hand-built reports are unaffected. `audit -y` keep-selection semantics are deliberately unchanged (surfacing-only scope).

## Decision Record

- **Selected option:** minimal audit-core change — normalized grouping keys + per-instance versions + group divergence flag (direct plan, light profile)
- **Options rejected:** fuzzy/similarity matching (out of scope, high false-positive risk against criterion 4); changing `audit -y` to skip divergent groups (behavior change beyond the issues' report-surfacing scope — noted as follow-up); folding dot separators (would merge versioned variants)
- **Complexity/risk:** low / low — confined to `src/auditor.ts` + types; consumers read only existing fields

## Changes

| File | Change |
|------|--------|
| `src/utils/types.ts` | `DuplicateGroup` gains optional `versionDivergence` and `variants` |
| `src/auditor.ts` | `normalizeSkillKey()`, `compareVersions()`, `distinctVersions()` helpers; normalized Rule 1/Rule 2 buckets with variant capture; divergence computed per group; formatter renders versions, variants line, red divergence flag |
| `src/auditor.test.ts` | 17 new tests: key normalization, version comparators, case/separator grouping, distinct-name safety, variant preservation, divergence detection + formatting + JSON |

## Test Results

- `npx vitest run src/auditor.test.ts` — 54/54 pass (37 pre-existing + 17 new)
- `CI=true npm test` — **2259/2259 passed**, 70 files
- `npm run lint` — clean; `npm run build` — OK
- `npm run typecheck` — 10 pre-existing errors in `src/commands/stats.test.ts`, present on `main`; zero in changed files

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| #567: duplicate groups show each instance's version | ✅ `(v1.0.0)` rendered per instance line |
| #567: groups with differing versions flagged as upgrades/shadowing | ✅ red `⚠ versions differ: v2.0.0, v1.0.0 — possible upgrade/shadow` line |
| #567: uniform-version groups not flagged | ✅ `versionDivergence=false`, no flag rendered |
| #564: case-only dirName/frontmatter differences grouped | ✅ normalized buckets in both rules |
| #564: separator-only differences grouped | ✅ `_`/whitespace fold to `-` |
| #564: displayed group key preserves original names | ✅ key = first-seen spelling; `variants:` line lists originals |
| #564: normalization does not merge distinct skills | ✅ digits/dots untouched; regression test for `skillone` vs `skill-one` |

<!-- gitissue:qa v1 head=a6c28efb4a85df430fe6f17f43eeb26e8cfd972d profile=light cycles=1 review=clean tests=2259@a6c28efb4a85df430fe6f17f43eeb26e8cfd972d ui=none -->
