### PR TITLE
feat(audit): content fingerprints + guarded auto-remove (#562)

### DIFF
--- a/src/auditor.test.ts
+++ b/src/auditor.test.ts
@@ -8,6 +8,8 @@ import {
   normalizeSkillKey,
   compareVersions,
   distinctVersions,
+  extractSkillMdBody,
+  skillContentFingerprint,
 } from "./auditor";
 import type { SkillInfo } from "./utils/types";
 
@@ -973,5 +975,234 @@ describe("detectDuplicates version divergence (#567)", () => {
       "Code_Review",
       "code-review",
     ]);
+  });
+});
+
+// ─── content fingerprinting (#562) ─────────────────────────────────────────
+
+const BODY_A = "# Steps\n\nDo the thing.";
+const BODY_B = "# Steps\n\nDo the other thing.";
+const fm = (name: string, body: string): string =>
+  `---\nname: ${name}\ndescription: d\n---\n${body}\n`;
+
+function withContent(overrides: Partial<SkillInfo>): SkillInfo {
+  return makeSkill(overrides);
+}
+
+describe("extractSkillMdBody (#562)", () => {
+  it("returns everything after the closing frontmatter delimiter", () => {
+    expect(extractSkillMdBody(fm("x", BODY_A))).toBe(`${BODY_A}\n`);
+  });
+
+  it("returns whole content when there is no frontmatter", () => {
+    expect(extractSkillMdBody(BODY_A)).toBe(BODY_A);
+  });
+
+  it("treats unterminated frontmatter as plain content", () => {
+    const content = "---\nname: x\nno closing delimiter";
+    expect(extractSkillMdBody(content)).toBe(content);
+  });
+
+  it("tolerates CRLF delimiters", () => {
+    const content = "---\r\nname: x\r\n---\r\nbody\r\n";
+    expect(extractSkillMdBody(content)).toBe("body\r\n");
+  });
+});
+
+describe("skillContentFingerprint (#562)", () => {
+  it("matches renamed copies whose bodies are identical", () => {
+    const a = withContent({
+      dirName: "alpha",
+      path: "/a",
+      _skillMdContent: fm("alpha", BODY_A),
+    });
+    const b = withContent({
+      dirName: "beta",
+      path: "/b",
+      _skillMdContent: fm("beta", BODY_A),
+    });
+    expect(skillContentFingerprint(a)).toBe(skillContentFingerprint(b));
+  });
+
+  it("differs when bodies differ", () => {
+    const a = withContent({ path: "/a", _skillMdContent: fm("x", BODY_A) });
+    const b = withContent({ path: "/b", _skillMdContent: fm("x", BODY_B) });
+    expect(skillContentFingerprint(a)).not.toBe(skillContentFingerprint(b));
+  });
+
+  it("returns null when the content cache is absent", () => {
+    expect(skillContentFingerprint(makeSkill())).toBeNull();
+  });
+});
+
+describe("detectDuplicates content classification (#562)", () => {
+  function sameDirTwoLocations(bodyA: string, bodyB: string) {
+    return [
+      withContent({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/claude/code-review",
+        location: "global-claude",
+        _skillMdContent: fm("code-review", bodyA),
+      }),
+      withContent({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/codex/code-review",
+        location: "global-codex",
+        _skillMdContent: fm("code-review", bodyB),
+      }),
+    ];
+  }
+
+  it("tags a group identical when every member hashes the same", () => {
+    const report = detectDuplicates(sameDirTwoLocations(BODY_A, BODY_A));
+    expect(report.duplicateGroups[0].contentClass).toBe("identical");
+  });
+
+  it("tags a group diverged when any member differs", () => {
+    const report = detectDuplicates(sameDirTwoLocations(BODY_A, BODY_B));
+    expect(report.duplicateGroups[0].contentClass).toBe("diverged");
+  });
+
+  it("omits classification when any instance has no cached content", () => {
+    const skills = sameDirTwoLocations(BODY_A, BODY_B);
+    delete (skills[1] as { _skillMdContent?: string })._skillMdContent;
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups[0].contentClass).toBeUndefined();
+  });
+
+  it("classifies independently of version divergence", () => {
+    const skills = sameDirTwoLocations(BODY_A, BODY_A);
+    skills[1].version = "2.0.0";
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups[0].versionDivergence).toBe(true);
+    expect(report.duplicateGroups[0].contentClass).toBe("identical");
+  });
+
+  it("shows the classification and force hint in the formatted report", () => {
+    let output = formatAuditReport(detectDuplicates(sameDirTwoLocations(BODY_A, BODY_A)));
+    expect(output).toContain("identical copies");
+
+    output = formatAuditReport(detectDuplicates(sameDirTwoLocations(BODY_A, BODY_B)));
+    expect(output).toContain("diverged copies");
+    expect(output).toContain("--force");
+  });
+
+  it("carries contentClass through the JSON output", () => {
+    const parsed = JSON.parse(
+      formatAuditReportJSON(detectDuplicates(sameDirTwoLocations(BODY_A, BODY_B))),
+    );
+    expect(parsed.duplicateGroups[0].contentClass).toBe("diverged");
+  });
+});
+
+describe("detectDuplicates same-content rule (#562)", () => {
+  function renamedIdenticalPair() {
+    return [
+      withContent({
+        dirName: "alpha-skill",
+        name: "Alpha Skill",
+        path: "/claude/alpha-skill",
+        location: "global-claude",
+        _skillMdContent: fm("Alpha Skill", BODY_A),
+      }),
+      withContent({
+        dirName: "beta-skill",
+        name: "Beta Skill",
+        path: "/codex/beta-skill",
+        location: "global-codex",
+        _skillMdContent: fm("Beta Skill", BODY_A),
+      }),
+    ];
+  }
+
+  it("surfaces different-name skills with byte-identical bodies", () => {
+    const report = detectDuplicates(renamedIdenticalPair());
+    expect(report.duplicateGroups).toHaveLength(1);
+    expect(report.duplicateGroups[0].reason).toBe("same-content");
+    expect(report.duplicateGroups[0].contentClass).toBe("identical");
+    expect(report.totalDuplicateInstances).toBe(2);
+  });
+
+  it("does not group different bodies under different names", () => {
+    const skills = [
+      withContent({
+        dirName: "alpha-skill",
+        name: "Alpha Skill",
+        path: "/a",
+        location: "global-claude",
+        _skillMdContent: fm("Alpha Skill", BODY_A),
+      }),
+      withContent({
+        dirName: "beta-skill",
+        name: "Beta Skill",
+        path: "/b",
+        location: "global-codex",
+        _skillMdContent: fm("Beta Skill", BODY_B),
+      }),
+    ];
+    expect(detectDuplicates(skills).duplicateGroups).toHaveLength(0);
+  });
+
+  it("does not re-group skills already covered by the name rules", () => {
+    const skills = [
+      withContent({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/claude/code-review",
+        location: "global-claude",
+        _skillMdContent: fm("code-review", BODY_A),
+      }),
+      withContent({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/codex/code-review",
+        location: "global-codex",
+        _skillMdContent: fm("code-review", BODY_A),
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(1);
+    expect(report.duplicateGroups[0].reason).toBe("same-dirName");
+  });
+
+  it("sorts same-content groups after the name-based rules", () => {
+    const skills = [
+      ...renamedIdenticalPair(),
+      withContent({
+        dirName: "deploy",
+        name: "deploy",
+        path: "/claude/deploy",
+        location: "global-claude",
+        _skillMdContent: fm("deploy", BODY_B),
+      }),
+      withContent({
+        dirName: "deploy",
+        name: "deploy",
+        path: "/codex/deploy",
+        location: "global-codex",
+        _skillMdContent: fm("deploy", BODY_B),
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups.map((g) => g.reason)).toEqual([
+      "same-dirName",
+      "same-content",
+    ]);
+  });
+
+  it("labels the new reason in human output", () => {
+    expect(reasonLabel("same-content")).toBe("identical content");
+    const output = formatAuditReport(detectDuplicates(renamedIdenticalPair()));
+    expect(output).toContain("identical content");
+  });
+
+  it("carries the same-content reason through the JSON output", () => {
+    const parsed = JSON.parse(
+      formatAuditReportJSON(detectDuplicates(renamedIdenticalPair())),
+    );
+    expect(parsed.duplicateGroups[0].reason).toBe("same-content");
+    expect(parsed.duplicateGroups[0].contentClass).toBe("identical");
   });
 });

--- a/src/auditor.test.ts
+++ b/src/auditor.test.ts
@@ -1081,17 +1081,23 @@ describe("detectDuplicates content classification (#562)", () => {
   });
 
   it("shows the classification and force hint in the formatted report", () => {
-    let output = formatAuditReport(detectDuplicates(sameDirTwoLocations(BODY_A, BODY_A)));
+    let output = formatAuditReport(
+      detectDuplicates(sameDirTwoLocations(BODY_A, BODY_A)),
+    );
     expect(output).toContain("identical copies");
 
-    output = formatAuditReport(detectDuplicates(sameDirTwoLocations(BODY_A, BODY_B)));
+    output = formatAuditReport(
+      detectDuplicates(sameDirTwoLocations(BODY_A, BODY_B)),
+    );
     expect(output).toContain("diverged copies");
     expect(output).toContain("--force");
   });
 
   it("carries contentClass through the JSON output", () => {
     const parsed = JSON.parse(
-      formatAuditReportJSON(detectDuplicates(sameDirTwoLocations(BODY_A, BODY_B))),
+      formatAuditReportJSON(
+        detectDuplicates(sameDirTwoLocations(BODY_A, BODY_B)),
+      ),
     );
     expect(parsed.duplicateGroups[0].contentClass).toBe("diverged");
   });

--- a/src/auditor.test.ts
+++ b/src/auditor.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
 import {
   detectDuplicates,
   sortInstancesForKeep,
@@ -10,6 +13,7 @@ import {
   distinctVersions,
   extractSkillMdBody,
   skillContentFingerprint,
+  ensureSkillMdContent,
 } from "./auditor";
 import type { SkillInfo } from "./utils/types";
 
@@ -1032,6 +1036,33 @@ describe("skillContentFingerprint (#562)", () => {
 
   it("returns null when the content cache is absent", () => {
     expect(skillContentFingerprint(makeSkill())).toBeNull();
+  });
+});
+
+describe("ensureSkillMdContent (#562)", () => {
+  it("fills the cache non-enumerably so JSON output never leaks it", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "asm-audit-md-"));
+    try {
+      const skill = makeSkill({ path: dir });
+      await writeFile(
+        join(dir, "SKILL.md"),
+        `---\nname: x\n---\n${BODY_A}\n`,
+        "utf-8",
+      );
+      await ensureSkillMdContent(skill);
+      expect(skill._skillMdContent).toContain(BODY_A);
+      // The scanner's private cache must never reach serialized output.
+      expect(JSON.stringify(skill)).not.toContain("_skillMdContent");
+      expect(JSON.stringify(skill)).not.toContain(BODY_A);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves the cache unset when SKILL.md is unreadable", async () => {
+    const skill = makeSkill({ path: "/nonexistent/asm-audit-missing" });
+    await ensureSkillMdContent(skill);
+    expect(skillContentFingerprint(skill)).toBeNull();
   });
 });
 

--- a/src/auditor.test.ts
+++ b/src/auditor.test.ts
@@ -1167,6 +1167,28 @@ describe("detectDuplicates same-content rule (#562)", () => {
     expect(report.duplicateGroups[0].reason).toBe("same-dirName");
   });
 
+  it("does not double-report a same-frontmatterName pair as same-content", () => {
+    const skills = [
+      withContent({
+        dirName: "alpha-skill",
+        name: "review",
+        path: "/claude/alpha-skill",
+        location: "global-claude",
+        _skillMdContent: fm("review", BODY_A),
+      }),
+      withContent({
+        dirName: "beta-skill",
+        name: "review",
+        path: "/codex/beta-skill",
+        location: "global-codex",
+        _skillMdContent: fm("review", BODY_A),
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    expect(report.duplicateGroups).toHaveLength(1);
+    expect(report.duplicateGroups[0].reason).toBe("same-frontmatterName");
+  });
+
   it("sorts same-content groups after the name-based rules", () => {
     const skills = [
       ...renamedIdenticalPair(),

--- a/src/auditor.ts
+++ b/src/auditor.ts
@@ -2,6 +2,7 @@ import { createHash } from "crypto";
 import { readFile } from "fs/promises";
 import { join } from "path";
 import { ansi, colorProvider, shortenPath } from "./formatter";
+import { cacheSkillMdContent } from "./scanner";
 import type { SkillInfo, DuplicateGroup, AuditReport } from "./utils/types";
 
 // ─── Detection ─────────────────────────────────────────────────────────────
@@ -90,16 +91,16 @@ export function skillContentFingerprint(skill: SkillInfo): string | null {
 
 /**
  * Fills the scanner's SKILL.md content cache from disk when absent, using
- * the same fallback read as `checkHealth`. Unreadable content leaves the
- * cache unset so fingerprint checks degrade to "unknown" safely.
+ * the same fallback read as `checkHealth` and the scanner's non-enumerable
+ * caching so the refilled cache never leaks into serialized output.
+ * Unreadable content leaves the cache unset so fingerprint checks degrade
+ * to "unknown" safely.
  */
 export async function ensureSkillMdContent(skill: SkillInfo): Promise<void> {
   if (skill._skillMdContent !== undefined) return;
   try {
-    skill._skillMdContent = await readFile(
-      join(skill.path, "SKILL.md"),
-      "utf-8",
-    );
+    const content = await readFile(join(skill.path, "SKILL.md"), "utf-8");
+    cacheSkillMdContent(skill, content);
   } catch {
     // unreadable — leave uncached; fingerprint stays unavailable
   }

--- a/src/auditor.ts
+++ b/src/auditor.ts
@@ -238,6 +238,8 @@ export function detectDuplicates(skills: SkillInfo[]): AuditReport {
         ? { variants: [...uncoveredVariants] }
         : {}),
     });
+    // Mark grouped instances so Rule 3 never re-reports them (#562).
+    for (const m of uncovered) coveredPaths.add(m.path);
   }
 
   // Rule 3: byte-identical bodies under different names (#562). Only skills
@@ -348,7 +350,7 @@ export function formatAuditReport(report: AuditReport): string {
       lines.push(ansi.yellow("     ⚠ diverged copies"));
       lines.push(
         ansi.dim(
-          "     auto-remove keeps every copy here unless you pass --force",
+          "     auto-remove skips copies that differ unless you pass --force",
         ),
       );
     }

--- a/src/auditor.ts
+++ b/src/auditor.ts
@@ -1,3 +1,6 @@
+import { createHash } from "crypto";
+import { readFile } from "fs/promises";
+import { join } from "path";
 import { ansi, colorProvider, shortenPath } from "./formatter";
 import type { SkillInfo, DuplicateGroup, AuditReport } from "./utils/types";
 
@@ -57,6 +60,64 @@ function groupVersionDivergence(instances: SkillInfo[]): boolean {
   return distinctVersions(instances).length >= 2;
 }
 
+// ─── Content fingerprinting (#562) ─────────────────────────────────────────
+
+/**
+ * Returns the SKILL.md body — everything after the closing `---` of the
+ * frontmatter. Content without a frontmatter block is returned whole.
+ * Frontmatter is excluded so renamed copies (whose `name:` differs by
+ * design) still fingerprint identically.
+ */
+export function extractSkillMdBody(content: string): string {
+  const lines = content.split("\n");
+  if (lines.length === 0 || lines[0].trim() !== "---") return content;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") return lines.slice(i + 1).join("\n");
+  }
+  return content;
+}
+
+/**
+ * Stable sha256 fingerprint of a skill's SKILL.md body (frontmatter
+ * excluded, issue #562). Returns null when the scanner's content cache is
+ * absent — callers should treat null as "unknown", never as "diverged".
+ */
+export function skillContentFingerprint(skill: SkillInfo): string | null {
+  const cached = skill._skillMdContent;
+  if (cached === undefined) return null;
+  return createHash("sha256").update(extractSkillMdBody(cached)).digest("hex");
+}
+
+/**
+ * Fills the scanner's SKILL.md content cache from disk when absent, using
+ * the same fallback read as `checkHealth`. Unreadable content leaves the
+ * cache unset so fingerprint checks degrade to "unknown" safely.
+ */
+export async function ensureSkillMdContent(skill: SkillInfo): Promise<void> {
+  if (skill._skillMdContent !== undefined) return;
+  try {
+    skill._skillMdContent = await readFile(
+      join(skill.path, "SKILL.md"),
+      "utf-8",
+    );
+  } catch {
+    // unreadable — leave uncached; fingerprint stays unavailable
+  }
+}
+
+/**
+ * Classifies a group's instances by body fingerprint. Only fully-fingerprinted
+ * groups get a class; any unknown content yields undefined (never guessed).
+ */
+function classifyContent(
+  fingerprints: (string | null)[],
+): "identical" | "diverged" | undefined {
+  if (fingerprints.length < 2 || fingerprints.some((f) => f === null)) {
+    return undefined;
+  }
+  return new Set(fingerprints).size === 1 ? "identical" : "diverged";
+}
+
 export function detectDuplicates(skills: SkillInfo[]): AuditReport {
   const groups: DuplicateGroup[] = [];
   const coveredPaths = new Set<string>();
@@ -88,6 +149,12 @@ export function detectDuplicates(skills: SkillInfo[]): AuditReport {
     }
   }
 
+  // Content fingerprints for the deduped set (#562). Computed once; groups
+  // classify as identical/diverged only when every member has one.
+  const fingerprints = new Map<SkillInfo, string | null>(
+    deduped.map((s) => [s, skillContentFingerprint(s)]),
+  );
+
   // Rule 1: same dirName across different locations. Grouping keys are
   // normalized (#564) so `Code-Review`, `code_review` and `code review`
   // land in one bucket; the first-seen spelling becomes the display key.
@@ -110,11 +177,15 @@ export function detectDuplicates(skills: SkillInfo[]): AuditReport {
   for (const entry of byDirName.values()) {
     const uniqueLocations = new Set(entry.members.map((m) => m.location));
     if (uniqueLocations.size >= 2) {
+      const contentClass = classifyContent(
+        entry.members.map((m) => fingerprints.get(m) ?? null),
+      );
       groups.push({
         key: entry.key,
         reason: "same-dirName",
         instances: entry.members,
         versionDivergence: groupVersionDivergence(entry.members),
+        ...(contentClass ? { contentClass } : {}),
         ...(entry.variants.size > 1 ? { variants: [...entry.variants] } : {}),
       });
       for (const m of entry.members) coveredPaths.add(m.path);
@@ -154,22 +225,57 @@ export function detectDuplicates(skills: SkillInfo[]): AuditReport {
     if (uncoveredDirNames.size < 2) continue;
 
     const uncoveredVariants = new Set(uncovered.map((m) => m.name));
+    const contentClass = classifyContent(
+      uncovered.map((m) => fingerprints.get(m) ?? null),
+    );
     groups.push({
       key: entry.key,
       reason: "same-frontmatterName",
       instances: uncovered,
       versionDivergence: groupVersionDivergence(uncovered),
+      ...(contentClass ? { contentClass } : {}),
       ...(uncoveredVariants.size > 1
         ? { variants: [...uncoveredVariants] }
         : {}),
     });
   }
 
-  // Sort: same-dirName groups first, then same-frontmatterName; within each,
-  // by normalized key so case/separator variants order deterministically.
+  // Rule 3: byte-identical bodies under different names (#562). Only skills
+  // not already grouped by the name rules participate, so no skill is
+  // reported in overlapping groups. Frontmatter is excluded from the
+  // fingerprint, which is exactly what lets renamed copies match.
+  const byFingerprint = new Map<string, SkillInfo[]>();
+  for (const s of deduped) {
+    if (coveredPaths.has(s.path)) continue;
+    const fp = fingerprints.get(s);
+    if (!fp) continue;
+    const members = byFingerprint.get(fp) ?? [];
+    members.push(s);
+    byFingerprint.set(fp, members);
+  }
+  for (const members of byFingerprint.values()) {
+    if (members.length < 2) continue;
+    if (new Set(members.map((m) => m.dirName)).size < 2) continue;
+    groups.push({
+      key: members[0].dirName,
+      reason: "same-content",
+      instances: members,
+      versionDivergence: groupVersionDivergence(members),
+      contentClass: "identical",
+    });
+  }
+
+  // Sort: same-dirName groups first, then same-frontmatterName, then
+  // same-content; within each, by normalized key so case/separator variants
+  // order deterministically.
+  const reasonRank: Record<DuplicateGroup["reason"], number> = {
+    "same-dirName": 0,
+    "same-frontmatterName": 1,
+    "same-content": 2,
+  };
   groups.sort((a, b) => {
     if (a.reason !== b.reason) {
-      return a.reason === "same-dirName" ? -1 : 1;
+      return reasonRank[a.reason] - reasonRank[b.reason];
     }
     return (
       normalizeSkillKey(a.key).localeCompare(normalizeSkillKey(b.key)) ||
@@ -207,7 +313,9 @@ export function sortInstancesForKeep(instances: SkillInfo[]): SkillInfo[] {
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
 export function reasonLabel(reason: DuplicateGroup["reason"]): string {
-  return reason === "same-dirName" ? "same dirName" : "same name";
+  if (reason === "same-dirName") return "same dirName";
+  if (reason === "same-content") return "identical content";
+  return "same name";
 }
 
 // ─── CLI Formatters ────────────────────────────────────────────────────────
@@ -233,6 +341,16 @@ export function formatAuditReport(report: AuditReport): string {
     if (group.variants && group.variants.length > 1) {
       const spellings = group.variants.map((v) => `"${v}"`).join(", ");
       lines.push(ansi.dim(`     variants: ${spellings}`));
+    }
+    if (group.contentClass === "identical") {
+      lines.push(ansi.green("     ✓ identical copies"));
+    } else if (group.contentClass === "diverged") {
+      lines.push(ansi.yellow("     ⚠ diverged copies"));
+      lines.push(
+        ansi.dim(
+          "     auto-remove keeps every copy here unless you pass --force",
+        ),
+      );
     }
     if (group.versionDivergence) {
       const newestFirst = distinctVersions(group.instances).slice().reverse();

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1135,6 +1135,143 @@ describe("CLI integration: audit", () => {
   });
 });
 
+describe("CLI integration: audit duplicate content + guarded auto-remove (#562/#563/#565)", () => {
+  let home: string;
+  let cwd: string;
+
+  const BODY_A = "# Steps\n\nDo the thing.";
+  const BODY_B = "# Steps\n\nDo the other thing.";
+
+  const globalSkillsDir = () => join(home, ".claude", "skills");
+  const projectSkillsDir = () => join(cwd, ".claude", "skills");
+
+  const writeSkill = async (
+    base: string,
+    dirName: string,
+    body: string,
+    name = dirName,
+  ) => {
+    await mkdir(join(base, dirName), { recursive: true });
+    await writeFile(
+      join(base, dirName, "SKILL.md"),
+      `---\nname: ${name}\nversion: 1.0.0\ndescription: test skill\n---\n${body}\n`,
+    );
+  };
+
+  const isRealDir = async (path: string): Promise<boolean> => {
+    try {
+      return !(await lstat(path)).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  };
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "asm-audit-home-"));
+    cwd = await mkdtemp(join(tmpdir(), "asm-audit-cwd-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  function runAudit(...args: string[]) {
+    return spawnCollect(["npx", "tsx", CLI_BIN, ...args], {
+      cwd,
+      env: { ...process.env, HOME: home, NO_COLOR: "1" },
+    });
+  }
+
+  test("--json tags an identical same-dirName group (#562)", async () => {
+    await writeSkill(globalSkillsDir(), "code-review", BODY_A);
+    await writeSkill(projectSkillsDir(), "code-review", BODY_A);
+    const { stdout, exitCode } = await runAudit("audit", "--json");
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.duplicateGroups).toHaveLength(1);
+    expect(data.duplicateGroups[0].contentClass).toBe("identical");
+    expect(data.totalDuplicateInstances).toBe(2);
+  });
+
+  test("--json tags a diverged same-dirName group (#562)", async () => {
+    await writeSkill(globalSkillsDir(), "code-review", BODY_A);
+    await writeSkill(projectSkillsDir(), "code-review", BODY_B);
+    const data = JSON.parse((await runAudit("audit", "--json")).stdout);
+    expect(data.duplicateGroups[0].contentClass).toBe("diverged");
+  });
+
+  test("--json surfaces renamed-identical skills as one same-content group (#562)", async () => {
+    await writeSkill(globalSkillsDir(), "alpha-skill", BODY_A, "Alpha Skill");
+    await writeSkill(globalSkillsDir(), "beta-skill", BODY_A, "Beta Skill");
+    const { stdout, exitCode } = await runAudit("audit", "--json");
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.duplicateGroups).toHaveLength(1);
+    expect(data.duplicateGroups[0].reason).toBe("same-content");
+    expect(data.duplicateGroups[0].contentClass).toBe("identical");
+  });
+
+  test("-y removes byte-identical duplicates (#563 keeps working)", async () => {
+    await writeSkill(globalSkillsDir(), "code-review", BODY_A);
+    await writeSkill(projectSkillsDir(), "code-review", BODY_A);
+    const { stderr, exitCode } = await runAudit("audit", "-y");
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("Removed 1 duplicate copy");
+    // The project copy was redundant: gone or repointed at the kept global
+    // install; the global real directory survives.
+    expect(await isRealDir(join(projectSkillsDir(), "code-review"))).toBe(false);
+    expect(await isRealDir(join(globalSkillsDir(), "code-review"))).toBe(true);
+  });
+
+  test("-y skips diverged copies and names the kept copy (#563)", async () => {
+    await writeSkill(globalSkillsDir(), "code-review", BODY_A);
+    await writeSkill(projectSkillsDir(), "code-review", BODY_B);
+    const { stderr, exitCode } = await runAudit("audit", "-y");
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("Skipping");
+    expect(stderr).toContain("contents differ from the kept copy");
+    expect(stderr).toContain("--force");
+    // Both copies survive: the diverged project skill must not be replaced.
+    expect(await isRealDir(join(globalSkillsDir(), "code-review"))).toBe(true);
+    expect(await isRealDir(join(projectSkillsDir(), "code-review"))).toBe(true);
+  });
+
+  test("--force overrides the diverged-copy guard (#563)", async () => {
+    await writeSkill(globalSkillsDir(), "code-review", BODY_A);
+    await writeSkill(projectSkillsDir(), "code-review", BODY_B);
+    const { stderr, exitCode } = await runAudit("audit", "-y", "--force");
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("Skipping");
+    expect(await isRealDir(join(projectSkillsDir(), "code-review"))).toBe(false);
+    expect(await isRealDir(join(globalSkillsDir(), "code-review"))).toBe(true);
+  });
+
+  test("--machine envelope exposes reason, content class, and totals (#565)", async () => {
+    await writeSkill(globalSkillsDir(), "code-review", BODY_A);
+    await writeSkill(projectSkillsDir(), "code-review", BODY_B);
+    const { stdout, exitCode } = await runAudit("audit", "--machine");
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.version).toBe(1);
+    expect(envelope.command).toBe("audit duplicates");
+    const group = envelope.data.duplicate_groups[0];
+    expect(group.reason).toBe("same-dirName");
+    expect(group.contentClass).toBe("diverged");
+    expect(group.count).toBe(2);
+    expect(envelope.data.totalDuplicateInstances).toBe(2);
+    // Machine output reports; it must not remove anything even though
+    // --machine implies --yes at the parser level.
+    expect(await isRealDir(join(projectSkillsDir(), "code-review"))).toBe(true);
+  });
+
+  test("audit --help documents --force", async () => {
+    const { stdout, exitCode } = await runAudit("audit", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--force");
+  });
+});
+
 describe("CLI integration: stats --tokens (issue #421)", () => {
   test("--tokens exits 0 and reports the attention budget", async () => {
     const { stdout, exitCode } = await runCLI("stats", "--tokens");

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1220,7 +1220,9 @@ describe("CLI integration: audit duplicate content + guarded auto-remove (#562/#
     expect(stderr).toContain("Removed 1 duplicate copy");
     // The project copy was redundant: gone or repointed at the kept global
     // install; the global real directory survives.
-    expect(await isRealDir(join(projectSkillsDir(), "code-review"))).toBe(false);
+    expect(await isRealDir(join(projectSkillsDir(), "code-review"))).toBe(
+      false,
+    );
     expect(await isRealDir(join(globalSkillsDir(), "code-review"))).toBe(true);
   });
 
@@ -1243,7 +1245,9 @@ describe("CLI integration: audit duplicate content + guarded auto-remove (#562/#
     const { stderr, exitCode } = await runAudit("audit", "-y", "--force");
     expect(exitCode).toBe(0);
     expect(stderr).not.toContain("Skipping");
-    expect(await isRealDir(join(projectSkillsDir(), "code-review"))).toBe(false);
+    expect(await isRealDir(join(projectSkillsDir(), "code-review"))).toBe(
+      false,
+    );
     expect(await isRealDir(join(globalSkillsDir(), "code-review"))).toBe(true);
   });
 

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -181,7 +181,9 @@ export async function cmdAudit(args: ParsedArgs) {
       );
     }
     console.error(
-      ansi.green(`\nDone. Removed ${removed} duplicate cop${removed === 1 ? "y" : "ies"}.`),
+      ansi.green(
+        `\nDone. Removed ${removed} duplicate cop${removed === 1 ? "y" : "ies"}.`,
+      ),
     );
   }
 }

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -2,7 +2,7 @@ import { loadConfig, getLibrarySkillsDir } from "../config";
 import { scanAllSkills } from "../scanner";
 import { realpath as fsRealpath } from "fs/promises";
 import { buildRemovalPlan, executeRemoval } from "../uninstaller";
-import { formatJSON, ansi } from "../formatter";
+import { formatJSON, ansi, shortenPath } from "../formatter";
 import {
   parseSource,
   assertNoParentSegments,
@@ -17,6 +17,8 @@ import { computeResidencyAudit, formatResidencyReport } from "../residency";
 import {
   detectDuplicates,
   sortInstancesForKeep,
+  skillContentFingerprint,
+  ensureSkillMdContent,
   formatAuditReport,
   formatAuditReportJSON,
 } from "../auditor";
@@ -48,6 +50,7 @@ ${ansi.bold("Options:")}
   --json             Output as JSON
   --machine          Output in stable machine-readable v1 envelope format
   -y, --yes          Auto-remove duplicates, keeping one instance per group
+  -f, --force        With -y: remove even diverged (content-differing) copies
   -s, --scope <s>    Filter: global, project, or both (default: both)
   --no-color         Disable ANSI colors
   -V, --verbose      Show debug output
@@ -96,12 +99,17 @@ export async function cmdAudit(args: ParsedArgs) {
   const config = await loadConfig();
   // Always scan all providers regardless of --scope
   const allSkills = await scanAllSkills(config, "both");
+  // Fingerprinting (#562) needs SKILL.md content; the scanner usually caches
+  // it, but reconstructed rows (e.g. disabled skills) may lack it.
+  await Promise.all(allSkills.map(ensureSkillMdContent));
   const report = detectDuplicates(allSkills);
 
   if (args.flags.machine) {
     const data = {
       duplicate_groups: report.duplicateGroups.map((g) => ({
         name: g.key,
+        reason: g.reason,
+        ...(g.contentClass ? { contentClass: g.contentClass } : {}),
         count: g.instances.length,
         instances: g.instances.map((i) => ({
           path: i.path,
@@ -110,6 +118,7 @@ export async function cmdAudit(args: ParsedArgs) {
         })),
       })),
       total_duplicates: report.duplicateGroups.length,
+      totalDuplicateInstances: report.totalDuplicateInstances,
     };
     console.log(formatMachineOutput("audit duplicates", data, startTime));
     return;
@@ -123,22 +132,57 @@ export async function cmdAudit(args: ParsedArgs) {
   console.log(formatAuditReport(report));
 
   if (args.flags.yes && report.duplicateGroups.length > 0) {
-    // Auto-remove all but the first (recommended keep) instance per group
+    // Auto-remove all but the first (recommended keep) instance per group.
+    // Safety guard (#563): an instance is only removed when its content
+    // fingerprint matches the kept copy; diverged or unverifiable copies
+    // are skipped unless --force is given.
     console.error(ansi.bold("\nAuto-removing duplicates..."));
+    let removed = 0;
+    let skipped = 0;
     for (const group of report.duplicateGroups) {
       const sorted = sortInstancesForKeep(group.instances);
-      const keptPath = sorted[0].path;
-      // Keep the first, remove the rest (replace with symlinks)
+      const kept = sorted[0];
+      const keptFingerprint = skillContentFingerprint(kept);
       for (let i = 1; i < sorted.length; i++) {
         const skill = sorted[i];
+        const fingerprint = skillContentFingerprint(skill);
+        const identical =
+          keptFingerprint !== null &&
+          fingerprint !== null &&
+          keptFingerprint === fingerprint;
+        if (!identical && !args.flags.force) {
+          skipped++;
+          const why =
+            keptFingerprint === null || fingerprint === null
+              ? "contents could not be verified"
+              : "contents differ from the kept copy";
+          console.error(
+            ansi.yellow(
+              `  Skipping ${shortenPath(skill.path)} — ${why}. ` +
+                `Kept ${shortenPath(kept.path)}. ` +
+                `Re-run with --force to remove it anyway.`,
+            ),
+          );
+          continue;
+        }
         const plan = buildRemovalPlan(skill, config);
-        const log = await executeRemoval(plan, keptPath);
+        const log = await executeRemoval(plan, kept.path);
         for (const entry of log) {
           console.error(entry);
         }
+        removed++;
       }
     }
-    console.error(ansi.green("\nDone."));
+    if (skipped > 0) {
+      console.error(
+        ansi.yellow(
+          `\n${skipped} duplicate cop${skipped === 1 ? "y" : "ies"} skipped (content differs or could not be verified).`,
+        ),
+      );
+    }
+    console.error(
+      ansi.green(`\nDone. Removed ${removed} duplicate cop${removed === 1 ? "y" : "ies"}.`),
+    );
   }
 }
 

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -249,8 +249,17 @@ export async function countFiles(dir: string): Promise<number> {
   }
 }
 
-/** Retain scanned content without exposing it through JSON output. */
-function cacheSkillMdContent(skill: SkillInfo, content: string): void {
+/**
+ * Retain scanned content without exposing it through JSON output.
+ * Shared with `auditor.ensureSkillMdContent`, which refills the cache for
+ * rows the scanner built without content (e.g. Codex plugin manifests) —
+ * the non-enumerable definition here is what keeps `_skillMdContent` out
+ * of serialized reports, so writers must go through this helper.
+ */
+export function cacheSkillMdContent(
+  skill: SkillInfo,
+  content: string,
+): void {
   Object.defineProperty(skill, "_skillMdContent", {
     value: content,
     writable: true,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -434,8 +434,21 @@ export interface RelocationInfo {
 
 export interface DuplicateGroup {
   key: string;
-  reason: "same-dirName" | "same-frontmatterName";
+  /**
+   * Why the group was formed: shared directory name (`same-dirName`),
+   * shared frontmatter name across different directories
+   * (`same-frontmatterName`), or byte-identical SKILL.md bodies under
+   * different names (`same-content`, issue #562).
+   */
+  reason: "same-dirName" | "same-frontmatterName" | "same-content";
   instances: SkillInfo[];
+  /**
+   * Content classification from the group's SKILL.md body fingerprints
+   * (issue #562): `identical` when every instance hashes the same,
+   * `diverged` when any two differ. Absent when any instance's content is
+   * unavailable, so an unknown state is never reported as either class.
+   */
+  contentClass?: "identical" | "diverged";
   /**
    * True when the group's instances carry two or more distinct non-empty
    * `version` strings — likely a shadowed upgrade rather than identical


### PR DESCRIPTION
Closes #562
Closes #563
Closes #565

## Summary

The audit duplicate check now compares SKILL.md content, not just names: each group is classified `identical` or `diverged` from sha256 body fingerprints, byte-identical bodies under different names surface as a new `same-content` group kind, and `asm audit -y` refuses to delete copies whose contents differ from (or cannot be compared against) the kept copy unless `--force` is given. The machine envelope gains the grouping reason, per-group content class, and total instance count so it matches the JSON field set.

## Approach

Balanced option: shared fingerprint helpers in `auditor.ts` (`extractSkillMdBody`, `skillContentFingerprint`, `ensureSkillMdContent`) over the scanner's `_skillMdContent` cache, classification attached to existing groups plus one new grouping rule, and a per-pair guard in the auto-remove loop. Frontmatter is excluded from the fingerprint so renamed copies match by design.

## Decision Record

- **Root cause:** duplicate detection grouped only by dirName/frontmatter name and never compared content (#562), so `-y` deleted every non-kept member regardless of local divergence (#563), and the machine envelope carried only name/count (#565).
- **Options considered:** Option 1 — minimal cache-only classification without a new rule; Option 2 — shared fingerprint helpers + `contentClass` + `same-content` rule + guarded removal + enriched envelope; Option 3 — async detection reading disk inside `detectDuplicates` with serialized fingerprints.
- **Options rejected:** Option 1 — misses renamed-identical skills (acceptance criterion 2); Option 3 — touches the `stats` caller and leaks noisy hashes into JSON.
- **Selected option:** Option 2 — balanced.
- **Residual risk:** skills whose SKILL.md is unreadable get no classification and are skipped by auto-remove (conservative); `asm audit --machine` still implies `--yes` parser-wide but returns before any removal, unchanged.
- **Reproduction:** manual — #563 symptom confirmed by reading the unguarded removal loop; regression tests cover identical-removes / diverged-skips / force-overrides (`src/cli.test.ts`).

Analyzed at: `refactor/562-add-content-hashing-to-classify @ ff269ab` (2026-08-25)

## Changes

| File | Change |
|------|--------|
| `src/utils/types.ts` | `DuplicateGroup.reason` gains `"same-content"`; new optional `contentClass: "identical" \| "diverged"` |
| `src/auditor.ts` | Body extraction + sha256 fingerprint helpers; classify Rule 1/2 groups; new Rule 3 same-content grouping (covered-path guarded so no overlap); sort rank, reason label, human-output tags |
| `src/commands/audit.ts` | Fill content cache before detection; machine envelope gains `reason`, `contentClass`, `totalDuplicateInstances`; `-y` skips diverged/unverifiable copies naming kept path and `--force` escape; help documents `--force` |
| `src/auditor.test.ts` | Unit tests: body extraction, fingerprint equality/divergence, classification incl. unknown-content omission, version-vs-content independence, same-content rule, no double-reporting, JSON/human rendering |
| `src/cli.test.ts` | E2E sandbox-HOME tests: identical/diverged tags, renamed-identical grouping, `-y` remove vs skip vs `--force`, machine envelope fields + no-removal guarantee, help |

## Test Results

- Full suite: 2287 passed / 70 files (`npx vitest run src/`) at `ff269ab`
- New tests: 20 unit (`src/auditor.test.ts`) + 8 e2e (`src/cli.test.ts`)
- `npm run lint`: clean; `npm run typecheck`: only the 10 pre-existing `src/commands/stats.test.ts` errors on main

## Acceptance Criteria Verification

| Issue | Criterion | Status |
|-------|-----------|--------|
| #562 | Skills in a duplicate group tagged identical or diverged based on content | ✅ `contentClass` from body fingerprints |
| #562 | Different-name, identical-body skills surfaced as a duplicate group | ✅ `same-content` rule |
| #562 | Classification appears in `asm audit` output | ✅ human tags + JSON + machine |
| #562 | Auto-remove still removes only redundant copies when content matches | ✅ per-pair fingerprint check |
| #563 | Auto-remove skips instances whose contents differ from the kept copy | ✅ e2e verified |
| #563 | `--force` overrides the safety guard | ✅ e2e verified |
| #563 | Skipped copy message tells which was kept and why | ✅ stderr names both paths + reason |
| #563 | No legitimately identical duplicate left un-removed | ✅ identical pairs always removed |
| #565 | Machine envelope includes the grouping reason per group | ✅ `reason` |
| #565 | Machine envelope includes per-group instance counts and total instances | ✅ `count` + `totalDuplicateInstances` |
| #565 | Machine and JSON expose the same duplicate fields | ✅ `reason`/`contentClass`/totals aligned |

<!-- gitissue:qa v1 head=ff269abfa73a52fa5c25b383fff77fb44c47ff4a profile=full cycles=2 review=clean tests=2287@ff269abfa73a52fa5c25b383fff77fb44c47ff4a ui=code:clean@ff269abfa73a52fa5c25b383fff77fb44c47ff4a -->
