### PR TITLE
feat(skills): gate skill dependencies and report run stats (#571)

### DIFF
--- a/skills/skill-auto-improver/SKILL.md
+++ b/skills/skill-auto-improver/SKILL.md
@@ -6,7 +6,7 @@ compatibility: "Claude Code; requires `asm` on PATH and Python 3 for skill-creat
 allowed-tools: Bash Read Write Edit Grep Glob
 effort: high
 metadata:
-  version: 1.3.0
+  version: 1.4.0
   author: luongnv89
 ---
 
@@ -58,6 +58,7 @@ Verify all of the following before touching any files. Stop and tell the user if
 Resolve skill-creator's validator (required) and rubric (fail-soft) once and reuse them. The rubric is **fail-soft** — a locally-installed skill-creator may predate the repo and not ship it; a missing file only degrades Phase 2b to a warning and never aborts the run:
 
 ```bash
+RUN_STARTED_EPOCH="$(date +%s)"   # anchors the Run stats block below
 QV="$HOME/.claude/skills/skill-creator/scripts/quick_validate.py"
 test -f "$QV" || { echo "skill-creator not installed at $QV"; exit 1; }
 RUBRIC="$HOME/.claude/skills/skill-creator/references/predictability-rubric.md"
@@ -89,6 +90,7 @@ A skill passes this gate when **all** of these are true:
 - `metadata.version` follows `MAJOR.MINOR.PATCH`; `metadata.author` is present
 - If `docs/README.md` exists, it carries the AI-skip HTML comment at the top
 - Any bundled scripts under `scripts/` print descriptive errors on stderr before exiting
+- **If the target skill invokes another skill**, it carries a dependency preflight that names each dependency, its install command, the command that installs the installer itself, and a verification step (`references/skill-creator-checklist.md` → _Dependency preflight_). A skill that invokes no other skill needs no such section — its absence is not a finding, and never add an empty one
 
 This gate is **non-negotiable** — `asm publish` and the catalog rely on it.
 
@@ -168,6 +170,7 @@ Many skills jump 5–15 points on `asm eval` here without touching the body, and
 - Body over 500 lines → split dense sections into `references/<topic>.md` and replace inline content with a one-line pointer
 - Missing AI-skip notice in `docs/README.md` → prepend the HTML comment from `references/skill-creator-checklist.md`
 - Bundled script exits silently → add `echo "Error: ..." >&2` lines before each `exit 1` / `sys.exit(1)`
+- Skill invokes another skill with no preflight gate, or with one that never explains installation → report the finding and add the gate from `references/skill-creator-checklist.md` → _Dependency preflight_. Detect it by scanning the target for `/skill-name` invocations, reads under `~/.claude/skills/` or `~/.agents/skills/`, and phases handed to a named skill
 
 Re-run `python "$QV" "$SKILL_PATH"` after every Gate 1 edit. Do not move to Phase 2b until Gate 1 is clean.
 
@@ -233,7 +236,36 @@ Write `.asm-improver/report.md` (full layout in `references/report-template.md`)
 2. **Predictability findings** (advisory) — Phase 2b findings per item, open ones with a one-line note; say so if it was skipped fail-soft. Never a gate failure.
 3. **Unresolved blockers** — BLOCKER only; each names the failed **hard gate** (Gate 1 or Gate 2), the specific check, and what was unresolvable. Predictability findings are never promoted here.
 
-Also include: skill path, `metadata.version` baseline → final, files changed, iterations (N of 8), key fixes applied. Do not pretend a blocker is a pass.
+Also include: skill path, `metadata.version` baseline → final, files changed, iterations (N of 8), key fixes applied. Do not pretend a blocker is a pass. Close the report — and the printed summary — with the **Run stats** block below.
+
+## Run stats (mandatory)
+
+Every run that updates a skill closes its summary with a run-stats block — the last thing printed, after the Phase 7 report. It reports what the run **cost**, and never repeats a metric the report already carries (iterations, scores, files changed).
+
+`RUN_STARTED_EPOCH` is captured once in the Prerequisites block above; `elapsed` is `now - RUN_STARTED_EPOCH`.
+
+```
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Run stats   elapsed 4m 12s · tokens 128,400 · cost $0.42
+              agents 0 · skills 1 · tool calls 63
+```
+
+Fields are fixed and in this order — never reordered, renamed, or added to:
+
+| Field        | Value                                                                                            |
+| ------------ | ------------------------------------------------------------------------------------------------ |
+| `elapsed`    | wall-clock duration, `{H}h {M}m {S}s`; drop zero-valued leading units only (`4m 12s`, `48s`)     |
+| `tokens`     | **conditional** — printed only where the host reported a usage figure, with thousands separators |
+| `cost`       | **conditional** — printed only where the host reported a run cost, as `$0.42`                    |
+| `agents`     | subagents this run spawned                                                                       |
+| `skills`     | other skills this run invoked (`skill-creator`'s validator counts as one)                        |
+| `tool calls` | tool invocations this run made                                                                   |
+
+- **`tokens` and `cost` are omitted entirely when the host reported no figure** — no dangling `·`, no placeholder. Never estimate one from output length, file sizes, or iteration counts, and never reconstruct one from host transcripts or logs.
+- **`elapsed`, `agents`, `skills`, and `tool calls` always print.** A value that cannot be determined prints the literal `n/a`; `0` is a determined value and is correct where it is true.
+- A missing optional figure never suppresses the rest of the block.
+
+Print it at **every** terminal outcome, not only a PASS: a completed loop, a BLOCKER report, the Phase 0 early exit when the baseline already passes both gates, a failed prerequisite, and an aborted run. Only a run that produced no output at all has no block. One epoch read at start, one at the end, two lines of output — never a timing call per phase or a summarization pass.
 
 ## Step Completion Reports (mandatory)
 
@@ -250,19 +282,21 @@ After each phase, emit a compact status block so pass/fail is scannable:
   Result:              PASS | FAIL | PARTIAL
 ```
 
-Use `√` for pass, `×` for fail, `—` for context. Report per phase: Phase 0 (baseline captured), Phase 1 (deterministic + normalization), Phase 2 (Gate 1 fixes), Phase 2b (predictability audit — report findings count and "advisory" / "skipped fail-soft"; this phase never gates), Phase 3 (asm-eval category fixes), Phase 5 (version bump applied), Phase 6 (loop stop condition), Phase 7 (final report written).
+Use `√` for pass, `×` for fail, `—` for context. Report per phase: Phase 0 (baseline captured), Phase 1 (deterministic + normalization), Phase 2 (Gate 1 fixes), Phase 2b (predictability audit — report findings count and "advisory" / "skipped fail-soft"; this phase never gates), Phase 3 (asm-eval category fixes), Phase 5 (version bump applied), Phase 6 (loop stop condition), Phase 7 (final report written, run stats printed).
 
 ## Acceptance Criteria
 
 - `.asm-improver/baseline.json`, `.asm-improver/baseline-quickvalidate.txt`, and `.asm-improver/baseline-frontmatter-audit.md` captured before any edits
 - `asm eval --fix` applied, then frontmatter normalized so `quick_validate.py` accepts the result
 - Each Gate 1 check addressed at least once before any Gate 2 work
+- A target that invokes another skill ends the run with a dependency preflight naming each dependency, its install command, the command that installs the installer itself, and a verification step; a target that invokes none gains no such section
 - Predictability audit (Phase 2b) run after Gate 1 is clean — findings captured to `.asm-improver/predictability-audit.md`, or the skip logged when the rubric is unavailable. Findings are advisory and never gate the loop
 - Each `asm eval` category below 8 addressed at least once
 - Re-eval against **both** gates after every iteration, captured to `.asm-improver/iter-N.json` and `.asm-improver/iter-N-gates.txt`
 - Target skill's `metadata.version` bumped exactly once per iteration that produced edits
 - Loop stops on one of the 4 conditions in Phase 6 — never unbounded
 - `.asm-improver/report.md` exists on exit, pass or blocker, with gate status, advisory predictability findings, and unresolved blockers as three visually distinct sections
+- Every terminal outcome closes with the Run stats block — `elapsed`, `agents`, `skills`, and `tool calls` always present (`n/a` when undetermined), `tokens` and `cost` printed only where the host reported them and never invented
 - On PASS: `python "$QV" "$SKILL_PATH"` exits 0 AND final eval JSON shows `overallScore > 85` AND `min(categories[*].score) >= 8`
 - On BLOCKER: report names every Gate 1 check still failing and every category still below 8 with a one-line reason. Open predictability findings alone never constitute a blocker
 
@@ -293,5 +327,6 @@ See `references/report-template.md` for the full PASS and BLOCKER report templat
 - `~/.claude/skills/skill-creator/scripts/quick_validate.py` — the Gate 1 mechanical validator
 - `~/.claude/skills/skill-creator/references/frontmatter-rules.md` — upstream source of the audit rules
 - `~/.claude/skills/skill-creator/references/predictability-rubric.md` — upstream source of the Phase 2b audit (fail-soft if absent)
+- `~/.claude/skills/skill-creator/references/dependency-preflight.md` — upstream source of the dependency-preflight rule (the checklist above carries everything needed to audit and fix without it)
 - `asm eval --help` — flag reference for the evaluator
 - `src/evaluator.ts` in the ASM repo — source of truth for how each Gate 2 category is scored

--- a/skills/skill-auto-improver/SKILL.md
+++ b/skills/skill-auto-improver/SKILL.md
@@ -55,15 +55,25 @@ Verify all of the following before touching any files. Stop and tell the user if
 - The working tree has no unrelated uncommitted edits (dirty files get mixed into diffs)
 - You have write access to the skill directory
 
-Resolve skill-creator's validator (required) and rubric (fail-soft) once and reuse them. The rubric is **fail-soft** — a locally-installed skill-creator may predate the repo and not ship it; a missing file only degrades Phase 2b to a warning and never aborts the run:
+## Dependency Preflight (mandatory)
+
+This skill invokes `skill-creator`: it runs that skill's `quick_validate.py` (required — the Gate 1 validator) and reads its `predictability-rubric.md` (fail-soft — Phase 2b). Resolve both once and reuse them, **before** Phase 0, the first step that changes anything. The rubric is **fail-soft** — a locally-installed skill-creator may predate the repo and not ship it; a missing file only degrades Phase 2b to a warning and never aborts the run:
 
 ```bash
 RUN_STARTED_EPOCH="$(date +%s)"   # anchors the Run stats block below
 QV="$HOME/.claude/skills/skill-creator/scripts/quick_validate.py"
-test -f "$QV" || { echo "skill-creator not installed at $QV"; exit 1; }
+test -f "$QV" || {
+  echo "Missing required skill: skill-creator" >&2
+  echo "Install it:      asm install skill-creator --yes" >&2
+  echo "No asm yet:      npm install -g agent-skill-manager" >&2
+  echo "Verify:          asm list --json | grep 'skill-creator'" >&2
+  exit 1
+}
 RUBRIC="$HOME/.claude/skills/skill-creator/references/predictability-rubric.md"
 test -f "$RUBRIC" || echo "⚠ predictability rubric missing — Phase 2b degraded (gates unaffected)"
 ```
+
+On a miss, stop before the first mutation and print the three commands above — do not continue with a partial run. This is the same gate this skill audits every target for (`references/skill-creator-checklist.md` → _Dependency preflight_).
 
 ## Inputs
 

--- a/skills/skill-auto-improver/SKILL.md
+++ b/skills/skill-auto-improver/SKILL.md
@@ -188,7 +188,7 @@ Re-run `python "$QV" "$SKILL_PATH"` after every Gate 1 edit. Do not move to Phas
 
 With Gate 1 clean, audit against skill-creator's rubric **before** Phase 3 so the findings can steer your category edits. Advisory — never gates, never blocks.
 
-1. Confirm `$RUBRIC` resolved (Prerequisites). If missing, **skip fail-soft** — log `⚠ predictability audit skipped (rubric unavailable)` and move to Phase 3.
+1. Confirm `$RUBRIC` resolved (_Dependency Preflight (mandatory)_). If missing, **skip fail-soft** — log `⚠ predictability audit skipped (rubric unavailable)` and move to Phase 3.
 2. Walk `references/predictability-audit.md` — record each of the 7 items as `pass` / `advisory` with a specific note, save to `.asm-improver/predictability-audit.md`.
 
 Act on findings only when _targeted_ (a predictability fix often also lifts an asm-eval category); never bloat to satisfy one. Finding-handling detail and the no-bloat rule live in `references/predictability-audit.md`.
@@ -252,7 +252,7 @@ Also include: skill path, `metadata.version` baseline → final, files changed, 
 
 Every run that updates a skill closes its summary with a run-stats block — the last thing printed, after the Phase 7 report. It reports what the run **cost**, and never repeats a metric the report already carries (iterations, scores, files changed).
 
-`RUN_STARTED_EPOCH` is captured once in the Prerequisites block above; `elapsed` is `now - RUN_STARTED_EPOCH`.
+`RUN_STARTED_EPOCH` is captured once in the _Dependency Preflight (mandatory)_ block above; `elapsed` is `now - RUN_STARTED_EPOCH`. A stop before that block ran has no anchor, so `elapsed` prints `n/a`.
 
 ```
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄

--- a/skills/skill-auto-improver/SKILL.md
+++ b/skills/skill-auto-improver/SKILL.md
@@ -22,6 +22,28 @@ The target must clear **two hard gates**, then gets one **advisory** audit:
 
 A skill that scores 92 but fails `quick_validate.py` is not done; one that passes `quick_validate.py` but scores 70 is not done. **Both gates must clear, or the loop reports a blocker** — open predictability findings alone never make one.
 
+## Dependency Preflight (mandatory)
+
+This skill invokes `skill-creator`: it runs that skill's `quick_validate.py` (required — the Gate 1 validator) and reads its `predictability-rubric.md` (fail-soft — Phase 2b). Resolve both once and reuse them **before the repo sync below**, which is the first step that changes anything. The rubric is **fail-soft** — a locally-installed skill-creator may predate the repo and not ship it; a missing file only degrades Phase 2b to a warning and never aborts the run:
+
+```bash
+RUN_STARTED_EPOCH="$(date +%s)"   # anchors the Run stats block below
+QV="$HOME/.claude/skills/skill-creator/scripts/quick_validate.py"
+test -f "$QV" || {
+  echo "Missing required skill: skill-creator" >&2
+  echo "Install it:      asm install skill-creator -p claude --yes" >&2
+  echo "No asm yet:      npm install -g agent-skill-manager" >&2
+  echo "Verify:          asm list -p claude --json | grep 'skill-creator'" >&2
+  exit 1
+}
+RUBRIC="$HOME/.claude/skills/skill-creator/references/predictability-rubric.md"
+test -f "$RUBRIC" || echo "⚠ predictability rubric missing — Phase 2b degraded (gates unaffected)"
+```
+
+`-p claude` is required, not decoration: `asm install` refuses to guess a provider in a non-interactive shell and `--yes` does not cover that choice, so a gate that omits it hands the user a command that errors instead of installing. The verification names the same provider the detection path belongs to, so an install landing under a different tool cannot report success while `$QV` is still missing.
+
+On a miss, stop before the first mutation and print the three commands above — do not continue with a partial run. This is the same gate this skill audits every target for (`references/skill-creator-checklist.md` → _Dependency preflight_).
+
 ## Repo Sync Before Edits (mandatory)
 
 This skill mutates files in a git repo. Before any edit, sync the local branch with the remote:
@@ -50,30 +72,10 @@ Reach for this on an **existing, external, legacy, manually-authored, or drifted
 Verify all of the following before touching any files. Stop and tell the user if any fails.
 
 - `asm` is available on PATH (`command -v asm` or `which asm`)
-- Python 3 is available, and `~/.claude/skills/skill-creator/scripts/quick_validate.py` exists (skill-creator must be installed locally)
+- Python 3 is available; skill-creator's `quick_validate.py` is resolved by _Dependency Preflight (mandatory)_ above, which is the only place that handles a miss
 - The target skill path contains a `SKILL.md` file
 - The working tree has no unrelated uncommitted edits (dirty files get mixed into diffs)
 - You have write access to the skill directory
-
-## Dependency Preflight (mandatory)
-
-This skill invokes `skill-creator`: it runs that skill's `quick_validate.py` (required — the Gate 1 validator) and reads its `predictability-rubric.md` (fail-soft — Phase 2b). Resolve both once and reuse them, **before** Phase 0, the first step that changes anything. The rubric is **fail-soft** — a locally-installed skill-creator may predate the repo and not ship it; a missing file only degrades Phase 2b to a warning and never aborts the run:
-
-```bash
-RUN_STARTED_EPOCH="$(date +%s)"   # anchors the Run stats block below
-QV="$HOME/.claude/skills/skill-creator/scripts/quick_validate.py"
-test -f "$QV" || {
-  echo "Missing required skill: skill-creator" >&2
-  echo "Install it:      asm install skill-creator --yes" >&2
-  echo "No asm yet:      npm install -g agent-skill-manager" >&2
-  echo "Verify:          asm list --json | grep 'skill-creator'" >&2
-  exit 1
-}
-RUBRIC="$HOME/.claude/skills/skill-creator/references/predictability-rubric.md"
-test -f "$RUBRIC" || echo "⚠ predictability rubric missing — Phase 2b degraded (gates unaffected)"
-```
-
-On a miss, stop before the first mutation and print the three commands above — do not continue with a partial run. This is the same gate this skill audits every target for (`references/skill-creator-checklist.md` → _Dependency preflight_).
 
 ## Inputs
 

--- a/skills/skill-auto-improver/SKILL.md
+++ b/skills/skill-auto-improver/SKILL.md
@@ -27,7 +27,7 @@ A skill that scores 92 but fails `quick_validate.py` is not done; one that passe
 This skill invokes `skill-creator`: it runs that skill's `quick_validate.py` (required — the Gate 1 validator) and reads its `predictability-rubric.md` (fail-soft — Phase 2b). Resolve both once and reuse them **before the repo sync below**, which is the first step that changes anything. The rubric is **fail-soft** — a locally-installed skill-creator may predate the repo and not ship it; a missing file only degrades Phase 2b to a warning and never aborts the run:
 
 ```bash
-RUN_STARTED_EPOCH="$(date +%s)"   # anchors the Run stats block below
+date +%s >&2                      # anchors the Run stats block below — read it off stderr
 QV="$HOME/.claude/skills/skill-creator/scripts/quick_validate.py"
 test -f "$QV" || {
   echo "Missing required skill: skill-creator" >&2
@@ -254,7 +254,7 @@ Also include: skill path, `metadata.version` baseline → final, files changed, 
 
 Every run that updates a skill closes its summary with a run-stats block — the last thing printed, after the Phase 7 report. It reports what the run **cost**, and never repeats a metric the report already carries (iterations, scores, files changed).
 
-`RUN_STARTED_EPOCH` is captured once in the _Dependency Preflight (mandatory)_ block above; `elapsed` is `now - RUN_STARTED_EPOCH`. A stop before that block ran has no anchor, so `elapsed` prints `n/a`.
+`run_started_epoch` is captured once, by the `date +%s >&2` in the _Dependency Preflight (mandatory)_ block above; read the value off that block's stderr rather than from a shell variable, which need not survive to a later command. `elapsed` is `now - run_started_epoch`. A stop before that block ran has no anchor, so `elapsed` prints `n/a`.
 
 ```
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄

--- a/skills/skill-auto-improver/docs/README.md
+++ b/skills/skill-auto-improver/docs/README.md
@@ -17,7 +17,9 @@
 - Hard loop cap (8 iterations) so it never runs unbounded.
 - Bumps the target skill's `metadata.version` once per iteration per skill-creator's Version Management rule.
 - Saves every iteration JSON and gate-summary line to `.asm-improver/` for auditability.
+- Reports a skill that invokes another skill without a dependency preflight gate — and retrofits one that names the dependency, its install command, the installer's own install command, and a verification step.
 - Writes a final before/after report on pass or blocker.
+- Closes every run with a run-stats block: elapsed time, agents, skills, tool calls, plus tokens and cost where the host reports them.
 
 ## When to Use
 

--- a/skills/skill-auto-improver/references/report-template.md
+++ b/skills/skill-auto-improver/references/report-template.md
@@ -77,7 +77,7 @@ Source: Phase 2b audit against skill-creator's predictability rubric. None of th
               agents 0 · skills 1 · tool calls 63
 ```
 
-The `Dependency preflight` row is **conditional**: it appears only when the target invokes another skill, with the count in the label (`invokes 1 skill`). A target that invokes none reports `n/a` in both columns, and no preflight section is added to it.
+The `Dependency preflight` row always appears; its label is **conditional**. A target that invokes another skill carries the count (`invokes 1 skill`); a target that invokes none reads `n/a` in both columns — exactly like the `Bundled scripts` row above it — and no preflight section is added to it.
 
 The **Run stats** block closes the report and the printed summary at every terminal outcome — PASS, BLOCKER, the Phase 0 early exit, and a failed prerequisite. `elapsed`, `agents`, `skills`, and `tool calls` always print (`n/a` when undetermined); `tokens` and `cost` print only where the host reported a figure and are left out entirely otherwise, never invented and never suppressing the rest of the block. Field definitions live in SKILL.md → _Run stats (mandatory)_.
 

--- a/skills/skill-auto-improver/references/report-template.md
+++ b/skills/skill-auto-improver/references/report-template.md
@@ -34,6 +34,7 @@ Target version: 0.2.0 → 1.0.0
 | SKILL.md body <500 lines             | √ (290)     | √ (290)|
 | docs/README.md AI-skip notice        | √           | √     |
 | Bundled scripts have descriptive errors | n/a      | n/a   |
+| Dependency preflight (invokes 1 skill)  | ×        | √     |
 
 ## Gate 2 — asm-eval categories
 
@@ -69,7 +70,16 @@ Source: Phase 2b audit against skill-creator's predictability rubric. None of th
 - references/examples.md (new)
 - references/prerequisites.md (new)
 - docs/README.md (added AI-skip notice)
+- references/dependency-preflight.md (new — gate for the skill it invokes)
+
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Run stats   elapsed 4m 12s · tokens 128,400 · cost $0.42
+              agents 0 · skills 1 · tool calls 63
 ```
+
+The `Dependency preflight` row is **conditional**: it appears only when the target invokes another skill, with the count in the label (`invokes 1 skill`). A target that invokes none reports `n/a` in both columns, and no preflight section is added to it.
+
+The **Run stats** block closes the report and the printed summary at every terminal outcome — PASS, BLOCKER, the Phase 0 early exit, and a failed prerequisite. `elapsed`, `agents`, `skills`, and `tool calls` always print (`n/a` when undetermined); `tokens` and `cost` print only where the host reported a figure and are left out entirely otherwise, never invented and never suppressing the rest of the block. Field definitions live in SKILL.md → _Run stats (mandatory)_.
 
 ## BLOCKER example
 

--- a/skills/skill-auto-improver/references/skill-creator-checklist.md
+++ b/skills/skill-auto-improver/references/skill-creator-checklist.md
@@ -119,7 +119,47 @@ Every iteration that edits the SKILL.md body or frontmatter must bump `metadata.
 
 Bump once per loop iteration, not once per individual edit — otherwise the version churns ahead of meaningful change.
 
-## 8. Final mechanical check
+## 8. Dependency preflight (conditional)
+
+Applies only to a target that **invokes another skill** — it calls `/other-skill`, delegates a phase to a named skill, or reads a path under `~/.claude/skills/`, `~/.agents/skills/`, or `~/.codex/skills/`. Scan the target for those three signals before deciding.
+
+- **Invokes no other skill** → nothing is required and nothing is added. An absent preflight section is **not** a finding here, and adding an empty one is itself a defect.
+- **Invokes another skill** → the target must carry a `## Dependency Preflight (mandatory)` section above its first mutating step. Missing it, or carrying one that detects the miss without explaining the fix, is a Gate 1 finding.
+
+Per dependency the gate names four things:
+
+| Element                 | Requirement                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| **Name**                | the missing skill, exactly as installed                                         |
+| **Install command**     | the command that installs that skill                                            |
+| **Installer bootstrap** | the command that installs the installer itself, for a user who does not have it |
+| **Verification**        | a command that confirms the install landed                                      |
+
+Retrofit template — one entry per dependency, `<skill-name>` replaced:
+
+````markdown
+## Dependency Preflight (mandatory)
+
+This skill invokes `<skill-name>`. Verify it is installed **before** the first
+step that changes anything:
+
+```bash
+asm list --json | grep -q '"<skill-name>"' || {
+  echo "Missing required skill: <skill-name>" >&2
+  echo "Install it:      asm install <skill-name> --yes" >&2
+  echo "No asm yet:      npm install -g agent-skill-manager" >&2
+  echo "Verify:          asm list --json | grep '<skill-name>'" >&2
+  exit 1
+}
+```
+
+If the check fails, stop and print the three commands above — do not continue
+with a partial run.
+````
+
+Where `asm` is not the target's installer, keep the four elements and swap the mechanics — e.g. `test -f "$HOME/.claude/skills/<skill-name>/SKILL.md"` for detection. Upstream source of the rule: `~/.claude/skills/skill-creator/references/dependency-preflight.md`.
+
+## 9. Final mechanical check
 
 Before declaring Gate 1 cleared, run:
 

--- a/skills/skill-auto-improver/references/skill-creator-checklist.md
+++ b/skills/skill-auto-improver/references/skill-creator-checklist.md
@@ -135,7 +135,7 @@ Per dependency the gate names four things:
 | **Installer bootstrap** | the command that installs the installer itself, for a user who does not have it |
 | **Verification**        | a command that confirms the install landed                                      |
 
-Retrofit template — one entry per dependency, `<skill-name>` replaced:
+Retrofit template — one entry per dependency, with both `<skill-name>` and `<tool>` (the provider it installs for, e.g. `claude`) replaced. An unreplaced `<tool>` is read by the shell as a redirection, not a flag:
 
 ````markdown
 ## Dependency Preflight (mandatory)

--- a/skills/skill-auto-improver/references/skill-creator-checklist.md
+++ b/skills/skill-auto-improver/references/skill-creator-checklist.md
@@ -144,11 +144,11 @@ This skill invokes `<skill-name>`. Verify it is installed **before** the first
 step that changes anything:
 
 ```bash
-asm list --json | grep -q '"<skill-name>"' || {
+asm list -p <tool> --json | grep -q '"<skill-name>"' || {
   echo "Missing required skill: <skill-name>" >&2
-  echo "Install it:      asm install <skill-name> --yes" >&2
+  echo "Install it:      asm install <skill-name> -p <tool> --yes" >&2
   echo "No asm yet:      npm install -g agent-skill-manager" >&2
-  echo "Verify:          asm list --json | grep '<skill-name>'" >&2
+  echo "Verify:          asm list -p <tool> --json | grep '<skill-name>'" >&2
   exit 1
 }
 ```
@@ -156,6 +156,8 @@ asm list --json | grep -q '"<skill-name>"' || {
 If the check fails, stop and print the three commands above — do not continue
 with a partial run.
 ````
+
+`-p <tool>` is part of the install command, not optional polish: `asm install` refuses to guess a provider in a non-interactive shell and `--yes` does not cover that choice, so a gate that omits it prints a command that errors. An install command that cannot run unattended is an incomplete gate and still a Gate 1 finding. Use the same `-p` in the detection and the verification so an install under a different tool cannot report success while the dependency is missing.
 
 Where `asm` is not the target's installer, keep the four elements and swap the mechanics — e.g. `test -f "$HOME/.claude/skills/<skill-name>/SKILL.md"` for detection. Upstream source of the rule: `~/.claude/skills/skill-creator/references/dependency-preflight.md`.
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -4,7 +4,7 @@ description: "Create, improve, evaluate, benchmark skills. Use when authoring a 
 license: MIT
 effort: max
 metadata:
-  version: 1.13.2
+  version: 1.14.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -32,7 +32,7 @@ The skill supports two distinct workflows. **Identify which one the user is on b
 
 If the request is ambiguous ("can you look at this skill?"), assume **Path B** and confirm before interviewing as if it were new. Path B also fires when `/skill-creator` is invoked on a skill directory or file.
 
-Both paths share the mandatory rules below: **Repo Sync Before Edits**, **Version Management**, **YAML Frontmatter Safety**, and **Frontmatter Audit on Review/Evaluation**. Apply them in either path.
+Both paths share the mandatory rules below: **Repo Sync Before Edits**, **Dependency Preflight**, **Version Management**, **YAML Frontmatter Safety**, and **Frontmatter Audit on Review/Evaluation**. Apply them in either path. Both paths also close with the **Run stats** block.
 
 ## Step Completion Reports
 
@@ -54,11 +54,40 @@ Adapt the check names to match what the step actually validates. Use `√` for p
 
 **Intent Capture phase checks:** `Worth building`, `Goal defined`, `Triggers identified`, `Output format agreed`
 
-**Skill Writing phase checks:** `SKILL.md written`, `README generated`, `Subagents designed`, `Predictability pass` (the 7 rubric items from _Make it predictable_ — √ when each is satisfied, × naming the gap), `Adversarial review` (fresh-subagent findings addressed)
+**Skill Writing phase checks:** `SKILL.md written`, `README generated`, `Subagents designed`, `Dependency preflight` (√ when the skill has no skill dependencies, or when it has them and ships a gate for each; × when a dependency is invoked without one), `Predictability pass` (the 7 rubric items from _Make it predictable_ — √ when each is satisfied, × naming the gap), `Adversarial review` (fresh-subagent findings addressed)
 
 **Testing phase checks:** `Evals created`, `Runs completed`, `Viewer launched`
 
 **Iteration phase checks:** `Feedback incorporated`, `Benchmarks improved`, `Description optimized`
+
+## Run stats (mandatory)
+
+Every run that creates or updates a skill closes its summary with a run-stats block — the last thing printed, after the final Step Completion Report. It reports what the run **cost**, and nothing the run already reported.
+
+Capture `run_started_epoch` once at skill start, in the same shell as the skill's first command (`cmd; ec=$?; date +%s >&2; exit "$ec"` — read the epoch off stderr so stdout and the exit code stay intact). A run that already recorded a start time reuses it.
+
+```
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Run stats   elapsed 6m 04s · tokens 128,400 · cost $0.42
+              agents 3 · skills 1 · tool calls 47
+```
+
+Fields are fixed and in this order — never reordered, renamed, or added to:
+
+| Field        | Value                                                                                            |
+| ------------ | ------------------------------------------------------------------------------------------------ |
+| `elapsed`    | wall-clock duration, `{H}h {M}m {S}s`; drop zero-valued leading units only (`6m 04s`, `48s`)     |
+| `tokens`     | **conditional** — printed only where the host reported a usage figure, with thousands separators |
+| `cost`       | **conditional** — printed only where the host reported a run cost, as `$0.42`                    |
+| `agents`     | subagents this run spawned                                                                       |
+| `skills`     | other skills this run invoked                                                                    |
+| `tool calls` | tool invocations this run made                                                                   |
+
+- **`tokens` and `cost` are omitted entirely when the host reported no figure** — no dangling `·`, no placeholder. Never estimate one from output length, file sizes, or step counts, and never reconstruct one from host transcripts or logs.
+- **`elapsed`, `agents`, `skills`, and `tool calls` always print.** A value that cannot be determined prints the literal `n/a`; `0` is a determined value and is correct where it is true (a run that spawned no subagents prints `agents 0`).
+- A missing optional figure never suppresses the rest of the block.
+
+Print it on **every** path that finishes a create or update — Path A, Subpath B1, and Subpath B2 — and on every other terminal outcome too: an early stop, a gate that refused to continue, or a failed step. Only a run that produced no output at all has no block. Measuring must not become a measurable share of what it measures: one epoch read at start, one at the end, two lines of output — never a timing call per step or a summarization pass.
 
 ## Communicating with the user
 
@@ -75,6 +104,15 @@ When creating or updating any skill that changes files in a git repository (code
 - If `origin` is missing or conflicts occur: stop and ask the user before continuing.
 
 Do not ship repo-mutating skills without this pre-sync guardrail.
+
+## Mandatory Rule for Skills That Invoke Other Skills
+
+Establish, for every skill you author or retrofit, whether it invokes, delegates to, or reads **another skill**. Ask it as a question in the interview (Capture Intent, question 6) and confirm it against the draft — prose naming `/another-skill`, or a read under `~/.claude/skills/`, is a dependency even when the author said there were none.
+
+- **It does** → the skill you produce ships a `## Dependency Preflight (mandatory)` section, placed above the first step that changes anything. Per dependency it names the skill, the command that installs it, the command that installs the installer itself, and a verification command; on a miss it stops before the first mutation.
+- **It does not** → add nothing. No empty preflight section, no "no dependencies" placeholder.
+
+Read `references/dependency-preflight.md` for the copyable template and the on-miss behavior. `skill-auto-improver` audits for this same rule, so a skill that ships without a required gate comes back as a finding later.
 
 ## Frontmatter rules (mandatory)
 
@@ -104,7 +142,8 @@ Start by understanding the user's intent. The current conversation might already
    - Does the skill need independent quality review? → Review loop with fresh subagents
    - Will the skill produce large artifacts that require focused reasoning? → Executor subagent
      If any apply, design the skill with a main-agent-as-orchestrator architecture so subagents handle the heavy lifting and the main conversation context stays clean.
-6. **Model-invoked or user-invoked?** Decide the _primary_ invocation before drafting — it changes how you write. **Model-invoked** (the default) is a reusable discipline the agent applies when the situation fits; optimize the description for reliable triggering. **User-invoked** (`/skill-name`) is orchestration the user runs deliberately (a pipeline, an expensive or destructive action); the body reads as "the user asked for this, proceed." Weigh the **context-load and cognitive-load** budgets here too. See `references/predictability-rubric.md` for the full tradeoff.
+6. **Does this skill invoke other skills?** Name every skill it calls, delegates a phase to, or reads. If any exist, the skill you write ships a dependency preflight for them — see _Mandatory Rule for Skills That Invoke Other Skills_ above and `references/dependency-preflight.md`. If none exist, nothing is added.
+7. **Model-invoked or user-invoked?** Decide the _primary_ invocation before drafting — it changes how you write. **Model-invoked** (the default) is a reusable discipline the agent applies when the situation fits; optimize the description for reliable triggering. **User-invoked** (`/skill-name`) is orchestration the user runs deliberately (a pipeline, an expensive or destructive action); the body reads as "the user asked for this, proceed." Weigh the **context-load and cognitive-load** budgets here too. See `references/predictability-rubric.md` for the full tradeoff.
 
 ### Interview and Research
 
@@ -181,6 +220,7 @@ Sequence:
    - SKILL.md under 500 lines (split to `references/` if not).
    - Step Completion Reports section present.
    - "Repo Sync Before Edits" section if the skill mutates a git repo.
+   - "Dependency Preflight" section if the skill invokes another skill — and none if it invokes none (`references/dependency-preflight.md`).
    - Bundled scripts print descriptive errors before exiting.
    - Progressive disclosure used appropriately; references one level deep.
 5. Decide fix vs. review-only mode. If fixing, apply edits and **bump `metadata.version`** — patch for frontmatter-only fixes, minor for new sections, major for restructuring. If reviewing only, surface findings as before/after suggestions and don't silently edit.
@@ -232,6 +272,7 @@ The `agents/` directory contains instructions for specialized subagents. Read th
 The `references/` directory has additional documentation:
 
 - `references/frontmatter-rules.md` — Version Management, YAML Safety, and Frontmatter Audit (mandatory).
+- `references/dependency-preflight.md` — The skill-dependency rule: when a preflight gate is required, what it must name, and the template to emit (mandatory).
 - `references/predictability-rubric.md` — The predictability standard a new skill must meet by construction: invocation choice, branch mapping, demanding completion criteria, leading words, the pruning pass, and publish-ready (no auto-improver dependency).
 - `references/description-guide.md` — Pushy + negative-trigger description pattern, one trigger per branch, length budget.
 - `references/exemplars.md` — Three annotated exemplar skills (workflow, knowledge, orchestrator) to imitate.

--- a/skills/skill-creator/docs/README.md
+++ b/skills/skill-creator/docs/README.md
@@ -17,6 +17,8 @@
 - Benchmark aggregation, variance analysis, and report tooling
 - Description optimization flow to improve triggering accuracy
 - Dedicated eval viewer and grading agents for structured review
+- Dependency preflight: a skill that invokes other skills ships a gate naming each dependency, how to install it, and how to verify it
+- Run stats on every create/update run: elapsed time, agents, skills, tool calls, plus tokens and cost where the host reports them
 
 ## When to Use
 

--- a/skills/skill-creator/references/dependency-preflight.md
+++ b/skills/skill-creator/references/dependency-preflight.md
@@ -34,7 +34,7 @@ work out the fix is worse than no gate — it stops the run and explains nothing
 | Element                 | Requirement                                                                     |
 | ----------------------- | ------------------------------------------------------------------------------- |
 | **Name**                | The missing skill, named exactly as it is installed                             |
-| **Install command**     | The command that installs that skill                                            |
+| **Install command**     | The command that installs that skill, complete enough to run unattended         |
 | **Installer bootstrap** | The command that installs the installer itself, for a user who does not have it |
 | **Verification**        | A command the user runs to confirm the install landed                           |
 
@@ -54,11 +54,11 @@ This skill invokes `<skill-name>`. Verify it is installed **before** the first
 step that changes anything:
 
 ```bash
-asm list --json | grep -q '"<skill-name>"' || {
+asm list -p <tool> --json | grep -q '"<skill-name>"' || {
   echo "Missing required skill: <skill-name>" >&2
-  echo "Install it:      asm install <skill-name> --yes" >&2
+  echo "Install it:      asm install <skill-name> -p <tool> --yes" >&2
   echo "No asm yet:      npm install -g agent-skill-manager" >&2
-  echo "Verify:          asm list --json | grep '<skill-name>'" >&2
+  echo "Verify:          asm list -p <tool> --json | grep '<skill-name>'" >&2
   exit 1
 }
 ```
@@ -67,8 +67,15 @@ If the check fails, stop and print the three commands above — do not continue
 with a partial run.
 ````
 
-Adapt the detection to what the host offers: `asm list --json` where `asm` is on
-PATH, otherwise a path test such as
+Name the provider explicitly (`-p <tool>`, e.g. `claude`): `asm install` refuses
+to guess one in a non-interactive shell and `--yes` does not cover that choice,
+so an install command without it errors instead of installing — the one outcome
+this gate exists to prevent. Use the same `-p` in the detection and the
+verification so an install landing under a different tool cannot report success
+while the dependency is still missing.
+
+Adapt the detection to what the host offers: `asm list -p <tool> --json` where
+`asm` is on PATH, otherwise a path test such as
 `test -f "$HOME/.claude/skills/<skill-name>/SKILL.md"`. The four elements are
 fixed; the mechanics are not.
 

--- a/skills/skill-creator/references/dependency-preflight.md
+++ b/skills/skill-creator/references/dependency-preflight.md
@@ -45,7 +45,10 @@ and say what the run does without it.
 ## Template to emit into the authored skill
 
 Copy this into the skill being authored, replacing `<skill-name>` with each real
-dependency. Keep it above the first step that writes, commits, or publishes.
+dependency **and `<tool>` with the provider it installs for** (e.g. `claude`).
+Both placeholders must be substituted — an unreplaced `<tool>` is read by the
+shell as a redirection, not a flag. Keep it above the first step that writes,
+commits, or publishes.
 
 ````markdown
 ## Dependency Preflight (mandatory)

--- a/skills/skill-creator/references/dependency-preflight.md
+++ b/skills/skill-creator/references/dependency-preflight.md
@@ -1,0 +1,84 @@
+# Dependency Preflight
+
+The rule for skills that **invoke other skills**. A skill that calls
+`/other-skill`, tells the agent to read another skill's `SKILL.md`, or delegates
+a phase to a named skill has a **skill dependency**. Without a gate, the miss
+surfaces halfway through someone else's work, after the run has already made
+edits.
+
+This file is the single home of the rule. `skill-creator` applies it while
+authoring; `skill-auto-improver` audits for it
+(`references/skill-creator-checklist.md` → _Dependency preflight_).
+
+## When the rule applies
+
+Establish the answer during the interview — one question, asked every time:
+
+> Does this skill invoke, delegate to, or read another skill?
+
+- **No** → the rule is satisfied by doing nothing. Do **not** add an empty
+  preflight section, a "no dependencies" note, or a placeholder heading. A skill
+  with no skill dependencies ships exactly as it would have.
+- **Yes** → the skill you produce carries a `## Dependency Preflight (mandatory)`
+  section that runs **before** the first step that changes anything.
+
+Signals that the answer is yes even when the author says no: the draft names
+another skill in prose (`/skill-name`), reads a path under `~/.claude/skills/`,
+`~/.agents/skills/`, or `~/.codex/skills/`, or hands a phase to a skill by name.
+
+## What a generated preflight must contain
+
+Four things, per dependency. A gate that detects a miss but leaves the user to
+work out the fix is worse than no gate — it stops the run and explains nothing.
+
+| Element                 | Requirement                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| **Name**                | The missing skill, named exactly as it is installed                             |
+| **Install command**     | The command that installs that skill                                            |
+| **Installer bootstrap** | The command that installs the installer itself, for a user who does not have it |
+| **Verification**        | A command the user runs to confirm the install landed                           |
+
+State the behavior on a miss too: **stop before the first mutation** by default.
+A dependency used by only one optional branch may degrade instead — say which,
+and say what the run does without it.
+
+## Template to emit into the authored skill
+
+Copy this into the skill being authored, replacing `<skill-name>` with each real
+dependency. Keep it above the first step that writes, commits, or publishes.
+
+````markdown
+## Dependency Preflight (mandatory)
+
+This skill invokes `<skill-name>`. Verify it is installed **before** the first
+step that changes anything:
+
+```bash
+asm list --json | grep -q '"<skill-name>"' || {
+  echo "Missing required skill: <skill-name>" >&2
+  echo "Install it:      asm install <skill-name> --yes" >&2
+  echo "No asm yet:      npm install -g agent-skill-manager" >&2
+  echo "Verify:          asm list --json | grep '<skill-name>'" >&2
+  exit 1
+}
+```
+
+If the check fails, stop and print the three commands above — do not continue
+with a partial run.
+````
+
+Adapt the detection to what the host offers: `asm list --json` where `asm` is on
+PATH, otherwise a path test such as
+`test -f "$HOME/.claude/skills/<skill-name>/SKILL.md"`. The four elements are
+fixed; the mechanics are not.
+
+## Author-facing summary
+
+An author following this file without running either skill needs only this:
+
+1. Ask whether the skill invokes another skill.
+2. If it does, emit the template above, one entry per dependency, before the
+   first mutating step.
+3. Name the dependency, its install command, the installer's own install
+   command, and a verification command.
+4. If it does not, add nothing.

--- a/src/skills-authoring-contract.test.ts
+++ b/src/skills-authoring-contract.test.ts
@@ -65,6 +65,13 @@ describe("dependency preflight rule (#571)", () => {
     );
   });
 
+  it("skill-auto-improver carries the gate it enforces, for its own skill-creator dependency", () => {
+    expect(improverSkill).toContain("## Dependency Preflight (mandatory)");
+    expect(improverSkill).toContain("asm install skill-creator --yes");
+    expect(improverSkill).toContain("npm install -g agent-skill-manager");
+    expect(improverSkill).toContain("asm list --json | grep 'skill-creator'");
+  });
+
   it("the report template marks the preflight row conditional", () => {
     expect(improverReport).toContain("Dependency preflight");
     expect(improverReport).toMatch(/conditional/i);

--- a/src/skills-authoring-contract.test.ts
+++ b/src/skills-authoring-contract.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function readRepoFile(relPath: string): string {
+  return readFileSync(
+    fileURLToPath(new URL(`../${relPath}`, import.meta.url)),
+    "utf8",
+  );
+}
+
+const creatorSkill = readRepoFile("skills/skill-creator/SKILL.md");
+const creatorPreflight = readRepoFile(
+  "skills/skill-creator/references/dependency-preflight.md",
+);
+const improverSkill = readRepoFile("skills/skill-auto-improver/SKILL.md");
+const improverChecklist = readRepoFile(
+  "skills/skill-auto-improver/references/skill-creator-checklist.md",
+);
+const improverReport = readRepoFile(
+  "skills/skill-auto-improver/references/report-template.md",
+);
+
+const authoringSkills: Array<[string, string]> = [
+  ["skill-creator", creatorSkill],
+  ["skill-auto-improver", improverSkill],
+];
+
+describe("dependency preflight rule (#571)", () => {
+  it("skill-creator establishes skill dependencies during the interview", () => {
+    expect(creatorSkill).toContain(
+      "## Mandatory Rule for Skills That Invoke Other Skills",
+    );
+    expect(creatorSkill).toContain("Does this skill invoke other skills?");
+    expect(creatorSkill).toContain("references/dependency-preflight.md");
+  });
+
+  it.each([
+    ["skill-creator reference", creatorPreflight],
+    ["skill-auto-improver checklist", improverChecklist],
+  ])("%s documents all four preflight elements", (_name, doc) => {
+    expect(doc).toContain("## Dependency Preflight (mandatory)");
+    expect(doc).toContain("asm install <skill-name> --yes");
+    expect(doc).toContain("npm install -g agent-skill-manager");
+    expect(doc).toMatch(/verif/i);
+  });
+
+  it("skill-auto-improver reports a missing gate as a Gate 1 finding", () => {
+    expect(improverSkill).toMatch(
+      /If the target skill invokes another skill\*\*, it carries a dependency preflight/,
+    );
+    expect(improverSkill).toContain(
+      "Skill invokes another skill with no preflight gate",
+    );
+  });
+
+  it.each([
+    ["skill-creator", creatorSkill],
+    ["skill-creator reference", creatorPreflight],
+    ["skill-auto-improver", improverSkill],
+    ["skill-auto-improver checklist", improverChecklist],
+  ])("%s leaves a skill with no dependencies untouched", (_name, doc) => {
+    expect(doc).toMatch(
+      /empty\s+preflight|no such section|nothing is added|add nothing/i,
+    );
+  });
+
+  it("the report template marks the preflight row conditional", () => {
+    expect(improverReport).toContain("Dependency preflight");
+    expect(improverReport).toMatch(/conditional/i);
+  });
+});
+
+describe("run stats block (#572)", () => {
+  it.each(authoringSkills)("%s defines the run-stats block", (_name, doc) => {
+    expect(doc).toContain("## Run stats (mandatory)");
+    expect(doc).toMatch(/Run stats {3}elapsed /);
+  });
+
+  it.each(authoringSkills)("%s reports every required figure", (_name, doc) => {
+    const block = doc.slice(doc.indexOf("## Run stats (mandatory)"));
+    for (const field of [
+      "`elapsed`",
+      "`tokens`",
+      "`cost`",
+      "`agents`",
+      "`skills`",
+      "`tool calls`",
+    ]) {
+      expect(block).toContain(field);
+    }
+  });
+
+  it.each(authoringSkills)(
+    "%s omits or marks unavailable figures instead of inventing them",
+    (_name, doc) => {
+      const block = doc.slice(doc.indexOf("## Run stats (mandatory)"));
+      expect(block).toMatch(
+        /omitted entirely when the host reported no figure/,
+      );
+      expect(block).toContain("prints the literal `n/a`");
+      expect(block).toContain(
+        "A missing optional figure never suppresses the rest of the block.",
+      );
+    },
+  );
+
+  it("skill-creator prints run stats on every create/update path", () => {
+    const block = creatorSkill.slice(
+      creatorSkill.indexOf("## Run stats (mandatory)"),
+    );
+    expect(block).toContain("Path A, Subpath B1, and Subpath B2");
+  });
+
+  it("skill-auto-improver prints run stats at every terminal outcome", () => {
+    const block = improverSkill.slice(
+      improverSkill.indexOf("## Run stats (mandatory)"),
+    );
+    expect(block).toMatch(/every\*\* terminal outcome/);
+    expect(block).toContain("BLOCKER");
+  });
+});
+
+describe("authoring skills stay within the skill-creator standard", () => {
+  it.each(authoringSkills)("%s body is under 500 lines", (_name, doc) => {
+    expect(doc.split("\n").length).toBeLessThan(500);
+  });
+});

--- a/src/skills-authoring-contract.test.ts
+++ b/src/skills-authoring-contract.test.ts
@@ -40,9 +40,9 @@ describe("dependency preflight rule (#571)", () => {
     ["skill-auto-improver checklist", improverChecklist],
   ])("%s documents all four preflight elements", (_name, doc) => {
     expect(doc).toContain("## Dependency Preflight (mandatory)");
-    expect(doc).toContain("asm install <skill-name> --yes");
+    expect(doc).toContain("asm install <skill-name> -p <tool> --yes");
     expect(doc).toContain("npm install -g agent-skill-manager");
-    expect(doc).toMatch(/verif/i);
+    expect(doc).toContain("asm list -p <tool> --json | grep '<skill-name>'");
   });
 
   it("skill-auto-improver reports a missing gate as a Gate 1 finding", () => {
@@ -67,9 +67,13 @@ describe("dependency preflight rule (#571)", () => {
 
   it("skill-auto-improver carries the gate it enforces, for its own skill-creator dependency", () => {
     expect(improverSkill).toContain("## Dependency Preflight (mandatory)");
-    expect(improverSkill).toContain("asm install skill-creator --yes");
+    expect(improverSkill).toContain(
+      "asm install skill-creator -p claude --yes",
+    );
     expect(improverSkill).toContain("npm install -g agent-skill-manager");
-    expect(improverSkill).toContain("asm list --json | grep 'skill-creator'");
+    expect(improverSkill).toContain(
+      "asm list -p claude --json | grep 'skill-creator'",
+    );
   });
 
   it("the report template marks the preflight row conditional", () => {


### PR DESCRIPTION
## Summary

Two changes to the same two authoring skills, made as one pass because they touch the same files.

- **Dependency preflight (#571)** — `skill-creator` now establishes, in the interview, whether the skill being authored invokes another skill. When it does, the skill it produces ships a `## Dependency Preflight (mandatory)` section above its first mutating step, naming each dependency, its install command, the command that installs the installer itself (`npm install -g agent-skill-manager`), and a verification command. When it does not, nothing is added — no empty section, no placeholder. `skill-auto-improver` audits for the same rule and reports a skill that invokes another skill without a gate (or with one that never explains installation) as a Gate 1 finding.
- **Run stats (#572)** — both skills close every create/update run with a run-stats block: `elapsed`, `agents`, `skills`, and `tool calls` always present (`n/a` when undetermined, `0` when determined-zero), `tokens` and `cost` printed only where the host reported a figure and omitted entirely otherwise. A missing optional figure never suppresses the rest of the block. The shape follows the established Run Stats Footer contract in the IDD skill family (two lines, `┄` separator, ` · ` between fields) extended with the fields this issue asks for.

## Approach

The rule has one home per skill and a pointer everywhere else, per the progressive-disclosure standard both skills enforce:

- `skills/skill-creator/references/dependency-preflight.md` (new) — when the gate is required, the four elements it must name, the copyable template, and an author-facing summary so the rule can be followed without running either skill.
- `skills/skill-auto-improver/references/skill-creator-checklist.md` §8 — the same rule as an audit item, self-contained so the auditor does not depend on an installed skill-creator to apply it.
- Run stats are documented inline in both `SKILL.md` bodies — universal material printed on every run, so it does not belong behind a pointer.

Both `SKILL.md` bodies stay well under the 500-line cap (291 and 332). `metadata.version` bumped 1.13.2 → 1.14.0 and 1.3.0 → 1.4.0 (new sections = minor).

## Changes

| File | Change |
|------|--------|
| `skills/skill-creator/SKILL.md` | Mandatory dependency rule, Capture Intent question 6, `Dependency preflight` step check, Subpath B1 inspection item, `## Run stats (mandatory)`, version bump |
| `skills/skill-creator/references/dependency-preflight.md` | New — the rule, the four elements, the template, author-facing summary |
| `skills/skill-creator/docs/README.md` | Two highlights |
| `skills/skill-auto-improver/SKILL.md` | Gate 1 conditional check, Phase 2 fix pattern, `RUN_STARTED_EPOCH` capture, `## Run stats (mandatory)`, two acceptance criteria, version bump |
| `skills/skill-auto-improver/references/skill-creator-checklist.md` | New §8 dependency preflight (final mechanical check renumbered to §9) |
| `skills/skill-auto-improver/references/report-template.md` | Conditional Gate 1 row plus the run-stats block in the report layout |
| `skills/skill-auto-improver/docs/README.md` | Two highlights |
| `src/skills-authoring-contract.test.ts` | New — 19 guard tests over both contracts |

## Test Results

- `CI=true npm test` — 2538 passed, 78 files (19 new).
- `npm run lint` — clean.
- `npm run typecheck` — 10 pre-existing errors in `src/commands/stats.test.ts`, untouched by this branch and unrelated to it.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 571-1 | skill-creator establishes whether the skill invokes other skills; output carries a gate | met | Capture Intent Q6 + *Mandatory Rule for Skills That Invoke Other Skills* |
| 571-2 | Gate names dependency, install command, installer bootstrap, verification | met | `references/dependency-preflight.md` element table + template |
| 571-3 | skill-auto-improver reports a missing gate as a finding | met | Gate 1 bullet, Phase 2 fix pattern, checklist §8, report row |
| 571-4 | Skill with no dependencies unaffected — no empty section | met | Stated in the rule, the reference, the checklist, and the report note |
| 571-5 | Both skills document the rule for an author not running them | met | *Author-facing summary* + checklist §8 + both READMEs |
| 572-1 | skill-creator summary includes run stats | met | `## Run stats (mandatory)` in `skill-creator/SKILL.md` |
| 572-2 | skill-auto-improver summary includes the same stats | met | `## Run stats (mandatory)` in `skill-auto-improver/SKILL.md` |
| 572-3 | Total time; tokens/cost when available; agents, skills, tool calls | met | Field table in both skills |
| 572-4 | Missing optional figures not invented, rest of block preserved | met | Omission rule + `n/a` rule + explicit non-suppression line |
| 572-5 | Present on every successful create/update path | met | Path A / B1 / B2 named in skill-creator; every terminal outcome in skill-auto-improver |

Closes #571
Closes #572

Made with [Cursor](https://cursor.com)