### PR TITLE
feat(audit): add semantic overlap detection for installed skills (#566)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ graph LR
 | One-command install      | `asm install github:user/repo` or `asm install skill-name`           |
 | Agent-parseable output   | `--json` on list, search, inspect, install, audit                    |
 | Duplicate audit          | `asm audit --yes` removes redundant skills non-interactively         |
+| Semantic overlap audit   | `asm audit overlap` finds different-name skills doing the same job   |
 | Attention budget         | `asm stats --tokens` shows resident vs body token cost per tool      |
 | Residency audit          | `asm audit residency` ranks skills to demote out of resident context |
 | Reference tier           | `asm get <skill>` delivers a body once, at zero residency            |
@@ -122,6 +123,7 @@ Node.js 22+ required. Optional TUI: run `asm` with no arguments.
 | Skill metadata for agents     | `asm inspect my-skill --json`                    |
 | Non-interactive install       | `asm install code-review -p claude --yes --json` |
 | Remove duplicates             | `asm audit --yes`                                |
+| Find same-job near-duplicates | `asm audit overlap`                              |
 | See your context cost         | `asm stats --tokens`                             |
 | Find skills to demote         | `asm audit residency`                            |
 | Use a skill without residency | `asm get code-review`                            |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,6 +82,7 @@ Each view is an ink/React component:
 | Config              | `config.ts`                          | Load/save config from `~/.config/agent-skill-manager/config.json`                 |
 | Scanner             | `scanner.ts`                         | Walk provider directories, parse SKILL.md frontmatter, filter & sort              |
 | Auditor             | `auditor.ts`                         | Detect duplicate skills, rank instances for keeping, format reports               |
+| Overlap Detector    | `installed-overlap.ts`               | `asm audit overlap` — different-name skills doing the same job (offline)          |
 | Uninstaller         | `uninstaller.ts`                     | Build removal plans and execute safe deletions                                    |
 | Formatter           | `formatter.ts`                       | ASCII table, detail view, and JSON output formatting                              |
 | Eval                | `eval/`                              | Pluggable skill evaluation framework (see below)                                  |

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1468,8 +1468,9 @@ describe("CLI integration: audit overlap (issue #566)", () => {
   test("audit overlap exits 0 and reports without changing anything", async () => {
     const { stdout, exitCode } = await runCLI("audit", "overlap");
     expect(exitCode).toBe(0);
+    // The sandboxed home has no installed skills, so the report takes its
+    // empty-set branch — same contract as the residency sibling above.
     expect(stdout).toContain("Semantic Overlap Audit");
-    expect(stdout).toContain("Nothing was changed");
   });
 
   test("--yes never triggers a removal on the overlap path", async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -367,6 +367,14 @@ describe("parseArgs: audit residency (issue #423)", () => {
   });
 });
 
+describe("parseArgs: audit overlap (issue #566)", () => {
+  test("overlap parses as an audit subcommand, not a top-level verb", () => {
+    const args = parseArgs(["node", "cli", "audit", "overlap"]);
+    expect(args.command).toBe("audit");
+    expect(args.subcommand).toBe("overlap");
+  });
+});
+
 describe("isCLIMode", () => {
   const check = (...args: string[]) =>
     isCLIMode(["node", "script.ts", ...args]);
@@ -1380,6 +1388,10 @@ describe("CLI integration: stats with nothing installed", () => {
     const residency = await runEmpty("audit", "residency");
     expect(residency.exitCode).toBe(0);
     expect(residency.stdout).toContain("No installed skills");
+
+    const overlap = await runEmpty("audit", "overlap");
+    expect(overlap.exitCode).toBe(0);
+    expect(overlap.stdout).toContain("No installed skills.");
   });
 });
 
@@ -1449,6 +1461,64 @@ describe("CLI integration: audit residency (issue #423)", () => {
     const { stderr, exitCode } = await runCLI("audit", "bogus");
     expect(exitCode).toBe(2);
     expect(stderr).toContain("residency");
+  });
+});
+
+describe("CLI integration: audit overlap (issue #566)", () => {
+  test("audit overlap exits 0 and reports without changing anything", async () => {
+    const { stdout, exitCode } = await runCLI("audit", "overlap");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Semantic Overlap Audit");
+    expect(stdout).toContain("Nothing was changed");
+  });
+
+  test("--yes never triggers a removal on the overlap path", async () => {
+    // The overlap report is advisory; only `audit -y` (duplicates) removes.
+    const { stdout, stderr, exitCode } = await runCLI(
+      "audit",
+      "overlap",
+      "--yes",
+    );
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("Auto-removing");
+    expect(stdout).not.toContain("Auto-removing");
+  });
+
+  test("audit overlap --json has the overlap report shape", async () => {
+    const { stdout, exitCode } = await runCLI("audit", "overlap", "--json");
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data).toHaveProperty("scannedAt");
+    expect(data).toHaveProperty("totalSkills");
+    expect(data).toHaveProperty("comparedSkills");
+    expect(Array.isArray(data.pairs)).toBe(true);
+    expect(data).toHaveProperty("highConfidenceCount");
+    for (const pair of data.pairs) {
+      expect(typeof pair.score).toBe("number");
+      expect(pair.a).toHaveProperty("name");
+      expect(pair.b).toHaveProperty("path");
+    }
+  });
+
+  test("audit overlap --machine emits the v1 envelope", async () => {
+    const { stdout, exitCode } = await runCLI("audit", "overlap", "--machine");
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.version).toBe(1);
+    expect(envelope.command).toBe("audit overlap");
+    expect(envelope.data).toHaveProperty("pairs");
+    expect(envelope.data).toHaveProperty("total_overlaps");
+    expect(envelope.data).toHaveProperty("compared_skills");
+  });
+
+  test("audit --help lists the overlap subcommand", async () => {
+    const { stdout } = await runCLI("audit", "--help");
+    expect(stdout).toContain("overlap");
+  });
+
+  test("unknown audit subcommand names overlap too", async () => {
+    const { stderr } = await runCLI("audit", "bogus");
+    expect(stderr).toContain("overlap");
   });
 });
 

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -32,6 +32,11 @@ import {
   formatMachineError,
   ErrorCodes,
 } from "../utils/machine";
+import {
+  detectSemanticOverlaps,
+  formatOverlapReport,
+  formatOverlapReportJSON,
+} from "../installed-overlap";
 
 import { formatAuditMachineData, error } from "./shared";
 import type { ParsedArgs } from "../cli";
@@ -43,6 +48,7 @@ Detect duplicate skills or run security audits on installed/remote skills.
 
 ${ansi.bold("Subcommands:")}
   duplicates             Find duplicate skills (default)
+  overlap                Find installed skills that do the same job under different names
   security <name|source> Run security audit on an installed skill or GitHub source
   residency              Rank installed skills that do not earn their resident context
 
@@ -59,6 +65,8 @@ ${ansi.bold("Examples:")}
   asm audit                                    ${ansi.dim("Find duplicates")}
   asm audit -y                                 ${ansi.dim("Auto-remove duplicates")}
   asm audit --json                             ${ansi.dim("Output as JSON")}
+  asm audit overlap                            ${ansi.dim("Find same-job skills under different names")}
+  asm audit overlap --json                     ${ansi.dim("Overlap report as JSON")}
   asm audit residency                          ${ansi.dim("Rank demotion candidates")}
   asm audit residency --json                   ${ansi.dim("Residency report as JSON")}
   asm audit security code-review               ${ansi.dim("Audit an installed skill")}
@@ -89,9 +97,14 @@ export async function cmdAudit(args: ParsedArgs) {
     return;
   }
 
+  if (sub === "overlap") {
+    await cmdAuditOverlap(args, startTime);
+    return;
+  }
+
   if (sub !== "duplicates") {
     error(
-      `Unknown audit subcommand: "${sub}". Use: duplicates, security, residency`,
+      `Unknown audit subcommand: "${sub}". Use: duplicates, overlap, security, residency`,
     );
     process.exit(2);
   }
@@ -225,6 +238,43 @@ export async function cmdAuditResidency(args: ParsedArgs, startTime: number) {
   }
 
   console.log(formatResidencyReport(report));
+}
+
+/**
+ * `asm audit overlap` — surface installed skills that do substantially the
+ * same job under different names (issue #566). The exact-match duplicate
+ * check above only catches identical names; this compares name+description
+ * with boilerplate down-weighted (offline token similarity) and ranks pairs,
+ * flagging high-confidence overlaps. Read-only: it reports and never removes.
+ */
+export async function cmdAuditOverlap(args: ParsedArgs, startTime: number) {
+  const config = await loadConfig();
+  const allSkills = await scanAllSkills(config, "both");
+  const report = detectSemanticOverlaps(allSkills);
+
+  if (args.flags.machine) {
+    const data = {
+      compared_skills: report.comparedSkills,
+      total_overlaps: report.pairs.length,
+      high_confidence_overlaps: report.highConfidenceCount,
+      pairs: report.pairs.map((p) => ({
+        score: Number(p.score.toFixed(4)),
+        high_confidence: p.highConfidence,
+        reason: p.reason,
+        a: { name: p.a.name, provider: p.a.provider, scope: p.a.scope, path: p.a.path },
+        b: { name: p.b.name, provider: p.b.provider, scope: p.b.scope, path: p.b.path },
+      })),
+    };
+    console.log(formatMachineOutput("audit overlap", data, startTime));
+    return;
+  }
+
+  if (args.flags.json) {
+    console.log(formatOverlapReportJSON(report));
+    return;
+  }
+
+  console.log(formatOverlapReport(report));
 }
 
 export async function cmdAuditSecurity(args: ParsedArgs, startTime: number) {

--- a/src/installed-overlap.test.ts
+++ b/src/installed-overlap.test.ts
@@ -401,6 +401,31 @@ describe("detectSemanticOverlaps", () => {
       /kubernetes|deployments|manifests|apply/i,
     );
   });
+
+  it("credits the name side when descriptions share no distinctive terms", () => {
+    const report = detectSemanticOverlaps(
+      [
+        makeSkill({
+          name: "kube-helper",
+          dirName: "kube-helper",
+          path: "/a",
+          realPath: "/a",
+          description: "Manage kubernetes deployments and debug pods.",
+        }),
+        makeSkill({
+          name: "helper-kube",
+          dirName: "helper-kube",
+          path: "/b",
+          realPath: "/b",
+          description: "Cook dinner recipes from pantry ingredients.",
+        }),
+      ],
+      0.01,
+    );
+    expect(report.pairs).toHaveLength(1);
+    expect(report.pairs[0].reason).toMatch(/similar names/i);
+    expect(report.pairs[0].reason).not.toMatch(/near-identical/i);
+  });
 });
 
 describe("formatOverlapReport", () => {

--- a/src/installed-overlap.test.ts
+++ b/src/installed-overlap.test.ts
@@ -1,0 +1,468 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_OVERLAP_THRESHOLD,
+  HIGH_CONFIDENCE_OVERLAP_THRESHOLD,
+  buildIdfWeights,
+  computeInstalledOverlapScore,
+  dedupeForComparison,
+  detectSemanticOverlaps,
+  formatOverlapReport,
+  formatOverlapReportJSON,
+} from "./installed-overlap";
+import type { InstalledOverlapReport, SkillInfo } from "./utils/types";
+
+function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  const path = overrides.path ?? "/home/user/.claude/skills/test-skill";
+  return {
+    name: "test-skill",
+    version: "1.0.0",
+    description: "A test skill",
+    creator: "",
+    license: "",
+    compatibility: "",
+    allowedTools: [],
+    dirName: "test-skill",
+    path,
+    originalPath: path,
+    location: "global-claude",
+    scope: "global",
+    provider: "claude",
+    providerLabel: "Claude Code",
+    isSymlink: false,
+    symlinkTarget: null,
+    realPath: path,
+    ...overrides,
+  };
+}
+
+describe("buildIdfWeights", () => {
+  it("collapses to weight 1 when every token appears in every skill", () => {
+    const weights = buildIdfWeights([
+      new Set(["shared", "alpha"]),
+      new Set(["shared", "beta"]),
+      new Set(["shared", "gamma"]),
+    ]);
+    expect(weights.get("shared")).toBeCloseTo(1, 10);
+  });
+
+  it("gives rare tokens more weight than common ones", () => {
+    const weights = buildIdfWeights([
+      new Set(["common", "rare-a"]),
+      new Set(["common", "rare-b"]),
+    ]);
+    expect(weights.get("rare-a")!).toBeGreaterThan(weights.get("common")!);
+  });
+
+  it("returns an empty map for an empty corpus", () => {
+    expect(buildIdfWeights([]).size).toBe(0);
+  });
+});
+
+describe("computeInstalledOverlapScore", () => {
+  const weights = buildIdfWeights([
+    new Set(["kubernetes", "manifests", "deploy"]),
+    new Set(["docker", "images", "build"]),
+    new Set(["kubernetes", "deployments", "rollout"]),
+  ]);
+
+  it("scores identical name+description at 1", () => {
+    const score = computeInstalledOverlapScore(
+      "kube-deploy", "Deploy kubernetes manifests",
+      "kube-deploy", "Deploy kubernetes manifests",
+      weights,
+    );
+    expect(score).toBe(1);
+  });
+
+  it("caps different-name identical descriptions at the description weight", () => {
+    const score = computeInstalledOverlapScore(
+      "alpha-tools", "Deploy kubernetes manifests",
+      "beta-kit", "Deploy kubernetes manifests",
+      weights,
+    );
+    expect(score).toBeCloseTo(0.6, 10);
+  });
+
+  it("scores unrelated descriptions near 0", () => {
+    const score = computeInstalledOverlapScore(
+      "a", "Deploy kubernetes manifests",
+      "b", "Build docker images",
+      weights,
+    );
+    expect(score).toBeLessThan(0.2);
+  });
+
+  it("down-weights boilerplate so filler-only overlap scores low", () => {
+    // Same corpus trick: pretend every skill contains the boilerplate terms.
+    const boilerHeavy = buildIdfWeights([
+      new Set(["use", "this", "skill", "provides", "kubernetes"]),
+      new Set(["use", "this", "skill", "provides", "photography"]),
+      new Set(["use", "this", "skill", "provides", "cooking"]),
+    ]);
+    const score = computeInstalledOverlapScore(
+      "a", "Use this skill — provides help",
+      "b", "Use this skill — provides help",
+      boilerHeavy,
+    );
+    // All shared tokens are boilerplate with weight 1; nothing distinctive.
+    expect(score).toBeLessThan(DEFAULT_OVERLAP_THRESHOLD);
+  });
+
+  it("returns 0 for two empty descriptions", () => {
+    const score = computeInstalledOverlapScore("a", "", "b", "", weights);
+    expect(score).toBe(0);
+  });
+});
+
+describe("dedupeForComparison", () => {
+  it("collapses same-realPath rows across providers to one unit", () => {
+    const skills = [
+      makeSkill({ provider: "claude", path: "/lib/foo", realPath: "/lib/foo" }),
+      makeSkill({
+        provider: "codex",
+        path: "/home/.codex/skills/foo",
+        realPath: "/lib/foo",
+        isSymlink: true,
+        symlinkTarget: "/lib/foo",
+      }),
+    ];
+    expect(dedupeForComparison(skills)).toHaveLength(1);
+  });
+
+  it("keeps distinct realPaths as separate units", () => {
+    const skills = [
+      makeSkill({ path: "/a", realPath: "/a" }),
+      makeSkill({ path: "/b", realPath: "/b" }),
+    ];
+    expect(dedupeForComparison(skills)).toHaveLength(2);
+  });
+
+  it("prefers the non-symlink row for a shared realPath", () => {
+    const skills = [
+      makeSkill({
+        path: "/link",
+        realPath: "/real",
+        isSymlink: true,
+        symlinkTarget: "/real",
+      }),
+      makeSkill({ path: "/real", realPath: "/real" }),
+    ];
+    const [kept] = dedupeForComparison(skills);
+    expect(kept.isSymlink).toBe(false);
+    expect(kept.path).toBe("/real");
+  });
+});
+
+describe("detectSemanticOverlaps", () => {
+  it("returns an empty report for no installed skills", () => {
+    const report = detectSemanticOverlaps([]);
+    expect(report.totalSkills).toBe(0);
+    expect(report.comparedSkills).toBe(0);
+    expect(report.pairs).toHaveLength(0);
+    expect(report.highConfidenceCount).toBe(0);
+    expect(report.scannedAt).toBeTruthy();
+  });
+
+  it("finds different-name skills doing the same job", () => {
+    const report = detectSemanticOverlaps([
+      makeSkill({
+        name: "kube-helper",
+        dirName: "kube-helper",
+        path: "/a",
+        realPath: "/a",
+        description:
+          "Manage kubernetes deployments: apply manifests, roll out updates and debug pods in a cluster.",
+      }),
+      makeSkill({
+        name: "cluster-ops",
+        dirName: "cluster-ops",
+        path: "/b",
+        realPath: "/b",
+        description:
+          "Operate kubernetes deployments — apply manifests, roll out releases and debug pods.",
+      }),
+    ]);
+    expect(report.pairs).toHaveLength(1);
+    expect(report.pairs[0].score).toBeGreaterThanOrEqual(
+      DEFAULT_OVERLAP_THRESHOLD,
+    );
+    expect(report.pairs[0].highConfidence).toBe(false);
+  });
+
+  it("flags near-identical descriptions as high confidence", () => {
+    const description =
+      "Manage kubernetes deployments: apply manifests, roll out updates and debug pods in a cluster.";
+    const report = detectSemanticOverlaps([
+      makeSkill({
+        name: "kube-helper",
+        dirName: "kube-helper",
+        path: "/a",
+        realPath: "/a",
+        description,
+      }),
+      makeSkill({
+        name: "cluster-ops",
+        dirName: "cluster-ops",
+        path: "/b",
+        realPath: "/b",
+        description,
+      }),
+    ]);
+    expect(report.pairs).toHaveLength(1);
+    expect(report.pairs[0].highConfidence).toBe(true);
+    expect(report.highConfidenceCount).toBe(1);
+  });
+
+  it("does not flag unrelated skills", () => {
+    const report = detectSemanticOverlaps([
+      makeSkill({
+        name: "kube-helper",
+        dirName: "kube-helper",
+        path: "/a",
+        realPath: "/a",
+        description:
+          "Manage kubernetes deployments: apply manifests and roll out updates.",
+      }),
+      makeSkill({
+        name: "sous-chef",
+        dirName: "sous-chef",
+        path: "/b",
+        realPath: "/b",
+        description:
+          "Suggest dinner recipes from pantry ingredients with step-by-step cooking timers.",
+      }),
+    ]);
+    expect(report.pairs).toHaveLength(0);
+  });
+
+  it("skips same-normalized-name pairs — duplicates territory", () => {
+    const report = detectSemanticOverlaps([
+      makeSkill({
+        name: "Code Review",
+        dirName: "code-review",
+        path: "/a",
+        realPath: "/a",
+        description: "Reviews code for defects and style issues before merge.",
+      }),
+      makeSkill({
+        name: "code_review",
+        dirName: "code-review-2",
+        path: "/b",
+        realPath: "/b",
+        description: "Reviews code for defects and style issues before merge.",
+      }),
+    ]);
+    expect(report.pairs).toHaveLength(0);
+  });
+
+  it("never pairs multi-provider copies of one install against itself", () => {
+    const report = detectSemanticOverlaps([
+      makeSkill({
+        name: "deployer",
+        dirName: "deployer",
+        path: "/lib/deployer",
+        realPath: "/lib/deployer",
+        description: "Deploys services to production clusters safely.",
+      }),
+      makeSkill({
+        name: "deployer",
+        dirName: "deployer",
+        provider: "codex",
+        path: "/home/.codex/skills/deployer",
+        realPath: "/lib/deployer",
+        isSymlink: true,
+        symlinkTarget: "/lib/deployer",
+        description: "Deploys services to production clusters safely.",
+      }),
+    ]);
+    expect(report.comparedSkills).toBe(1);
+    expect(report.pairs).toHaveLength(0);
+  });
+
+  it("boilerplate-heavy descriptions do not create false pairs", () => {
+    const filler =
+      "Use this skill to get help. This skill provides support for your work.";
+    const report = detectSemanticOverlaps([
+      makeSkill({
+        name: "alpha",
+        dirName: "alpha",
+        path: "/a",
+        realPath: "/a",
+        description: filler,
+      }),
+      makeSkill({
+        name: "beta",
+        dirName: "beta",
+        path: "/b",
+        realPath: "/b",
+        description: filler,
+      }),
+    ]);
+    expect(report.pairs).toHaveLength(0);
+  });
+
+  it("ranks pairs by score descending", () => {
+    const report = detectSemanticOverlaps([
+      makeSkill({
+        name: "md-format",
+        dirName: "md-format",
+        path: "/a",
+        realPath: "/a",
+        description:
+          "Format markdown tables, sort sections and fix heading levels in documents.",
+      }),
+      makeSkill({
+        name: "strong-pair-a",
+        dirName: "strong-pair-a",
+        path: "/b",
+        realPath: "/b",
+        description:
+          "Manage kubernetes deployments: apply manifests, roll out updates and debug pods.",
+      }),
+      makeSkill({
+        name: "strong-pair-b",
+        dirName: "strong-pair-b",
+        path: "/c",
+        realPath: "/c",
+        description:
+          "Operate kubernetes deployments — apply manifests, roll out releases, debug pods.",
+      }),
+      makeSkill({
+        name: "pdf-export",
+        dirName: "pdf-export",
+        path: "/d",
+        realPath: "/d",
+        description:
+          "Convert markdown notes to a shareable PDF deck with one command.",
+      }),
+    ]);
+    expect(report.pairs.length).toBeGreaterThanOrEqual(1);
+    for (let i = 1; i < report.pairs.length; i++) {
+      expect(report.pairs[i - 1].score).toBeGreaterThanOrEqual(
+        report.pairs[i].score,
+      );
+    }
+    // The paraphrased same-job pair outranks the incidental markdown share.
+    const top = report.pairs[0];
+    expect(
+      [top.a.name, top.b.name].sort().join("/"),
+    ).toBe("strong-pair-a/strong-pair-b");
+  });
+
+  it("respects an explicit threshold", () => {
+    const skills = [
+      makeSkill({
+        name: "kube-helper",
+        dirName: "kube-helper",
+        path: "/a",
+        realPath: "/a",
+        description:
+          "Manage kubernetes deployments: apply manifests, roll out updates and debug pods.",
+      }),
+      makeSkill({
+        name: "cluster-ops",
+        dirName: "cluster-ops",
+        path: "/b",
+        realPath: "/b",
+        description:
+          "Operate kubernetes deployments — apply manifests, roll out releases and debug pods.",
+      }),
+    ];
+    const strict = detectSemanticOverlaps(skills, 0.99);
+    expect(strict.pairs).toHaveLength(0);
+    const loose = detectSemanticOverlaps(skills, 0.01);
+    expect(loose.pairs).toHaveLength(1);
+  });
+
+  it("explains the overlap with distinctive shared terms", () => {
+    const report = detectSemanticOverlaps(
+      [
+        makeSkill({
+          name: "kube-helper",
+          dirName: "kube-helper",
+          path: "/a",
+          realPath: "/a",
+          description:
+            "Manage kubernetes deployments: apply manifests, roll out updates and debug pods.",
+        }),
+        makeSkill({
+          name: "cluster-ops",
+          dirName: "cluster-ops",
+          path: "/b",
+          realPath: "/b",
+          description:
+            "Operate kubernetes deployments — apply manifests, roll out releases and debug pods.",
+        }),
+      ],
+      0.01,
+    );
+    expect(report.pairs[0].reason).toMatch(/shared terms/i);
+    expect(report.pairs[0].reason).toMatch(
+      /kubernetes|deployments|manifests|apply/i,
+    );
+  });
+});
+
+describe("formatOverlapReport", () => {
+  it("shows the empty-set sentence when nothing is installed", () => {
+    const out = formatOverlapReport(detectSemanticOverlaps([]));
+    expect(out).toContain("No installed skills.");
+  });
+
+  it("reports no overlaps without pairs", () => {
+    const out = formatOverlapReport(
+      detectSemanticOverlaps([makeSkill({ path: "/a", realPath: "/a" })]),
+    );
+    expect(out).toContain("No overlapping skills found.");
+  });
+
+  it("lists pair names, score, reason, paths and read-only note", () => {
+    const report = detectSemanticOverlaps([
+      makeSkill({
+        name: "kube-helper",
+        dirName: "kube-helper",
+        path: "/a",
+        realPath: "/a",
+        description:
+          "Manage kubernetes deployments: apply manifests, roll out updates and debug pods.",
+      }),
+      makeSkill({
+        name: "cluster-ops",
+        dirName: "cluster-ops",
+        path: "/b",
+        realPath: "/b",
+        description:
+          "Operate kubernetes deployments — apply manifests, roll out releases and debug pods.",
+      }),
+    ]);
+    const out = formatOverlapReport(report as InstalledOverlapReport);
+    expect(out).toContain("Semantic Overlap Audit");
+    expect(out).toContain("kube-helper");
+    expect(out).toContain("cluster-ops");
+    expect(out).toMatch(/\d{1,3}%/);
+    expect(out).toContain("/a");
+    expect(out).toContain("/b");
+    expect(out).toContain("Nothing was changed");
+  });
+});
+
+describe("formatOverlapReportJSON", () => {
+  it("emits parseable JSON with the report shape", () => {
+    const json = JSON.parse(
+      formatOverlapReportJSON(detectSemanticOverlaps([])),
+    ) as InstalledOverlapReport;
+    expect(json).toHaveProperty("scannedAt");
+    expect(json).toHaveProperty("totalSkills");
+    expect(json).toHaveProperty("comparedSkills");
+    expect(json).toHaveProperty("pairs");
+    expect(json).toHaveProperty("highConfidenceCount");
+  });
+});
+
+describe("thresholds", () => {
+  it("high confidence sits above the default threshold", () => {
+    expect(HIGH_CONFIDENCE_OVERLAP_THRESHOLD).toBeGreaterThan(
+      DEFAULT_OVERLAP_THRESHOLD,
+    );
+  });
+});

--- a/src/installed-overlap.ts
+++ b/src/installed-overlap.ts
@@ -189,15 +189,11 @@ export function computeInstalledOverlapScore(
  * can judge the overlap instead of trusting a bare number.
  */
 function overlapReason(
-  aName: string,
-  aDescription: string,
-  bName: string,
-  bDescription: string,
+  tokensA: Set<string>,
+  tokensB: Set<string>,
   weights: Map<string, number>,
   score: number,
 ): string {
-  const tokensA = descriptionTokens(aDescription);
-  const tokensB = descriptionTokens(bDescription);
   const shared = [...tokensA]
     .filter((t) => tokensB.has(t))
     .sort(
@@ -276,33 +272,28 @@ export function detectSemanticOverlaps(
 ): InstalledOverlapReport {
   const compared = dedupeForComparison(skills);
 
-  // Corpus statistics come from descriptions — the one text every skill has.
-  const weights = buildIdfWeights(compared.map((s) => descriptionTokens(s.description)));
+  // Tokenize once per skill; the pairwise loop reuses these sets. Corpus
+  // statistics come from descriptions — the one text every skill has.
+  const descSets = compared.map((s) => descriptionTokens(s.description));
+  const nameSets = compared.map((s) => nameTokens(s.name));
+  const weights = buildIdfWeights(descSets);
 
   const pairs: InstalledOverlapPair[] = [];
   for (let i = 0; i < compared.length; i++) {
     for (let j = i + 1; j < compared.length; j++) {
-      const a = compared[i];
-      const b = compared[j];
-      if (isSameIdentity(a, b)) continue;
-      const score = computeInstalledOverlapScore(
-        a.name,
-        a.description,
-        b.name,
-        b.description,
-        weights,
-      );
+      if (isSameIdentity(compared[i], compared[j])) continue;
+      const score =
+        0.6 * weightedOverlapCoefficient(descSets[i], descSets[j], weights) +
+        0.4 * weightedOverlapCoefficient(nameSets[i], nameSets[j], weights);
       if (score >= threshold) {
         pairs.push({
-          a: toSide(a),
-          b: toSide(b),
+          a: toSide(compared[i]),
+          b: toSide(compared[j]),
           score,
           highConfidence: score >= HIGH_CONFIDENCE_OVERLAP_THRESHOLD,
           reason: overlapReason(
-            a.name,
-            a.description,
-            b.name,
-            b.description,
+            descSets[i],
+            descSets[j],
             weights,
             score,
           ),

--- a/src/installed-overlap.ts
+++ b/src/installed-overlap.ts
@@ -154,6 +154,26 @@ function weightedOverlapCoefficient(
 }
 
 /**
+ * Combined name+description similarity from precomputed token sets.
+ *
+ * Single source of truth for the 0.6/0.4 description/name blend —
+ * `computeInstalledOverlapScore` (string inputs) and the pairwise loop in
+ * `detectSemanticOverlaps` (precomputed sets) must not drift apart.
+ */
+function combinedScore(
+  descA: Set<string>,
+  nameA: Set<string>,
+  descB: Set<string>,
+  nameB: Set<string>,
+  weights: Map<string, number>,
+): number {
+  return (
+    0.6 * weightedOverlapCoefficient(descA, descB, weights) +
+    0.4 * weightedOverlapCoefficient(nameA, nameB, weights)
+  );
+}
+
+/**
  * Combined name+description similarity between two skills.
  *
  * Mirrors `computeSimilarity` in `semantic-overlap.ts` (description 0.6,
@@ -169,17 +189,13 @@ export function computeInstalledOverlapScore(
   bDescription: string,
   weights: Map<string, number>,
 ): number {
-  const descSim = weightedOverlapCoefficient(
+  return combinedScore(
     descriptionTokens(aDescription),
-    descriptionTokens(bDescription),
-    weights,
-  );
-  const nameSim = weightedOverlapCoefficient(
     nameTokens(aName),
+    descriptionTokens(bDescription),
     nameTokens(bName),
     weights,
   );
-  return 0.6 * descSim + 0.4 * nameSim;
 }
 
 // ─── Reasons ────────────────────────────────────────────────────────────────
@@ -193,6 +209,7 @@ function overlapReason(
   tokensB: Set<string>,
   weights: Map<string, number>,
   score: number,
+  namesOverlap: boolean,
 ): string {
   const shared = [...tokensA]
     .filter((t) => tokensB.has(t))
@@ -201,7 +218,11 @@ function overlapReason(
         (weights.get(y) ?? 1) - (weights.get(x) ?? 1) || x.localeCompare(y),
     );
   if (shared.length === 0) {
-    return "Names and descriptions are near-identical";
+    // No distinctive description terms are shared, so this score is driven
+    // by the name side — say so instead of claiming identical descriptions.
+    return namesOverlap
+      ? "Similar names — descriptions share no distinctive terms"
+      : "Names and descriptions are near-identical";
   }
   const shown = shared.slice(0, 3).join(", ");
   const extra = shared.length > 3 ? ` +${shared.length - 3} more` : "";
@@ -282,10 +303,17 @@ export function detectSemanticOverlaps(
   for (let i = 0; i < compared.length; i++) {
     for (let j = i + 1; j < compared.length; j++) {
       if (isSameIdentity(compared[i], compared[j])) continue;
-      const score =
-        0.6 * weightedOverlapCoefficient(descSets[i], descSets[j], weights) +
-        0.4 * weightedOverlapCoefficient(nameSets[i], nameSets[j], weights);
+      const score = combinedScore(
+        descSets[i],
+        nameSets[i],
+        descSets[j],
+        nameSets[j],
+        weights,
+      );
       if (score >= threshold) {
+        const namesOverlap = [...nameSets[i]].some((t) =>
+          nameSets[j].has(t),
+        );
         pairs.push({
           a: toSide(compared[i]),
           b: toSide(compared[j]),
@@ -296,6 +324,7 @@ export function detectSemanticOverlaps(
             descSets[j],
             weights,
             score,
+            namesOverlap,
           ),
         });
       }

--- a/src/installed-overlap.ts
+++ b/src/installed-overlap.ts
@@ -106,7 +106,7 @@ function nameTokens(name: string): Set<string> {
  * `weight(t) = 1 + ln(N / df(t))` — a term in every description weighs 1,
  * a term unique to one skill weighs `1 + ln(N)`. With fewer than two
  * corpora every df equals N, so all weights collapse to 1 and scoring
- * degrades to plain Jaccard instead of failing.
+ * degrades to unweighted overlap instead of failing.
  */
 export function buildIdfWeights(
   tokenSets: Array<Set<string>>,

--- a/src/installed-overlap.ts
+++ b/src/installed-overlap.ts
@@ -1,0 +1,403 @@
+/**
+ * Semantic overlap detection for installed skills (issue #566).
+ *
+ * Surfaces installed skills that do substantially the same job even when
+ * their names differ — the near-duplicates the exact-match duplicate check
+ * (`src/auditor.ts`) cannot see. Similarity compares each skill's name and
+ * frontmatter description with common boilerplate down-weighted twice:
+ *
+ *  1. A static stopword list drops filler that carries no topic signal
+ *     ("use this skill to", "provides", "helps", …).
+ *  2. Corpus inverse document frequency down-weights terms that appear in
+ *     most of the installed set's descriptions, so distinctive terms decide
+ *     the score.
+ *
+ * Scoring is token-based Jaccard — no external embedding service, fully
+ * offline and deterministic. Read-only by construction: the report never
+ * removes, disables, or suggests auto-removal for anything.
+ *
+ * This is distinct from `semantic-overlap.ts`, which ranks overlaps in the
+ * indexed catalog (#495); this module works on locally installed SkillInfo
+ * entries (#566).
+ */
+
+import { tokenize } from "./skill-index";
+import { ansi, shortenPath } from "./formatter";
+import { normalizeSkillKey } from "./auditor";
+import type {
+  InstalledOverlapPair,
+  InstalledOverlapReport,
+  OverlapSide,
+  SkillInfo,
+} from "./utils/types";
+
+// ─── Thresholds ─────────────────────────────────────────────────────────────
+
+/**
+ * Minimum combined similarity to report a pair.
+ *
+ * Calibrated against realistic installed sets: paraphrased same-job
+ * descriptions land around 0.40+, skills that merely share a domain stay
+ * below 0.15, so 0.35 separates them with margin on both sides.
+ */
+export const DEFAULT_OVERLAP_THRESHOLD = 0.35;
+
+/** Above this, the pair very likely covers the same ground. */
+export const HIGH_CONFIDENCE_OVERLAP_THRESHOLD = 0.55;
+
+// ─── Boilerplate ────────────────────────────────────────────────────────────
+
+/**
+ * Filler and skill-domain boilerplate stripped before scoring. These tokens
+ * appear in nearly every skill description ("Use this skill to…") and would
+ * otherwise make unrelated skills look alike.
+ */
+const BOILERPLATE_TOKENS = new Set([
+  // English function words
+  "the", "a", "an", "and", "or", "but", "nor", "for", "to", "of", "in", "on",
+  "at", "by", "with", "from", "into", "onto", "about", "over", "under",
+  "across", "between", "through", "during", "before", "after", "above",
+  "below", "up", "down", "out", "off", "again", "as", "is", "are", "was",
+  "were", "be", "been", "being", "am", "do", "does", "did", "doing", "have",
+  "has", "had", "will", "would", "shall", "should", "can", "could", "may",
+  "might", "must", "not", "no", "yes", "if", "then", "than", "so", "such",
+  "that", "this", "these", "those", "it", "its", "they", "them", "their",
+  "there", "here", "when", "while", "where", "which", "who", "whom", "whose",
+  "what", "why", "how", "all", "any", "both", "each", "few", "more", "most",
+  "other", "others", "some", "only", "own", "same", "too", "very", "just",
+  "also", "you", "your", "yours", "we", "our", "ours", "us",
+  // Skill-domain boilerplate
+  "skill", "skills", "agent", "agents", "ai", "claude", "code", "coding",
+  "llm", "llms", "assistant", "assistants", "use", "uses", "using", "used",
+  "user", "users", "provide", "provides", "provided", "providing", "help",
+  "helps", "helping", "support", "supports", "supported", "supporting",
+  "enable", "enables", "enabling", "allow", "allows", "allowing", "lets",
+  "make", "makes", "making", "get", "gets", "getting", "give", "gives",
+  "work", "works", "working", "tool", "tools", "based", "via", "per",
+  "new", "like", "want", "needs", "need", "including", "include", "includes",
+  "various", "multiple", "different", "specific", "without", "within",
+]);
+
+/**
+ * Topic tokens for a description: boilerplate removed.
+ */
+function descriptionTokens(description: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const t of tokenize(description)) {
+    if (!BOILERPLATE_TOKENS.has(t)) tokens.add(t);
+  }
+  return tokens;
+}
+
+/** Identity tokens for a name: boilerplate removed. */
+function nameTokens(name: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const t of tokenize(name)) {
+    if (!BOILERPLATE_TOKENS.has(t)) tokens.add(t);
+  }
+  return tokens;
+}
+
+// ─── Weighted similarity ────────────────────────────────────────────────────
+
+/**
+ * Inverse document frequency for every token in the compared set.
+ *
+ * `weight(t) = 1 + ln(N / df(t))` — a term in every description weighs 1,
+ * a term unique to one skill weighs `1 + ln(N)`. With fewer than two
+ * corpora every df equals N, so all weights collapse to 1 and scoring
+ * degrades to plain Jaccard instead of failing.
+ */
+export function buildIdfWeights(
+  tokenSets: Array<Set<string>>,
+): Map<string, number> {
+  const n = tokenSets.length;
+  const df = new Map<string, number>();
+  for (const tokens of tokenSets) {
+    for (const t of tokens) {
+      df.set(t, (df.get(t) ?? 0) + 1);
+    }
+  }
+  const weights = new Map<string, number>();
+  for (const [token, count] of df) {
+    weights.set(token, 1 + Math.log(n / count));
+  }
+  return weights;
+}
+
+/**
+ * Weighted overlap coefficient (Szymkiewicz–Simpson): shared-token weight
+ * over the smaller side's total weight.
+ *
+ * Chosen over Jaccard because installed-skill descriptions vary hugely in
+ * length — a one-line description inside a long one is still the same job,
+ * and Jaccard's union denominator would bury it. Returns 0 when either set
+ * is empty or nothing is shared.
+ */
+function weightedOverlapCoefficient(
+  a: Set<string>,
+  b: Set<string>,
+  weights: Map<string, number>,
+): number {
+  let intersectionWeight = 0;
+  let weightA = 0;
+  let weightB = 0;
+  for (const t of a) {
+    weightA += weights.get(t) ?? 1;
+    if (b.has(t)) intersectionWeight += weights.get(t) ?? 1;
+  }
+  for (const t of b) {
+    weightB += weights.get(t) ?? 1;
+  }
+  const smaller = Math.min(weightA, weightB);
+  return smaller === 0 ? 0 : intersectionWeight / smaller;
+}
+
+/**
+ * Combined name+description similarity between two skills.
+ *
+ * Mirrors `computeSimilarity` in `semantic-overlap.ts` (description 0.6,
+ * name 0.4) but every token is discounted by corpus IDF so shared
+ * boilerplate contributes almost nothing, and each side uses a weighted
+ * overlap coefficient so short descriptions are not buried by their own
+ * brevity.
+ */
+export function computeInstalledOverlapScore(
+  aName: string,
+  aDescription: string,
+  bName: string,
+  bDescription: string,
+  weights: Map<string, number>,
+): number {
+  const descSim = weightedOverlapCoefficient(
+    descriptionTokens(aDescription),
+    descriptionTokens(bDescription),
+    weights,
+  );
+  const nameSim = weightedOverlapCoefficient(
+    nameTokens(aName),
+    nameTokens(bName),
+    weights,
+  );
+  return 0.6 * descSim + 0.4 * nameSim;
+}
+
+// ─── Reasons ────────────────────────────────────────────────────────────────
+
+/**
+ * Human-readable reason naming the most distinctive shared terms, so users
+ * can judge the overlap instead of trusting a bare number.
+ */
+function overlapReason(
+  aName: string,
+  aDescription: string,
+  bName: string,
+  bDescription: string,
+  weights: Map<string, number>,
+  score: number,
+): string {
+  const tokensA = descriptionTokens(aDescription);
+  const tokensB = descriptionTokens(bDescription);
+  const shared = [...tokensA]
+    .filter((t) => tokensB.has(t))
+    .sort(
+      (x, y) =>
+        (weights.get(y) ?? 1) - (weights.get(x) ?? 1) || x.localeCompare(y),
+    );
+  if (shared.length === 0) {
+    return "Names and descriptions are near-identical";
+  }
+  const shown = shared.slice(0, 3).join(", ");
+  const extra = shared.length > 3 ? ` +${shared.length - 3} more` : "";
+  const label =
+    score >= HIGH_CONFIDENCE_OVERLAP_THRESHOLD
+      ? "Very similar"
+      : "Substantially overlapping";
+  return `${label} — shared terms: ${shown}${extra}`;
+}
+
+// ─── Comparison units ───────────────────────────────────────────────────────
+
+/**
+ * Collapse multi-provider installs of one physical copy to a single unit.
+ * Same-realpath symlinks (the normal `asm install` layout across providers)
+ * must never pair against themselves; the non-symlink row wins when both
+ * forms appear, mirroring `detectDuplicates`.
+ */
+export function dedupeForComparison(skills: SkillInfo[]): SkillInfo[] {
+  const byRealPath = new Map<string, SkillInfo>();
+  for (const s of skills) {
+    const existing = byRealPath.get(s.realPath);
+    if (!existing) {
+      byRealPath.set(s.realPath, s);
+    } else if (existing.isSymlink && !s.isSymlink) {
+      byRealPath.set(s.realPath, s);
+    }
+  }
+  return [...byRealPath.values()];
+}
+
+function toSide(s: SkillInfo): OverlapSide {
+  return {
+    name: s.name,
+    dirName: s.dirName,
+    provider: s.provider,
+    providerLabel: s.providerLabel || s.provider,
+    scope: s.scope,
+    path: s.path,
+  };
+}
+
+/**
+ * Same-normalized-name pairs are exact-duplicate territory — `asm audit
+ * duplicates` reports them with removal support. Overlap only answers the
+ * different-names question, so those pairs are skipped here.
+ */
+function isSameIdentity(a: SkillInfo, b: SkillInfo): boolean {
+  return (
+    normalizeSkillKey(a.dirName) === normalizeSkillKey(b.dirName) ||
+    (Boolean(a.name) &&
+      Boolean(b.name) &&
+      normalizeSkillKey(a.name) === normalizeSkillKey(b.name))
+  );
+}
+
+// ─── Detection ──────────────────────────────────────────────────────────────
+
+/**
+ * Rank pairs of installed skills that do substantially the same job.
+ *
+ * @param skills — installed skills as produced by `scanAllSkills`
+ * @param threshold — minimum similarity to report (default DEFAULT_OVERLAP_THRESHOLD)
+ */
+export function detectSemanticOverlaps(
+  skills: SkillInfo[],
+  threshold: number = DEFAULT_OVERLAP_THRESHOLD,
+): InstalledOverlapReport {
+  const compared = dedupeForComparison(skills);
+
+  // Corpus statistics come from descriptions — the one text every skill has.
+  const weights = buildIdfWeights(compared.map((s) => descriptionTokens(s.description)));
+
+  const pairs: InstalledOverlapPair[] = [];
+  for (let i = 0; i < compared.length; i++) {
+    for (let j = i + 1; j < compared.length; j++) {
+      const a = compared[i];
+      const b = compared[j];
+      if (isSameIdentity(a, b)) continue;
+      const score = computeInstalledOverlapScore(
+        a.name,
+        a.description,
+        b.name,
+        b.description,
+        weights,
+      );
+      if (score >= threshold) {
+        pairs.push({
+          a: toSide(a),
+          b: toSide(b),
+          score,
+          highConfidence: score >= HIGH_CONFIDENCE_OVERLAP_THRESHOLD,
+          reason: overlapReason(
+            a.name,
+            a.description,
+            b.name,
+            b.description,
+            weights,
+            score,
+          ),
+        });
+      }
+    }
+  }
+
+  pairs.sort(
+    (p, q) =>
+      q.score - p.score ||
+      p.a.name.localeCompare(q.a.name) ||
+      p.b.name.localeCompare(q.b.name),
+  );
+
+  return {
+    scannedAt: new Date().toISOString(),
+    totalSkills: skills.length,
+    comparedSkills: compared.length,
+    pairs,
+    highConfidenceCount: pairs.filter((p) => p.highConfidence).length,
+  };
+}
+
+// ─── CLI formatters ─────────────────────────────────────────────────────────
+
+/** Render the overlap report as CLI text. All output goes through `ansi`. */
+export function formatOverlapReport(report: InstalledOverlapReport): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(ansi.blueBold("  Semantic Overlap Audit"));
+  lines.push(ansi.dim("  " + "-".repeat(40)));
+  lines.push("");
+
+  if (report.totalSkills === 0) {
+    lines.push("  No installed skills.");
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  lines.push(
+    `  ${ansi.bold("Compared:")} ${report.comparedSkills} distinct skill(s)` +
+      ansi.dim(` (from ${report.totalSkills} installed)`),
+  );
+  lines.push("");
+
+  if (report.pairs.length === 0) {
+    lines.push(ansi.green("No overlapping skills found."));
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  lines.push(
+    ansi.bold(
+      `  Found ${report.pairs.length} overlapping pair(s) ` +
+        `(${report.highConfidenceCount} high confidence):`,
+    ),
+  );
+  lines.push("");
+
+  for (const pair of report.pairs) {
+    const pct = Math.round(pair.score * 100);
+    lines.push(
+      `  ${ansi.bold(`${pct}%`)} ${ansi.yellow(`"${pair.a.name}"`)} ` +
+        `${ansi.dim("↔")} ${ansi.yellow(`"${pair.b.name}"`)}`,
+    );
+    lines.push(
+      ansi.dim(
+        `     ${pair.a.providerLabel} (${pair.a.scope})  ${shortenPath(pair.a.path)}`,
+      ),
+    );
+    lines.push(
+      ansi.dim(
+        `     ${pair.b.providerLabel} (${pair.b.scope})  ${shortenPath(pair.b.path)}`,
+      ),
+    );
+    if (pair.highConfidence) {
+      lines.push(ansi.red("     ⚠ likely redundant — review before keeping both"));
+    }
+    lines.push(ansi.dim(`     ${pair.reason}`));
+    lines.push("");
+  }
+
+  lines.push(
+    ansi.dim(
+      "  Nothing was changed. Review each pair before removing either skill.",
+    ),
+  );
+  lines.push("");
+  return lines.join("\n");
+}
+
+/** Render the overlap report as JSON. */
+export function formatOverlapReportJSON(
+  report: InstalledOverlapReport,
+): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -399,6 +399,46 @@ export interface ResidencyReport {
   signals: ResidencySignal[];
 }
 
+/** One side of an installed-skill overlap pair (issue #566). */
+export interface OverlapSide {
+  name: string;
+  dirName: string;
+  provider: string;
+  providerLabel: string;
+  scope: "global" | "project";
+  path: string;
+}
+
+/**
+ * A pair of installed skills that do substantially the same job despite
+ * different names (issue #566). Reported read-only — `asm audit overlap`
+ * never removes or disables anything.
+ */
+export interface InstalledOverlapPair {
+  a: OverlapSide;
+  b: OverlapSide;
+  /** Combined name+description similarity, 0..1; higher means more similar. */
+  score: number;
+  /** True when `score` reaches the high-confidence threshold. */
+  highConfidence: boolean;
+  /** One-line human explanation of the overlap. */
+  reason: string;
+}
+
+/** Result of the semantic overlap check over installed skills (issue #566). */
+export interface InstalledOverlapReport {
+  scannedAt: string;
+  totalSkills: number;
+  /**
+   * Distinct skills actually compared: multi-provider copies of one install
+   * (same real path) collapse to a single comparison unit.
+   */
+  comparedSkills: number;
+  /** Ranked most-similar first. */
+  pairs: InstalledOverlapPair[];
+  highConfidenceCount: number;
+}
+
 export interface RemovalPlan {
   directories: Array<{ path: string; isSymlink: boolean }>;
   ruleFiles: string[];


### PR DESCRIPTION
Closes #566

## Summary

`asm audit`'s duplicate check only catches identical names, so skills that do substantially the same job under different names slip through. This adds a read-only `asm audit overlap` subcommand that compares every pair of distinct installed skills by name and description similarity, ranks the pairs most-similar-first, and flags high-confidence overlaps. Scoring is offline token math — stopword-filtered, corpus-IDF-weighted overlap coefficient — so it needs no external embedding service.

## Approach

Balanced option: a dedicated domain module (`src/installed-overlap.ts`) plus a thin command surface following the existing `residency` subcommand pattern (human text / `--json` / `--machine` v1 envelope). Boilerplate is down-weighted twice: a static stopword list drops skill-description filler ("use this skill to", "provides", …), then inverse document frequency across the installed set discounts terms nearly every skill shares, letting distinctive topic terms decide the score. Multi-provider copies of one install collapse to a single comparison unit, and same-normalized-name pairs are left to `asm audit duplicates`.

## Decision Record

- **Root cause:** the duplicate check groups by normalized name/dirName and byte-identical bodies only; two differently-named skills with paraphrased descriptions are invisible to it, leaving near-duplicate resident descriptions undetected.
- **Options considered:** Option 1 — fold semantic scoring into `detectDuplicates` as a fourth grouping rule; Option 2 — dedicated read-only module + `asm audit overlap` subcommand (stopwords + IDF-weighted overlap coefficient over name/description); Option 3 — embedding-service integration with TUI view.
- **Options rejected:** Option 1 — conflates fuzzy similarity with the exact-match report that drives `-y` auto-remove, coupling a removal path to heuristic scores; Option 3 — violates the no-external-embedding-service acceptance criterion and drags the TUI into scope.
- **Selected option:** Option 2 — balanced
- **Residual risk:** token-based similarity is lexical: paraphrases sharing no vocabulary score low, and the default thresholds (0.35 report / 0.55 high-confidence) were calibrated on representative sets rather than a large corpus — expect to tune them after reviewing real-world results.

Analyzed at: `feat/566-semantic-overlap-detection-for-installed @ 9ed9a97` (2026-08-25)

## Changes

| File | Change |
|------|--------|
| `src/installed-overlap.ts` | New module: boilerplate filtering, IDF weighting, pairwise overlap detection, CLI/JSON formatters |
| `src/utils/types.ts` | `OverlapSide`, `InstalledOverlapPair`, `InstalledOverlapReport` types |
| `src/commands/audit.ts` | `overlap` subcommand routing, help text, machine-envelope handler |
| `src/cli.test.ts` | parseArgs + CLI integration cases (json/machine/help/read-only/empty-set) |
| `src/installed-overlap.test.ts` | Unit tests for weighting, scoring, dedupe, detection, ranking, formatting |
| `README.md` | Feature-table rows for `asm audit overlap` |
| `docs/ARCHITECTURE.md` | Module table row for `installed-overlap.ts` |

## Test Results

- Unit tests: 2322 passed (`CI=true npm test`, 71 files) — includes 36 new tests (26 module + 10 CLI)
- Integration tests: included above (CLI spawn cases for `audit overlap`)
- E2e tests: none added (no e2e surface for this command)
- Build/typecheck: clean for changed files; repo has 10 documented pre-existing `src/commands/stats.test.ts` typecheck errors unrelated to this change
- QA cycles: 2 (review-fix-review; fix commits `502d1b9`, `f6a4bb8`)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| A command reports installed skills that do substantially the same job despite different names | pass | `asm audit overlap` — `cmdAuditOverlap` in `src/commands/audit.ts`; `detectSemanticOverlaps` finds the kube-helper/cluster-ops paraphrase pair in `src/installed-overlap.test.ts` |
| Similarity compares name and description with common boilerplate down-weighted | pass | `BOILERPLATE_TOKENS` + `buildIdfWeights` in `src/installed-overlap.ts`; boilerplate-only pairs never flagged (`boilerplate-heavy descriptions do not create false pairs`) |
| Results rank pairs by similarity and flag high-confidence overlaps | pass | `pairs.sort` score-descending + `highConfidence` flag; covered by `ranks pairs by score descending` and `flags near-identical descriptions as high confidence` |
| The check works without an external embedding service | pass | Pure token/set arithmetic — no network, no model calls anywhere in `src/installed-overlap.ts` |

<!-- gitissue:qa v1 head=f6a4bb8a221ce9844243045a3199adcd848fd488 profile=full cycles=2 review=clean tests=2322@f6a4bb8a221ce9844243045a3199adcd848fd488 ui=none -->
