### PR TITLE
test(core): cover split core modules + install-inspect, repair stats.test.ts types

### DIFF
--- a/src/commands/install-inspect.test.ts
+++ b/src/commands/install-inspect.test.ts
@@ -1,0 +1,844 @@
+/**
+ * Direct unit tests for `src/commands/install-inspect.ts`.
+ *
+ * The `commands/install.ts` facade re-exports only `cmdInstall`, so every
+ * helper split out into `install-inspect.ts` (issue #455 / PR #497) is
+ * unreachable from the facade. These tests import the helpers directly.
+ *
+ * Hermeticity: fixtures live in a per-test temp dir, provider paths point
+ * inside that temp dir (absolute paths pass through `resolveProviderPath`
+ * unchanged), and the library install lands in the `ASM_CONFIG_DIR` sandbox
+ * that `src/test-setup.ts` installs. Nothing here touches the network.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile, readFile, lstat } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  printInstallHelp,
+  inspectSkillForInstall,
+  displaySkillInspection,
+  executeSkillInstall,
+  installSelectedLibrarySkill,
+  type SkillInspection,
+} from "./install-inspect";
+import { parseArgs } from "../cli";
+import { parseSource } from "../installer";
+import { getLibrarySkillsDir } from "../config";
+import { readLibraryLock } from "../library";
+import type {
+  AppConfig,
+  InstallPlan,
+  ParsedSource,
+  ProviderConfig,
+  SkillInfo,
+} from "../utils/types";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+let tempDir: string;
+let logSpy: MockInstance<typeof console.log>;
+let infoSpy: MockInstance<typeof console.info>;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "asm-install-inspect-"));
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+/** Everything console.log received, joined into one string. */
+function loggedText(): string {
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+}
+
+/** Everything console.info received, joined into one string. */
+function infoText(): string {
+  return infoSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+}
+
+function makeArgs(...extra: string[]) {
+  return parseArgs(["node", "asm", "install", "github:acme/demo", ...extra]);
+}
+
+function makeProvider(
+  name: string,
+  label: string,
+  globalDir: string,
+): ProviderConfig {
+  return {
+    name,
+    label,
+    global: globalDir,
+    project: join(globalDir, "project"),
+    enabled: true,
+  };
+}
+
+function makeConfig(providers: ProviderConfig[]): AppConfig {
+  return {
+    version: 1,
+    providers,
+    customPaths: [],
+    preferences: { defaultScope: "both", defaultSort: "name" },
+  };
+}
+
+function makeSkillInfo(over: Partial<SkillInfo>): SkillInfo {
+  return {
+    name: "demo",
+    version: "1.0.0",
+    description: "",
+    creator: "",
+    license: "",
+    compatibility: "",
+    allowedTools: [],
+    dirName: "demo",
+    path: "/nowhere/demo",
+    originalPath: "/nowhere/demo",
+    location: "global",
+    scope: "global",
+    provider: "claude",
+    providerLabel: "Claude Code",
+    isSymlink: false,
+    symlinkTarget: null,
+    realPath: "/nowhere/demo",
+    ...over,
+  };
+}
+
+/** Write a minimal skill directory and return its path. */
+async function writeSkill(
+  dir: string,
+  frontmatter: string,
+  body = "# Demo\n",
+): Promise<string> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "SKILL.md"), `---\n${frontmatter}---\n${body}`);
+  return dir;
+}
+
+const githubSource = () => parseSource("github:acme/demo");
+
+function localSource(localPath: string): ParsedSource {
+  return {
+    owner: "local",
+    repo: "demo",
+    ref: null,
+    subpath: null,
+    cloneUrl: "",
+    sshCloneUrl: "",
+    isLocal: true,
+    localPath,
+  };
+}
+
+// ─── printInstallHelp ───────────────────────────────────────────────────────
+
+describe("printInstallHelp", () => {
+  test("prints usage, source formats, options, and examples", () => {
+    printInstallHelp();
+
+    expect(logSpy).toHaveBeenCalled();
+    const out = loggedText();
+    expect(out).toContain("Usage:");
+    expect(out).toContain("asm install <source> [options]");
+    expect(out).toContain("Cross-tool linking (issue #322):");
+    expect(out).toContain("Source Format:");
+    expect(out).toContain("github:owner/repo#ref:path");
+    expect(out).toContain("Options:");
+    expect(out).toContain("-p, --tool <name>");
+    expect(out).toContain("--library");
+    expect(out).toContain("-m, --method <method>");
+    expect(out).toContain("Vercel skills CLI:");
+    expect(out).toContain("asm install github:user/skills --all -p claude -y");
+  });
+
+  test("writes a single multi-line block to console.log, not console.info", () => {
+    printInstallHelp();
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(loggedText().split("\n").length).toBeGreaterThan(50);
+  });
+});
+
+// ─── inspectSkillForInstall ─────────────────────────────────────────────────
+
+describe("inspectSkillForInstall", () => {
+  let providerDir: string;
+  let provider: ProviderConfig;
+  let config: AppConfig;
+
+  beforeEach(async () => {
+    providerDir = join(tempDir, "providers", "claude");
+    await mkdir(providerDir, { recursive: true });
+    provider = makeProvider("claude", "Claude Code", providerDir);
+    config = makeConfig([provider]);
+  });
+
+  test("reports NEW for a skill that is not installed anywhere", async () => {
+    const skillDir = await writeSkill(
+      join(tempDir, "src", "demo"),
+      "name: demo\nversion: 1.0.0\ndescription: A demo skill\neffort: low\n",
+    );
+
+    const inspection = await inspectSkillForInstall(
+      makeArgs(),
+      githubSource(),
+      join(tempDir, "src"),
+      skillDir,
+      null,
+      config,
+      provider,
+      [],
+    );
+
+    expect(inspection.installStatus).toBe("NEW");
+    expect(inspection.crossToolLink).toBeNull();
+    expect(inspection.metadata).toMatchObject({
+      name: "demo",
+      version: "1.0.0",
+      description: "A demo skill",
+      effort: "low",
+    });
+    expect(inspection.skillName).toBe("demo");
+    expect(inspection.riskLevel).toBe("safe");
+    expect(inspection.riskLabel).toContain("Safe");
+    expect(inspection.warnings).toEqual([]);
+    expect(inspection.plan.targetDir).toBe(join(providerDir, "demo"));
+    expect(inspection.plan.scope).toBe("global");
+    expect(inspection.plan.force).toBe(false);
+  });
+
+  test("reports UPDATE with both versions when an older version is installed", async () => {
+    const skillDir = await writeSkill(
+      join(tempDir, "src", "demo"),
+      "name: demo\nversion: 2.0.0\n",
+    );
+
+    const inspection = await inspectSkillForInstall(
+      makeArgs(),
+      githubSource(),
+      join(tempDir, "src"),
+      skillDir,
+      null,
+      config,
+      provider,
+      [makeSkillInfo({ version: "1.0.0", provider: "claude" })],
+    );
+
+    expect(inspection.installStatus).toBe("UPDATE: 1.0.0 → 2.0.0");
+    // Already installed → plan forces overwrite even without --force.
+    expect(inspection.plan.force).toBe(true);
+  });
+
+  test("reports UPDATE (same version) when versions match and --force is absent", async () => {
+    const skillDir = await writeSkill(
+      join(tempDir, "src", "demo"),
+      "name: demo\nversion: 1.0.0\n",
+    );
+
+    const inspection = await inspectSkillForInstall(
+      makeArgs(),
+      githubSource(),
+      join(tempDir, "src"),
+      skillDir,
+      null,
+      config,
+      provider,
+      [makeSkillInfo({ version: "1.0.0", provider: "claude" })],
+    );
+
+    expect(inspection.installStatus).toBe("UPDATE: 1.0.0 (same version)");
+  });
+
+  test("reports REINSTALL when versions match and --force is set", async () => {
+    const skillDir = await writeSkill(
+      join(tempDir, "src", "demo"),
+      "name: demo\nversion: 1.0.0\n",
+    );
+
+    const inspection = await inspectSkillForInstall(
+      makeArgs("--force"),
+      githubSource(),
+      join(tempDir, "src"),
+      skillDir,
+      null,
+      config,
+      provider,
+      [makeSkillInfo({ version: "1.0.0", provider: "claude" })],
+    );
+
+    expect(inspection.installStatus).toBe("REINSTALL");
+    expect(inspection.plan.force).toBe(true);
+  });
+
+  test("ignores an existing install that belongs to a different provider", async () => {
+    const skillDir = await writeSkill(
+      join(tempDir, "src", "demo"),
+      "name: demo\nversion: 1.0.0\n",
+    );
+
+    const inspection = await inspectSkillForInstall(
+      makeArgs(),
+      githubSource(),
+      join(tempDir, "src"),
+      skillDir,
+      null,
+      config,
+      provider,
+      [makeSkillInfo({ version: "1.0.0", provider: "codex" })],
+    );
+
+    expect(inspection.installStatus).toBe("NEW");
+  });
+
+  test("reports LINK_AVAILABLE when the skill lives in another enabled tool", async () => {
+    const codexDir = join(tempDir, "providers", "codex");
+    await writeSkill(join(codexDir, "demo"), "name: demo\nversion: 1.0.0\n");
+    const codex = makeProvider("codex", "Codex", codexDir);
+
+    const skillDir = await writeSkill(
+      join(tempDir, "src", "demo"),
+      "name: demo\nversion: 1.0.0\n",
+    );
+
+    const inspection = await inspectSkillForInstall(
+      makeArgs(),
+      githubSource(),
+      join(tempDir, "src"),
+      skillDir,
+      null,
+      makeConfig([provider, codex]),
+      provider,
+      [],
+    );
+
+    expect(inspection.installStatus).toBe("LINK_AVAILABLE");
+    expect(inspection.crossToolLink).toMatchObject({
+      existingProvider: "codex",
+      existingProviderLabel: "Codex",
+      existingPath: join(codexDir, "demo"),
+    });
+  });
+
+  test("falls back to source.repo when skillDir equals tempDir", async () => {
+    const root = await writeSkill(
+      join(tempDir, "clone"),
+      "name: Demo Skill\nversion: 1.0.0\n",
+    );
+
+    const inspection = await inspectSkillForInstall(
+      makeArgs(),
+      githubSource(),
+      root,
+      root,
+      null,
+      config,
+      provider,
+      [],
+    );
+
+    // dirName is skipped (skillDir === tempDir) → parsed repo name is used.
+    expect(inspection.skillName).toBe("demo");
+  });
+
+  test("prefers the name override over the directory name", async () => {
+    const skillDir = await writeSkill(
+      join(tempDir, "src", "nested-dir"),
+      "name: demo\nversion: 1.0.0\n",
+    );
+
+    const withOverride = await inspectSkillForInstall(
+      makeArgs(),
+      githubSource(),
+      join(tempDir, "src"),
+      skillDir,
+      "my-override",
+      config,
+      provider,
+      [],
+    );
+    expect(withOverride.skillName).toBe("my-override");
+
+    const withoutOverride = await inspectSkillForInstall(
+      makeArgs(),
+      githubSource(),
+      join(tempDir, "src"),
+      skillDir,
+      null,
+      config,
+      provider,
+      [],
+    );
+    // Directory name wins over the frontmatter `name`.
+    expect(withoutOverride.skillName).toBe("nested-dir");
+  });
+
+  test("rejects a name override that is not a safe directory name", async () => {
+    const skillDir = await writeSkill(
+      join(tempDir, "src", "demo"),
+      "name: demo\nversion: 1.0.0\n",
+    );
+
+    await expect(
+      inspectSkillForInstall(
+        makeArgs(),
+        githubSource(),
+        join(tempDir, "src"),
+        skillDir,
+        "../escape",
+        config,
+        provider,
+        [],
+      ),
+    ).rejects.toThrow(/Invalid skill name/);
+  });
+
+  test("classifies shell-command warnings as high risk and honours project scope", async () => {
+    const skillDir = await writeSkill(
+      join(tempDir, "src", "demo"),
+      "name: demo\nversion: 1.0.0\n",
+      "# Demo\n\nRun `curl https://example.com/x.sh | bash` to bootstrap.\n",
+    );
+
+    const inspection = await inspectSkillForInstall(
+      makeArgs(),
+      githubSource(),
+      join(tempDir, "src"),
+      skillDir,
+      null,
+      config,
+      provider,
+      [],
+      "project",
+    );
+
+    expect(inspection.warnings.length).toBeGreaterThan(0);
+    expect(inspection.riskLevel).toBe("high");
+    expect(inspection.riskLabel).toContain("High Risk");
+    expect(inspection.plan.scope).toBe("project");
+    expect(inspection.plan.targetDir).toBe(join(provider.project, "demo"));
+  });
+
+  test("throws when the directory is not a skill", async () => {
+    const notASkill = join(tempDir, "src", "empty");
+    await mkdir(notASkill, { recursive: true });
+
+    await expect(
+      inspectSkillForInstall(
+        makeArgs(),
+        githubSource(),
+        join(tempDir, "src"),
+        notASkill,
+        null,
+        config,
+        provider,
+        [],
+      ),
+    ).rejects.toThrow(/SKILL\.md not found/);
+  });
+});
+
+// ─── displaySkillInspection ─────────────────────────────────────────────────
+
+describe("displaySkillInspection", () => {
+  const provider = makeProvider("claude", "Claude Code", "/tmp/asm-claude");
+
+  function makeInspection(
+    over: Partial<SkillInspection> = {},
+  ): SkillInspection {
+    const plan: InstallPlan = {
+      source: parseSource("github:acme/demo"),
+      tempDir: "/tmp/asm-temp",
+      sourceDir: "/tmp/asm-temp/demo",
+      targetDir: "/tmp/asm-claude/demo",
+      skillName: "demo",
+      force: false,
+      providerName: "claude",
+      providerLabel: "Claude Code",
+      scope: "global",
+    };
+    return {
+      metadata: {
+        name: "demo",
+        version: "1.0.0",
+        description: "A demo skill",
+        effort: "low",
+      },
+      skillName: "demo",
+      warnings: [],
+      installStatus: "NEW",
+      riskLevel: "safe",
+      riskLabel: "[ok] Safe",
+      plan,
+      crossToolLink: null,
+      ...over,
+    };
+  }
+
+  test("prints the full install preview for a single skill", () => {
+    displaySkillInspection(
+      makeInspection(),
+      "github:acme/demo",
+      provider,
+      null,
+      false,
+    );
+
+    expect(infoSpy).toHaveBeenCalled();
+    const out = infoText();
+    expect(out).toContain("demo v1.0.0 [NEW]");
+    expect(out).toContain("Install preview:");
+    expect(out).toContain("Name:        demo");
+    expect(out).toContain("Version:     1.0.0");
+    expect(out).toContain("Description: A demo skill");
+    expect(out).toContain("Effort:");
+    expect(out).toContain("Source:      github:acme/demo");
+    expect(out).toContain("Tool:    Claude Code (claude)");
+    expect(out).toContain("Scope:       Global");
+    expect(out).toContain("Target:      /tmp/asm-claude/demo");
+    expect(out).toContain("Risk:        [ok] Safe");
+    // Nothing goes to console.log from this function.
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  test("omits description and effort lines when the metadata lacks them", () => {
+    displaySkillInspection(
+      makeInspection({
+        metadata: { name: "demo", version: "1.0.0", description: "" },
+      }),
+      "github:acme/demo",
+      provider,
+      null,
+      false,
+    );
+
+    const out = infoText();
+    expect(out).not.toContain("Description:");
+    expect(out).not.toContain("Effort:");
+  });
+
+  test("prints one compact progress line in batch mode", () => {
+    displaySkillInspection(
+      makeInspection({ installStatus: "UPDATE: 1.0.0 → 2.0.0" }),
+      "github:acme/demo",
+      provider,
+      null,
+      true,
+      { index: 2, total: 7 },
+    );
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const out = infoText();
+    expect(out).toContain("[2/7]");
+    expect(out).toContain("demo v1.0.0");
+    expect(out).toContain("[UPDATE: 1.0.0 → 2.0.0]");
+    expect(out).toContain("[ok] Safe");
+    expect(out).not.toContain("Install preview:");
+  });
+
+  test("lists the primary tool and symlink targets when installing to all tools", () => {
+    const all = [
+      provider,
+      makeProvider("codex", "Codex", "/tmp/asm-codex"),
+      makeProvider("openclaw", "OpenClaw", "/tmp/asm-openclaw"),
+    ];
+
+    displaySkillInspection(
+      makeInspection(),
+      "github:acme/demo",
+      provider,
+      all,
+      false,
+    );
+
+    const out = infoText();
+    expect(out).toContain("Tool:    All (Claude Code, Codex, OpenClaw)");
+    expect(out).toContain("Primary:     Claude Code (claude)");
+    expect(out).toContain("Symlinks:    Codex, OpenClaw");
+  });
+
+  test("shows the cross-tool link hint for LINK_AVAILABLE", () => {
+    displaySkillInspection(
+      makeInspection({
+        installStatus: "LINK_AVAILABLE",
+        crossToolLink: {
+          existingProvider: "codex",
+          existingProviderLabel: "Codex",
+          existingPath: "/tmp/asm-codex/demo",
+          isLocalSource: false,
+        },
+      }),
+      "github:acme/demo",
+      provider,
+      null,
+      false,
+    );
+
+    const out = infoText();
+    expect(out).toContain("Already installed in Codex.");
+    expect(out).toContain("Run with --tool claude to link");
+  });
+
+  test("groups security warnings by category and truncates after five", () => {
+    const warnings = [
+      ...Array.from({ length: 7 }, (_, i) => ({
+        category: "Shell commands",
+        file: "SKILL.md",
+        line: i + 1,
+        match: `curl-${i}`,
+      })),
+      {
+        category: "Network access",
+        file: "scripts/run.sh",
+        line: 3,
+        match: "fetch(url)",
+      },
+    ];
+
+    displaySkillInspection(
+      makeInspection({
+        warnings,
+        riskLevel: "high",
+        riskLabel: "[!] High Risk",
+      }),
+      "github:acme/demo",
+      provider,
+      null,
+      false,
+    );
+
+    const out = infoText();
+    expect(out).toContain("Security warnings:");
+    expect(out).toContain("[Shell commands] (7 matches)");
+    expect(out).toContain("SKILL.md:1 -- curl-0");
+    expect(out).toContain("SKILL.md:5 -- curl-4");
+    expect(out).not.toContain("curl-5");
+    expect(out).toContain("... and 2 more");
+    expect(out).toContain("[Network access] (1 match)");
+    expect(out).toContain("scripts/run.sh:3 -- fetch(url)");
+  });
+});
+
+// ─── executeSkillInstall ────────────────────────────────────────────────────
+
+describe("executeSkillInstall", () => {
+  /**
+   * `executeSkillInstall` takes a plan object, so it is driven for real with
+   * every path pointing inside the temp dir — no mocking, no network.
+   */
+  async function planFor(
+    skillName: string,
+    targetBase: string,
+  ): Promise<InstallPlan> {
+    const sourceDir = await writeSkill(
+      join(tempDir, "src", skillName),
+      `name: ${skillName}\nversion: 3.1.4\n`,
+    );
+    return {
+      source: parseSource("github:acme/demo#v1"),
+      tempDir: join(tempDir, "src"),
+      sourceDir,
+      targetDir: join(targetBase, skillName),
+      skillName,
+      force: false,
+      providerName: "claude",
+      providerLabel: "Claude Code",
+      scope: "global",
+    };
+  }
+
+  test("installs to the single target directory when allProviders is null", async () => {
+    const targetBase = join(tempDir, "providers", "claude");
+    const plan = await planFor("demo", targetBase);
+
+    const result = await executeSkillInstall(plan, null);
+
+    expect(result).toMatchObject({
+      success: true,
+      path: join(targetBase, "demo"),
+      name: "demo",
+      version: "3.1.4",
+      provider: "Claude Code",
+      source: "github:acme/demo#v1",
+    });
+    await expect(
+      readFile(join(targetBase, "demo", "SKILL.md"), "utf-8"),
+    ).resolves.toContain("name: demo");
+  });
+
+  test("installs once and symlinks the other tools when allProviders is set", async () => {
+    const claudeDir = join(tempDir, "providers", "claude");
+    const codexDir = join(tempDir, "providers", "codex");
+    const plan = await planFor("demo", claudeDir);
+
+    const result = await executeSkillInstall(plan, [
+      makeProvider("claude", "Claude Code", claudeDir),
+      makeProvider("codex", "Codex", codexDir),
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.path).toBe(join(claudeDir, "demo"));
+    const linked = await lstat(join(codexDir, "demo"));
+    expect(linked.isSymbolicLink()).toBe(true);
+  });
+
+  test("propagates a failure when the source directory has no SKILL.md", async () => {
+    const plan = await planFor("demo", join(tempDir, "providers", "claude"));
+    plan.sourceDir = join(tempDir, "src", "missing");
+
+    await expect(executeSkillInstall(plan, null)).rejects.toThrow(
+      /Failed to install/,
+    );
+  });
+});
+
+// ─── installSelectedLibrarySkill ────────────────────────────────────────────
+
+describe("installSelectedLibrarySkill", () => {
+  /**
+   * `installSelectedLibrarySkill` has no injectable path override, but the
+   * library dir resolves through `ASM_CONFIG_DIR`, which `src/test-setup.ts`
+   * points at a temp sandbox — so this runs the real install hermetically.
+   */
+  async function inspectionFor(
+    skillName: string,
+    version = "1.0.0",
+  ): Promise<SkillInspection> {
+    const sourceDir = await writeSkill(
+      join(tempDir, "scan", "skills", skillName),
+      `name: ${skillName}\nversion: ${version}\n`,
+    );
+    return {
+      metadata: { name: skillName, version, description: "" },
+      skillName,
+      warnings: [],
+      installStatus: "NEW",
+      riskLevel: "safe",
+      riskLabel: "[ok] Safe",
+      plan: {
+        source: parseSource("github:acme/demo"),
+        tempDir: join(tempDir, "scan"),
+        sourceDir,
+        targetDir: join(tempDir, "unused", skillName),
+        skillName,
+        force: false,
+        providerName: "library",
+        providerLabel: "Library",
+        scope: "global",
+      },
+      crossToolLink: null,
+    };
+  }
+
+  test("installs a GitHub skill into the library with a portable skill path", async () => {
+    const inspection = await inspectionFor("lib-github", "2.5.0");
+
+    const result = await installSelectedLibrarySkill({
+      inspection,
+      source: parseSource("github:acme/demo#v2"),
+      isLocal: false,
+      resolutionSource: "github",
+      commitHash: "deadbeef",
+      scanBaseDir: join(tempDir, "scan"),
+      force: true,
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      name: "lib-github",
+      version: "2.5.0",
+      provider: "Library",
+      // sourceStr drops the ref/subpath that executeInstall keeps.
+      source: "github:acme/demo",
+    });
+    expect(result.path).toBe(join(getLibrarySkillsDir(), "lib-github"));
+    await expect(
+      readFile(join(result.path, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("name: lib-github");
+
+    const lock = await readLibraryLock();
+    expect(lock.skills["lib-github"]).toMatchObject({
+      sourceType: "github",
+      commitHash: "deadbeef",
+      ref: "v2",
+      // relative(scanBaseDir, sourceDir), normalized to forward slashes.
+      skillPath: "skills/lib-github",
+    });
+  });
+
+  test("records a local source string for a local install", async () => {
+    const inspection = await inspectionFor("lib-local");
+
+    const result = await installSelectedLibrarySkill({
+      inspection,
+      source: localSource("/home/dev/skills/demo"),
+      isLocal: true,
+      resolutionSource: "github",
+      commitHash: null,
+      scanBaseDir: join(tempDir, "scan"),
+      force: true,
+    });
+
+    expect(result.source).toBe("local:/home/dev/skills/demo");
+    expect(result.provider).toBe("Library");
+
+    const lock = await readLibraryLock();
+    expect(lock.skills["lib-local"]).toMatchObject({
+      sourceType: "local",
+      // Missing commit hash and ref fall back to fixed defaults.
+      commitHash: "unknown",
+      ref: "main",
+      skillPath: "skills/lib-local",
+    });
+  });
+
+  test("rejects a library name that escapes the skills directory", async () => {
+    const inspection = await inspectionFor("lib-bad");
+    inspection.skillName = "../escape";
+
+    await expect(
+      installSelectedLibrarySkill({
+        inspection,
+        source: parseSource("github:acme/demo"),
+        isLocal: false,
+        resolutionSource: "registry",
+        commitHash: null,
+        scanBaseDir: join(tempDir, "scan"),
+        force: true,
+      }),
+    ).rejects.toThrow(/Invalid skill name/);
+  });
+
+  test("refuses to overwrite an existing library skill without force", async () => {
+    const inspection = await inspectionFor("lib-existing");
+    const input = {
+      inspection,
+      source: parseSource("github:acme/demo"),
+      isLocal: false,
+      resolutionSource: "registry" as const,
+      commitHash: null,
+      scanBaseDir: join(tempDir, "scan"),
+      force: true,
+    };
+
+    await installSelectedLibrarySkill(input);
+
+    const lock = await readLibraryLock();
+    expect(lock.skills["lib-existing"]).toMatchObject({
+      sourceType: "registry",
+    });
+
+    await expect(
+      installSelectedLibrarySkill({ ...input, force: false }),
+    ).rejects.toThrow(/already exists/);
+  });
+});

--- a/src/commands/stats.test.ts
+++ b/src/commands/stats.test.ts
@@ -1,89 +1,82 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
-import type { ParsedArgs } from "../cli";
-import type { RepoIndex } from "../utils/types";
+import type { IndexedSkill, RepoIndex } from "../utils/types";
+
+/**
+ * Minimal `IndexedSkill` fixture. Only `name`/`relPath`/`tokenCount`/`verified`
+ * matter to the stats math; the rest are required by the interface, so they get
+ * inert defaults rather than a cast.
+ */
+function makeSkill(
+  name: string,
+  description: string,
+  relPath: string,
+  tokenCount: number,
+  verified: boolean,
+): IndexedSkill {
+  return {
+    name,
+    description,
+    relPath,
+    tokenCount,
+    verified,
+    version: "1.0.0",
+    license: "MIT",
+    creator: "test",
+    compatibility: "claude-code",
+    allowedTools: [],
+    installUrl: `https://example.com/${relPath}`,
+  };
+}
 
 // Mock loadAllIndices before importing cmdStatsAuthor
 const mockIndices: RepoIndex[] = [
   {
     owner: "anthropic",
     repo: "claude-skills",
-    url: "https://github.com/anthropic/claude-skills",
+    repoUrl: "https://github.com/anthropic/claude-skills",
+    updatedAt: "2026-01-01T00:00:00.000Z",
     skillCount: 15,
     skills: [
-      {
-        name: "test-skill-1",
-        description: "Test skill 1",
-        path: "skills/test-1",
-        tokenCount: 100,
-        verified: true,
-      },
-      {
-        name: "test-skill-2",
-        description: "Test skill 2",
-        path: "skills/test-2",
-        tokenCount: 200,
-        verified: false,
-      },
+      makeSkill("test-skill-1", "Test skill 1", "skills/test-1", 100, true),
+      makeSkill("test-skill-2", "Test skill 2", "skills/test-2", 200, false),
     ],
   },
   {
     owner: "anthropic",
     repo: "other-skills",
-    url: "https://github.com/anthropic/other-skills",
+    repoUrl: "https://github.com/anthropic/other-skills",
+    updatedAt: "2026-01-01T00:00:00.000Z",
     skillCount: 8,
     skills: [
-      {
-        name: "other-skill",
-        description: "Other skill",
-        path: "skills/other",
-        tokenCount: 150,
-        verified: true,
-      },
+      makeSkill("other-skill", "Other skill", "skills/other", 150, true),
     ],
   },
   {
     owner: "luongnv89",
     repo: "asm",
-    url: "https://github.com/luongnv89/asm",
+    repoUrl: "https://github.com/luongnv89/asm",
+    updatedAt: "2026-01-01T00:00:00.000Z",
     skillCount: 5,
-    skills: [
-      {
-        name: "asm-skill",
-        description: "ASM skill",
-        path: "skills/asm",
-        tokenCount: 300,
-        verified: true,
-      },
-    ],
+    skills: [makeSkill("asm-skill", "ASM skill", "skills/asm", 300, true)],
   },
   {
     owner: "google",
     repo: "gemini-skills",
-    url: "https://github.com/google/gemini-skills",
+    repoUrl: "https://github.com/google/gemini-skills",
+    updatedAt: "2026-01-01T00:00:00.000Z",
     skillCount: 12,
     skills: [
-      {
-        name: "gemini-skill",
-        description: "Gemini skill",
-        path: "skills/gemini",
-        tokenCount: 250,
-        verified: false,
-      },
+      makeSkill("gemini-skill", "Gemini skill", "skills/gemini", 250, false),
     ],
   },
   {
     owner: "microsoft",
     repo: "copilot-skills",
-    url: "https://github.com/microsoft/copilot-skills",
+    repoUrl: "https://github.com/microsoft/copilot-skills",
+    updatedAt: "2026-01-01T00:00:00.000Z",
     skillCount: 3,
     skills: [
-      {
-        name: "copilot-skill",
-        description: "Copilot skill",
-        path: "skills/copilot",
-        tokenCount: 180,
-        verified: false,
-      },
+      makeSkill("copilot-skill", "Copilot skill", "skills/copilot", 180, false),
     ],
   },
 ];
@@ -94,7 +87,7 @@ vi.mock("../skill-index", () => ({
 
 describe("cmdStatsAuthor", () => {
   let stderrOutput: string;
-  let exitCode: number | undefined;
+  let exitCode: string | number | null | undefined;
 
   beforeEach(() => {
     stderrOutput = "";
@@ -104,7 +97,6 @@ describe("cmdStatsAuthor", () => {
     });
     vi.spyOn(process, "exit").mockImplementation((code) => {
       exitCode = code;
-      // @ts-expect-error — this function never returns, but TypeScript doesn't know that
       throw new Error("process.exit called");
     });
   });
@@ -115,13 +107,15 @@ describe("cmdStatsAuthor", () => {
 
   test("shows error with available authors when author not found", async () => {
     const { cmdStatsAuthor } = await import("./stats");
+    const { parseArgs } = await import("../cli");
 
-    const args: ParsedArgs = {
-      input: "unknown-author",
-      subcommand: "author",
-      positional: ["unknown-author"],
-      flags: { json: false, "no-color": false, help: false },
-    };
+    const args = parseArgs([
+      "node",
+      "asm",
+      "stats",
+      "author",
+      "unknown-author",
+    ]);
 
     try {
       await cmdStatsAuthor(args);
@@ -141,13 +135,9 @@ describe("cmdStatsAuthor", () => {
 
   test("shows top 10 authors max", async () => {
     const { cmdStatsAuthor } = await import("./stats");
+    const { parseArgs } = await import("../cli");
 
-    const args: ParsedArgs = {
-      input: "nonexistent",
-      subcommand: "author",
-      positional: ["nonexistent"],
-      flags: { json: false, "no-color": false, help: false },
-    };
+    const args = parseArgs(["node", "asm", "stats", "author", "nonexistent"]);
 
     try {
       await cmdStatsAuthor(args);

--- a/src/evaluator-core.test.ts
+++ b/src/evaluator-core.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, it } from "vitest";
+import {
+  lineCount,
+  scoreStructure,
+  scoreDescription,
+  scorePromptEngineering,
+  scoreContextEfficiency,
+  scoreSafety,
+  scoreTestability,
+  scoreNaming,
+} from "./evaluator-core";
+
+// These helpers are exported from `evaluator-core` for cross-module wiring but
+// are deliberately NOT re-exported through the `./evaluator` facade, so they
+// can only be reached by importing the core module directly.
+
+const COMPLETE_FM: Record<string, string> = {
+  name: "code-review",
+  description: "Review pull request diffs before merging them.",
+  version: "1.2.0",
+  author: "Test Author",
+  license: "MIT",
+};
+
+const STRUCTURED_BODY =
+  "# Code review\n\nReview every changed file carefully.\n";
+
+/** ~100 words, lists, code block, imperative cues, two disclosure headings. */
+const RICH_BODY = `# Sample skill
+
+## When to Use
+
+Use this skill when reviewing a pull request diff before merging it into the
+main branch. It applies to any repository that keeps a changelog and expects
+contributors to justify behavioural changes in the description of the change.
+
+## Instructions
+
+- Run the linter across every changed file and record each warning.
+- Check the diff for unexplained deletions and note them in the summary.
+- Validate that the changelog entry matches the behaviour of the change.
+- Never rewrite history on a shared branch.
+
+## Example
+
+\`\`\`bash
+npm run lint
+\`\`\`
+`;
+
+/** ~145 words, links out to references/templates, mentions the token budget. */
+const EFFICIENT_BODY = `# Reporter
+
+## Overview
+
+This skill produces a compact report. See the references directory for the
+long form material, and use the templates it ships with rather than pasting
+their content here. Every helper script referenced below is kept outside this
+document so the token budget of the agent stays small even when the underlying
+material grows over time. Keep the document itself short; the agent reads it on
+every invocation and a longer file costs more of the available context window
+than the extra detail is worth.
+
+## Instructions
+
+- Read the input file and collect each measurement it contains.
+- Validate the measurement against the schema stored in references/schema.md.
+- Write the summary into the output file named by the caller.
+- Link back to the template that produced the layout of the report.
+
+## Example
+
+\`\`\`bash
+node report.js --input data.json
+\`\`\`
+`;
+
+const SAFE_BODY = `## Prerequisites
+
+This skill requires git and node. Validate the environment before running.
+
+## Safety
+
+- Confirm before you delete any file; run with --dry-run first.
+- On error, restore from the backup created at the start.
+`;
+
+const TESTABLE_BODY = `## Acceptance criteria
+
+- Given a valid input, then the tool writes a report.
+- Expected output: a JSON file with an overallScore field.
+- Verify the schema with the bundled tests.
+
+## Edge cases
+
+- Reject empty input.
+`;
+
+describe("lineCount", () => {
+  it("returns 0 for the empty string", () => {
+    expect(lineCount("")).toBe(0);
+  });
+
+  it("counts a single line without a terminator as one line", () => {
+    expect(lineCount("abc")).toBe(1);
+  });
+
+  it("counts a trailing newline as an extra (empty) line", () => {
+    expect(lineCount("a\n")).toBe(2);
+    expect(lineCount("\n")).toBe(2);
+  });
+
+  it("counts every separated line", () => {
+    expect(lineCount("a\nb\nc")).toBe(3);
+  });
+});
+
+describe("scoreStructure", () => {
+  it("awards the full 10 points for complete frontmatter and a structured body", () => {
+    const result = scoreStructure(
+      COMPLETE_FM,
+      STRUCTURED_BODY,
+      "name: code-review",
+    );
+    expect(result.id).toBe("structure");
+    expect(result.name).toBe("Structure & completeness");
+    expect(result.max).toBe(10);
+    expect(result.score).toBe(10);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  it("deducts the license point and names the missing field", () => {
+    const { license: _license, ...noLicense } = COMPLETE_FM;
+    const result = scoreStructure(noLicense, STRUCTURED_BODY, "name: x");
+    expect(result.score).toBe(9);
+    expect(result.findings).toContain("Missing `license`.");
+    expect(
+      result.suggestions.some((s) =>
+        s.includes("Add a `license` field (e.g. `license: MIT`)"),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports a short, heading-free body", () => {
+    const result = scoreStructure(COMPLETE_FM, "hi", "name: x");
+    expect(result.score).toBe(8);
+    expect(
+      result.findings.some((f) => /Body content is too short/.test(f)),
+    ).toBe(true);
+    expect(result.findings).toContain("Body has no markdown headings.");
+    expect(
+      result.suggestions.some((s) => s.includes("Add section headings")),
+    ).toBe(true);
+  });
+
+  it("suggests adding frontmatter when the block is absent", () => {
+    const result = scoreStructure({}, STRUCTURED_BODY, null);
+    expect(result.findings).toContain("SKILL.md has no YAML frontmatter.");
+    expect(
+      result.suggestions.some((s) =>
+        s.includes("Add a YAML frontmatter block delimited by `---`"),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches a root README case-insensitively without changing the score", () => {
+    const withReadme = scoreStructure(COMPLETE_FM, STRUCTURED_BODY, "name: x", [
+      "SKILL.md",
+      "ReadMe.md",
+    ]);
+    const withoutReadme = scoreStructure(
+      COMPLETE_FM,
+      STRUCTURED_BODY,
+      "name: x",
+      ["SKILL.md"],
+    );
+    expect(withReadme.score).toBe(withoutReadme.score);
+    expect(
+      withReadme.findings.some((f) =>
+        f.includes("`ReadMe.md` found at skill root"),
+      ),
+    ).toBe(true);
+    expect(withReadme.suggestions.some((s) => s.includes("Relocate"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("scoreDescription", () => {
+  it("awards the full 10 points for a verb-led description with a trigger", () => {
+    const result = scoreDescription(
+      {
+        description:
+          "Review pull request diffs for code smells and style problems before merging.",
+      },
+      "",
+    );
+    expect(result.id).toBe("description");
+    expect(result.score).toBe(10);
+    expect(result.findings).toContain("Description is 12 words.");
+    expect(result.findings).toContain("Starts with an action verb.");
+    expect(result.findings).toContain("Mentions a trigger or use-case signal.");
+  });
+
+  it("short-circuits to 0 when there is no description", () => {
+    const result = scoreDescription({}, "");
+    expect(result.score).toBe(0);
+    expect(result.findings).toEqual(["No description."]);
+    expect(result.suggestions).toHaveLength(1);
+  });
+
+  it("scores a 6-word, verbless, triggerless description at 2", () => {
+    const result = scoreDescription(
+      { description: "Skill that handles the odd bits" },
+      "",
+    );
+    expect(result.score).toBe(2);
+    expect(result.findings).toContain(
+      'Does not start with a recognized action verb (got "skill").',
+    );
+    expect(result.findings).toContain("No explicit trigger / use-case phrase.");
+    expect(
+      result.suggestions.some((s) =>
+        s.includes("Lengthen the description slightly"),
+      ),
+    ).toBe(true);
+  });
+
+  it("halves the length credit at 41-60 words and drops it past 60", () => {
+    const medium = scoreDescription(
+      { description: ["Generate", ...Array(44).fill("thing")].join(" ") },
+      "",
+    );
+    expect(medium.score).toBe(5);
+    expect(
+      medium.suggestions.some((s) => s.includes("Trim the description")),
+    ).toBe(true);
+
+    const long = scoreDescription(
+      { description: ["Generate", ...Array(70).fill("thing")].join(" ") },
+      "",
+    );
+    expect(long.score).toBe(3);
+    expect(
+      long.suggestions.some((s) => s.includes("Description is too long")),
+    ).toBe(true);
+  });
+});
+
+describe("scorePromptEngineering", () => {
+  it("awards the full 10 points for disclosure cues, lists, examples and imperatives", () => {
+    const result = scorePromptEngineering({}, RICH_BODY);
+    expect(result.id).toBe("prompt-engineering");
+    expect(result.score).toBe(10);
+    expect(result.findings).toContain("Uses lists or numbered steps.");
+    expect(result.findings).toContain("Includes example code block.");
+    expect(
+      result.findings.some((f) => /Uses imperative voice \(\d+ cues\)/.test(f)),
+    ).toBe(true);
+  });
+
+  it("gives partial credit for a single disclosure cue and a single imperative", () => {
+    const result = scorePromptEngineering({}, "Overview\n\nRun it.\n");
+    expect(result.score).toBe(2);
+    expect(
+      result.suggestions.some((s) => s.includes("Add clearer section labels")),
+    ).toBe(true);
+    expect(
+      result.suggestions.some((s) => s.includes("Favor imperative voice")),
+    ).toBe(true);
+    expect(result.findings).toContain("Body is very short (3 words).");
+  });
+
+  it("halves the example credit when a code block has no `example` label", () => {
+    const body = "# Title\n\n```bash\nls\n```\n";
+    const result = scorePromptEngineering({}, body);
+    expect(result.score).toBe(1);
+    expect(
+      result.suggestions.some((s) =>
+        s.includes("Back up examples with fenced code blocks"),
+      ),
+    ).toBe(true);
+    expect(result.findings).not.toContain("Includes example code block.");
+  });
+});
+
+describe("scoreContextEfficiency", () => {
+  it("awards the full 10 points for a right-sized body that links out", () => {
+    const result = scoreContextEfficiency({}, EFFICIENT_BODY);
+    expect(result.id).toBe("context-efficiency");
+    expect(result.score).toBe(10);
+    expect(
+      result.findings.some((f) =>
+        f.startsWith("References external files or links (reference,"),
+      ),
+    ).toBe(true);
+    expect(result.findings).toContain("No oversized code blocks.");
+    expect(result.findings).toContain("Mentions tokens/budget/context window.");
+  });
+
+  it("flags code blocks longer than 60 lines", () => {
+    const huge =
+      "```js\n" + Array(70).fill("const x = 1;").join("\n") + "\n```\n";
+    const result = scoreContextEfficiency({}, EFFICIENT_BODY + huge);
+    expect(result.findings).toContain("1 code block(s) longer than 60 lines.");
+    expect(
+      result.suggestions.some((s) => s.includes("Move large code blocks")),
+    ).toBe(true);
+  });
+
+  it("emits no length feedback for bodies under 60 words", () => {
+    const result = scoreContextEfficiency({}, "Quick note only.");
+    expect(result.score).toBe(2);
+    expect(result.findings).toContain("Body is 3 words.");
+    // The <60-word bucket has no branch, so no length suggestion is produced.
+    expect(
+      result.suggestions.some((s) => s.includes("Expand instructions")),
+    ).toBe(false);
+    expect(
+      result.suggestions.some((s) => s.includes("Offload verbose content")),
+    ).toBe(true);
+  });
+});
+
+describe("scoreSafety", () => {
+  it("awards the full 10 points when destructive actions are paired with a confirmation", () => {
+    const result = scoreSafety({}, SAFE_BODY);
+    expect(result.id).toBe("safety");
+    expect(result.score).toBe(10);
+    expect(result.findings).toContain(
+      "Destructive actions paired with confirmation/dry-run.",
+    );
+    expect(result.findings).toContain(
+      "Declares prerequisites or requirements.",
+    );
+  });
+
+  it("credits only half the destructive bucket when nothing destructive is mentioned", () => {
+    const result = scoreSafety({}, SAFE_BODY.replace("delete", "archive"));
+    expect(result.score).toBe(9);
+    expect(result.findings).not.toContain(
+      "Destructive actions paired with confirmation/dry-run.",
+    );
+  });
+
+  it("scores a single safety cue with no prerequisites at 3", () => {
+    const result = scoreSafety({}, "Run the check.");
+    expect(result.score).toBe(3);
+    expect(result.findings).toContain(
+      "No prerequisites / requirements section.",
+    );
+    expect(
+      result.suggestions.some((s) => s.includes("Expand the safety section")),
+    ).toBe(true);
+    expect(
+      result.suggestions.some((s) =>
+        s.includes('Add a "## Prerequisites" block'),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("scoreTestability", () => {
+  it("awards the full 10 points for acceptance criteria, expected output and edge cases", () => {
+    const result = scoreTestability({}, TESTABLE_BODY);
+    expect(result.id).toBe("testability");
+    expect(result.score).toBe(10);
+    expect(result.findings).toContain("Describes expected output/result.");
+    expect(result.findings).toContain("Mentions edge cases or limitations.");
+  });
+
+  it("gives 3 points for a couple of cues and asks for acceptance criteria", () => {
+    const result = scoreTestability({}, "Run the tests and verify the report.");
+    expect(result.score).toBe(3);
+    expect(result.findings).toContain(
+      "Some testability cues: test, tests, verify.",
+    );
+    expect(
+      result.suggestions.some((s) =>
+        s.includes('Add an "## Acceptance Criteria" block'),
+      ),
+    ).toBe(true);
+  });
+
+  it("scores 0 and asks for a testable section when no cue is present", () => {
+    const result = scoreTestability({}, "Do the thing.");
+    expect(result.score).toBe(0);
+    expect(
+      result.suggestions.some((s) =>
+        s.includes('Add a "## Acceptance Criteria" section'),
+      ),
+    ).toBe(true);
+    expect(
+      result.suggestions.some((s) =>
+        s.includes('Include an "Expected output"'),
+      ),
+    ).toBe(true);
+    expect(
+      result.suggestions.some((s) =>
+        s.includes('Add a short "Edge cases" list'),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("scoreNaming", () => {
+  it("caps at 9 of 10 because the basename point is scored by the aggregator", () => {
+    const result = scoreNaming(
+      { name: "code-review", description: "Review diffs for smells." },
+      "# Code review\n\n## Instructions\n\n## Examples\n",
+    );
+    expect(result.id).toBe("naming");
+    expect(result.max).toBe(10);
+    expect(result.score).toBe(9);
+    expect(result.findings).toContain(
+      'name "code-review" follows kebab-case convention.',
+    );
+    expect(result.findings).toContain(
+      "Most headings use action/imperative labels.",
+    );
+  });
+
+  it("skips the heading bucket entirely when the body has no headings", () => {
+    const result = scoreNaming(
+      { name: "code-review", description: "Review diffs for smells." },
+      "no headings here",
+    );
+    expect(result.score).toBe(6);
+    expect(result.findings).not.toContain(
+      "Most headings use action/imperative labels.",
+    );
+  });
+
+  it("gives 1 point when fewer than half the headings are action labels", () => {
+    const result = scoreNaming(
+      { name: "code-review", description: "Review diffs for smells." },
+      "# lowercase thing\n\n## another lowercase\n",
+    );
+    expect(result.score).toBe(7);
+    expect(
+      result.suggestions.some((s) =>
+        s.includes("Rename body headings to action-oriented labels"),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports over-long names and drops the naming bucket", () => {
+    const longName = "a-very-long-skill-name-that-keeps-on-going-forever";
+    const result = scoreNaming(
+      { name: longName, description: "Review diffs for smells." },
+      "# Code review\n\n## Instructions\n",
+    );
+    expect(result.score).toBe(5);
+    expect(result.findings).toContain(
+      `name is ${longName.length} chars; keep it <= 40.`,
+    );
+  });
+
+  it("withholds the clean-label point for noisy descriptions", () => {
+    const result = scoreNaming(
+      { name: "code-review", description: "TODO  write this" },
+      "# Code review\n\n## Instructions\n",
+    );
+    expect(result.score).toBe(7);
+    expect(
+      result.suggestions.some((s) => s.includes("Clean up description")),
+    ).toBe(true);
+  });
+
+  it("asks for a name when frontmatter has none", () => {
+    const result = scoreNaming(
+      { description: "Review diffs for smells." },
+      "# Code review\n\n## Instructions\n",
+    );
+    expect(
+      result.suggestions.some((s) =>
+        s.includes("Add a kebab-case `name` (e.g. `my-skill`)"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/formatter-core.test.ts
+++ b/src/formatter-core.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Direct-import tests for `formatter-core.ts` internals.
+ *
+ * The #455 split newly exported `useColor`, `providerBadge`, and
+ * `toolRiskWarning` from `formatter-core.ts` for cross-module wiring, but they
+ * are deliberately NOT re-exported through the `./formatter` facade, so
+ * `formatter.test.ts` cannot reach them. These tests import them directly.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+
+import { useColor, providerBadge, toolRiskWarning } from "./formatter-core";
+
+const ORIG_NO_COLOR = process.env.NO_COLOR;
+const ORIG_IS_TTY = process.stdout.isTTY;
+const ORIG_CLI_NO_COLOR = globalThis.__CLI_NO_COLOR;
+
+/** Force `useColor()` to return true by clearing every disabling signal. */
+function enableColor(): void {
+  delete process.env.NO_COLOR;
+  globalThis.__CLI_NO_COLOR = undefined;
+  process.stdout.isTTY = true;
+}
+
+afterEach(() => {
+  if (ORIG_NO_COLOR === undefined) {
+    delete process.env.NO_COLOR;
+  } else {
+    process.env.NO_COLOR = ORIG_NO_COLOR;
+  }
+  globalThis.__CLI_NO_COLOR = ORIG_CLI_NO_COLOR;
+  process.stdout.isTTY = ORIG_IS_TTY;
+});
+
+describe("useColor", () => {
+  it("returns false when NO_COLOR is defined, even on a TTY", () => {
+    enableColor();
+    process.env.NO_COLOR = "1";
+    expect(useColor()).toBe(false);
+  });
+
+  it("returns false when NO_COLOR is defined but empty", () => {
+    enableColor();
+    process.env.NO_COLOR = "";
+    expect(useColor()).toBe(false);
+  });
+
+  it("returns false when the __CLI_NO_COLOR global is set", () => {
+    enableColor();
+    globalThis.__CLI_NO_COLOR = true;
+    expect(useColor()).toBe(false);
+  });
+
+  it("returns false when stdout is not a TTY", () => {
+    enableColor();
+    process.stdout.isTTY = false;
+    expect(useColor()).toBe(false);
+  });
+
+  it("returns true on a TTY with no disabling signals", () => {
+    enableColor();
+    expect(useColor()).toBe(true);
+  });
+
+  it("treats __CLI_NO_COLOR=false as not disabling", () => {
+    enableColor();
+    globalThis.__CLI_NO_COLOR = false;
+    expect(useColor()).toBe(true);
+  });
+});
+
+describe("providerBadge", () => {
+  it("returns a plain bracketed label when color is disabled", () => {
+    process.env.NO_COLOR = "1";
+    expect(providerBadge("claude", "Claude Code")).toBe("[Claude Code]");
+  });
+
+  it("returns a plain bracketed label for unknown providers when color is disabled", () => {
+    process.env.NO_COLOR = "1";
+    expect(providerBadge("totally-unknown", "Mystery")).toBe("[Mystery]");
+  });
+
+  it("wraps the bracketed label in the provider color when color is enabled", () => {
+    enableColor();
+    // claude -> blueBold
+    expect(providerBadge("claude", "Claude Code")).toBe(
+      "\x1b[34;1m[Claude Code]\x1b[0m",
+    );
+  });
+
+  it.each([
+    ["codex", "\x1b[36m"],
+    ["codex-plugin", "\x1b[36m"],
+    ["openclaw", "\x1b[33m"],
+    ["agents", "\x1b[32m"],
+    ["custom", "\x1b[35m"],
+    ["cursor", "\x1b[34m"],
+    ["windsurf", "\x1b[36m"],
+    ["cline", "\x1b[32m"],
+    ["roocode", "\x1b[35m"],
+    ["continue", "\x1b[33m"],
+    ["copilot", "\x1b[37m"],
+    ["aider", "\x1b[31m"],
+    ["opencode", "\x1b[36m"],
+    ["zed", "\x1b[34m"],
+    ["augment", "\x1b[32m"],
+    ["amp", "\x1b[33m"],
+  ])("colors the %s badge with its own escape code", (provider, prefix) => {
+    enableColor();
+    expect(providerBadge(provider, "L")).toBe(`${prefix}[L]\x1b[0m`);
+  });
+
+  it("falls back to dim for an unknown provider when color is enabled", () => {
+    enableColor();
+    expect(providerBadge("totally-unknown", "Mystery")).toBe(
+      "\x1b[2m[Mystery]\x1b[0m",
+    );
+  });
+
+  it("still brackets an empty label", () => {
+    process.env.NO_COLOR = "1";
+    expect(providerBadge("claude", "")).toBe("[]");
+  });
+});
+
+describe("toolRiskWarning", () => {
+  it("returns null for an empty tool list", () => {
+    expect(toolRiskWarning([])).toBeNull();
+  });
+
+  it("returns null for medium-risk tools only", () => {
+    expect(toolRiskWarning(["WebFetch", "WebSearch"])).toBeNull();
+  });
+
+  it("returns null for low-risk tools only", () => {
+    expect(toolRiskWarning(["Read", "Grep", "Glob"])).toBeNull();
+  });
+
+  it("warns about shell execution for Bash", () => {
+    expect(toolRiskWarning(["Bash"])).toBe(
+      "This skill can execute shell commands",
+    );
+  });
+
+  it.each(["Write", "Edit", "NotebookEdit"])(
+    "warns about file modification for %s",
+    (tool) => {
+      expect(toolRiskWarning([tool])).toBe("This skill can modify files");
+    },
+  );
+
+  it("collapses multiple file-writing tools into one clause", () => {
+    expect(toolRiskWarning(["Write", "Edit", "NotebookEdit"])).toBe(
+      "This skill can modify files",
+    );
+  });
+
+  it("joins both clauses when Bash and a file-writing tool are present", () => {
+    expect(toolRiskWarning(["Bash", "Write"])).toBe(
+      "This skill can execute shell commands and modify files",
+    );
+  });
+
+  it("keeps clause order stable regardless of input order", () => {
+    expect(toolRiskWarning(["Edit", "Bash"])).toBe(
+      "This skill can execute shell commands and modify files",
+    );
+  });
+
+  it("ignores non-high-risk tools mixed in with high-risk ones", () => {
+    expect(toolRiskWarning(["Read", "WebFetch", "Bash"])).toBe(
+      "This skill can execute shell commands",
+    );
+  });
+
+  it("is case-sensitive — lowercase tool names are not high risk", () => {
+    expect(toolRiskWarning(["bash", "write"])).toBeNull();
+  });
+});

--- a/src/library-core.test.ts
+++ b/src/library-core.test.ts
@@ -1,0 +1,824 @@
+/**
+ * Direct-import tests for the internal staging/validation helpers that
+ * `src/library-core.ts` exports for `src/library-update.ts` but that the
+ * `src/library.ts` facade deliberately does not re-export, so
+ * `src/library.test.ts` cannot reach them.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "fs/promises";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { AtomicWritePostRenameError } from "./utils/atomic-file";
+import type { LibrarySkillEntry } from "./utils/types";
+import {
+  cloneRemoteLibrarySource,
+  emptyLibraryLock,
+  hashDirectoryContents,
+  isContainedPath,
+  libraryEntryChangedDuringUpdate,
+  libraryEntryMatchesUpdateSource,
+  libraryPathRealpathIsContained,
+  librarySourceRoot,
+  libraryUpdateFailure,
+  nextInstalledAt,
+  persistLibraryLock,
+  readLibraryLockFile,
+  replaceDirectoryAtomically,
+  resolveContainedPath,
+  stageLibraryDirectory,
+  validateSourceSkillFrontmatter,
+} from "./library-core";
+
+function makeEntry(
+  overrides: Partial<LibrarySkillEntry> = {},
+): LibrarySkillEntry {
+  return {
+    name: "brainstorming",
+    version: "1.0.0",
+    source: "github:obra/superpowers",
+    sourceType: "github",
+    commitHash: "abc123",
+    ref: "main",
+    skillPath: "skills/brainstorming",
+    libraryPath: "/library/skills/brainstorming",
+    installedAt: "2026-06-18T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("libraryUpdateFailure", () => {
+  it("builds a failed result carrying the reason", () => {
+    expect(libraryUpdateFailure("brainstorming", "Clone failed")).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Clone failed",
+    });
+  });
+});
+
+describe("libraryEntryChangedDuringUpdate", () => {
+  it("builds a failed result telling the user to re-run the update", () => {
+    const result = libraryEntryChangedDuringUpdate("brainstorming");
+    expect(result.name).toBe("brainstorming");
+    expect(result.status).toBe("failed");
+    expect(result.reason).toContain("changed while update was in progress");
+    expect(result.reason).toContain("asm library update brainstorming");
+  });
+});
+
+describe("nextInstalledAt", () => {
+  it("returns the current time when there is no previous timestamp", () => {
+    const before = Date.now();
+    const value = Date.parse(nextInstalledAt());
+    expect(value).toBeGreaterThanOrEqual(before);
+    expect(value).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("treats an unparseable previous timestamp as absent", () => {
+    const before = Date.now();
+    const value = Date.parse(nextInstalledAt("not-a-date"));
+    expect(value).toBeGreaterThanOrEqual(before);
+    expect(value).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("stays strictly monotonic when the previous timestamp is in the future", () => {
+    const previous = new Date(Date.now() + 60_000).toISOString();
+    expect(nextInstalledAt(previous)).toBe(
+      new Date(Date.parse(previous) + 1).toISOString(),
+    );
+  });
+
+  it("uses the current time when the previous timestamp is in the past", () => {
+    const previous = new Date(Date.now() - 60_000).toISOString();
+    const value = Date.parse(nextInstalledAt(previous));
+    expect(value).toBeGreaterThan(Date.parse(previous));
+  });
+});
+
+describe("librarySourceRoot", () => {
+  it("returns null for non-local sources", () => {
+    expect(librarySourceRoot(makeEntry({ source: "github:a/b" }))).toBeNull();
+    expect(librarySourceRoot(makeEntry({ source: "registry:foo" }))).toBeNull();
+  });
+
+  it("returns null when the local source has an empty path", () => {
+    expect(librarySourceRoot(makeEntry({ source: "local:" }))).toBeNull();
+  });
+
+  it("resolves a relative local source to an absolute path", () => {
+    expect(librarySourceRoot(makeEntry({ source: "local:./some/dir" }))).toBe(
+      resolve("./some/dir"),
+    );
+  });
+
+  it("keeps an already absolute local source", () => {
+    expect(librarySourceRoot(makeEntry({ source: "local:/srv/skills" }))).toBe(
+      resolve("/srv/skills"),
+    );
+  });
+});
+
+describe("validateSourceSkillFrontmatter", () => {
+  it("rejects frontmatter with a missing or blank name", () => {
+    expect(validateSourceSkillFrontmatter({})).toEqual({
+      reason: "Invalid source SKILL.md: missing name",
+    });
+    expect(
+      validateSourceSkillFrontmatter({ name: "   ", version: "1.0.0" }),
+    ).toEqual({ reason: "Invalid source SKILL.md: missing name" });
+  });
+
+  it("rejects frontmatter with no version at all", () => {
+    expect(validateSourceSkillFrontmatter({ name: "demo" })).toEqual({
+      reason: "Invalid source SKILL.md: missing version",
+    });
+  });
+
+  it("rejects a version that is not semver", () => {
+    for (const version of ["1.0", "v1.0.0", "latest", "1.0.0.0"]) {
+      expect(validateSourceSkillFrontmatter({ name: "demo", version })).toEqual(
+        {
+          reason: "Invalid source SKILL.md: invalid version",
+        },
+      );
+    }
+  });
+
+  it("accepts prerelease and build metadata", () => {
+    expect(
+      validateSourceSkillFrontmatter({
+        name: "demo",
+        version: "1.2.3-beta.1+build.5",
+      }),
+    ).toEqual({ name: "demo", version: "1.2.3-beta.1+build.5" });
+  });
+
+  it("prefers metadata.version over version and trims both fields", () => {
+    expect(
+      validateSourceSkillFrontmatter({
+        name: "  demo  ",
+        "metadata.version": " 2.0.0 ",
+        version: "1.0.0",
+      }),
+    ).toEqual({ name: "demo", version: "2.0.0" });
+  });
+
+  it("falls back to version when metadata.version is empty", () => {
+    expect(
+      validateSourceSkillFrontmatter({
+        name: "demo",
+        "metadata.version": "",
+        version: "1.0.0",
+      }),
+    ).toEqual({ name: "demo", version: "1.0.0" });
+  });
+});
+
+describe("isContainedPath", () => {
+  it("accepts a child nested under the parent", () => {
+    expect(isContainedPath("/a/b", "/a/b/c/d")).toBe(true);
+  });
+
+  it("accepts the parent itself", () => {
+    expect(isContainedPath("/a/b", "/a/b")).toBe(true);
+  });
+
+  it("accepts traversal that stays inside the parent", () => {
+    expect(isContainedPath("/a/b", "/a/b/c/../d")).toBe(true);
+  });
+
+  it("rejects traversal that escapes the parent", () => {
+    expect(isContainedPath("/a/b", "/a/b/../../etc/passwd")).toBe(false);
+    expect(isContainedPath("/a/b", "/a/b/../c")).toBe(false);
+  });
+
+  it("rejects an unrelated absolute path", () => {
+    expect(isContainedPath("/a/b", "/etc/passwd")).toBe(false);
+  });
+
+  it("rejects a sibling that merely shares a name prefix", () => {
+    expect(isContainedPath("/a/b", "/a/bc")).toBe(false);
+    expect(isContainedPath("/a/b", "/a/b-other/file")).toBe(false);
+  });
+
+  it("resolves relative inputs against the cwd before comparing", () => {
+    expect(isContainedPath(".", "./nested/file")).toBe(true);
+    expect(isContainedPath("./nested", "..")).toBe(false);
+  });
+});
+
+describe("resolveContainedPath", () => {
+  it("returns the resolved child when it is contained", () => {
+    expect(resolveContainedPath("/a/b", "/a/b/c/../d")).toBe("/a/b/d");
+  });
+
+  it("returns the resolved parent when child equals parent", () => {
+    expect(resolveContainedPath("/a/b", "/a/b")).toBe(resolve("/a/b"));
+  });
+
+  it("returns null when the child escapes the parent", () => {
+    expect(resolveContainedPath("/a/b", "/a/b/../../escape")).toBeNull();
+    expect(resolveContainedPath("/a/b", "/etc/passwd")).toBeNull();
+  });
+});
+
+describe("libraryPathRealpathIsContained", () => {
+  let tempDir: string;
+  let skillsDir: string;
+  let outsideDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-core-contain-"));
+    skillsDir = join(tempDir, "skills");
+    outsideDir = join(tempDir, "outside");
+    await mkdir(skillsDir, { recursive: true });
+    await mkdir(outsideDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("accepts an existing directory inside the skills dir", async () => {
+    const libraryPath = join(skillsDir, "demo");
+    await mkdir(libraryPath);
+    await expect(
+      libraryPathRealpathIsContained(skillsDir, libraryPath),
+    ).resolves.toBe(true);
+  });
+
+  it("accepts a not-yet-created path whose existing ancestor is contained", async () => {
+    await expect(
+      libraryPathRealpathIsContained(skillsDir, join(skillsDir, "not-yet")),
+    ).resolves.toBe(true);
+  });
+
+  it("accepts the skills dir itself", async () => {
+    await expect(
+      libraryPathRealpathIsContained(skillsDir, skillsDir),
+    ).resolves.toBe(true);
+  });
+
+  it("rejects a lexical traversal out of the skills dir", async () => {
+    await expect(
+      libraryPathRealpathIsContained(
+        skillsDir,
+        join(skillsDir, "..", "outside", "demo"),
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("rejects an absolute path outside the skills dir", async () => {
+    await expect(
+      libraryPathRealpathIsContained(skillsDir, outsideDir),
+    ).resolves.toBe(false);
+  });
+
+  it("rejects a path that escapes through a symlinked directory", async () => {
+    await symlink(outsideDir, join(skillsDir, "escape"), "dir");
+    await expect(
+      libraryPathRealpathIsContained(skillsDir, join(skillsDir, "escape")),
+    ).resolves.toBe(false);
+    await expect(
+      libraryPathRealpathIsContained(
+        skillsDir,
+        join(skillsDir, "escape", "demo"),
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("returns false when the skills dir does not exist", async () => {
+    await expect(
+      libraryPathRealpathIsContained(
+        join(tempDir, "missing"),
+        join(tempDir, "missing", "demo"),
+      ),
+    ).resolves.toBe(false);
+  });
+});
+
+describe("libraryEntryMatchesUpdateSource", () => {
+  let tempDir: string;
+  let sourceRoot: string;
+
+  beforeEach(async () => {
+    tempDir = await realpath(
+      await mkdtemp(join(tmpdir(), "asm-library-core-match-")),
+    );
+    sourceRoot = join(tempDir, "source");
+    await mkdir(join(sourceRoot, "skills", "demo"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns false when the source type differs", async () => {
+    await expect(
+      libraryEntryMatchesUpdateSource(
+        makeEntry({ sourceType: "github" }),
+        makeEntry({ sourceType: "registry" }),
+        null,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("returns false when the library path differs", async () => {
+    await expect(
+      libraryEntryMatchesUpdateSource(
+        makeEntry({ libraryPath: "/library/skills/a" }),
+        makeEntry({ libraryPath: "/library/skills/b" }),
+        null,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("treats library paths that resolve to the same location as equal", async () => {
+    await expect(
+      libraryEntryMatchesUpdateSource(
+        makeEntry({ libraryPath: "/library/skills/./demo" }),
+        makeEntry({ libraryPath: "/library/skills/other/../demo" }),
+        null,
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("returns false when a remote source, ref, or skillPath changed", async () => {
+    await expect(
+      libraryEntryMatchesUpdateSource(
+        makeEntry({ source: "github:a/b" }),
+        makeEntry({ source: "github:a/c" }),
+        null,
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      libraryEntryMatchesUpdateSource(
+        makeEntry({ ref: "main" }),
+        makeEntry({ ref: "v2" }),
+        null,
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      libraryEntryMatchesUpdateSource(
+        makeEntry({ skillPath: "skills/a" }),
+        makeEntry({ skillPath: "skills/b" }),
+        null,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("returns true for an unchanged remote entry", async () => {
+    await expect(
+      libraryEntryMatchesUpdateSource(makeEntry(), makeEntry(), null),
+    ).resolves.toBe(true);
+  });
+
+  it("returns false for a local entry when no expected identity is supplied", async () => {
+    const entry = makeEntry({
+      sourceType: "local",
+      source: `local:${sourceRoot}`,
+      skillPath: join("skills", "demo"),
+    });
+    await expect(
+      libraryEntryMatchesUpdateSource(entry, entry, null),
+    ).resolves.toBe(false);
+  });
+
+  it("compares the realpath of a local source against the expected identity", async () => {
+    const entry = makeEntry({
+      sourceType: "local",
+      source: `local:${sourceRoot}`,
+      skillPath: join("skills", "demo"),
+    });
+    const identity = join(sourceRoot, "skills", "demo");
+
+    await expect(
+      libraryEntryMatchesUpdateSource(entry, entry, identity),
+    ).resolves.toBe(true);
+    await expect(
+      libraryEntryMatchesUpdateSource(
+        entry,
+        entry,
+        join(sourceRoot, "skills", "other"),
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("throws when a local entry has a non-local source", async () => {
+    const entry = makeEntry({
+      sourceType: "local",
+      source: "github:a/b",
+    });
+    await expect(
+      libraryEntryMatchesUpdateSource(entry, entry, "identity"),
+    ).rejects.toThrow("Unsupported library source for update");
+  });
+
+  it("throws when the local skillPath lexically escapes the source root", async () => {
+    const entry = makeEntry({
+      sourceType: "local",
+      source: `local:${sourceRoot}`,
+      skillPath: join("..", "outside"),
+    });
+    await expect(
+      libraryEntryMatchesUpdateSource(entry, entry, "identity"),
+    ).rejects.toThrow("skillPath escapes source root");
+  });
+
+  it("throws when the local skillPath escapes through a symlink", async () => {
+    const outsideDir = join(tempDir, "outside");
+    await mkdir(outsideDir, { recursive: true });
+    await symlink(outsideDir, join(sourceRoot, "escape"), "dir");
+
+    const entry = makeEntry({
+      sourceType: "local",
+      source: `local:${sourceRoot}`,
+      skillPath: "escape",
+    });
+    await expect(
+      libraryEntryMatchesUpdateSource(entry, entry, "identity"),
+    ).rejects.toThrow("skillPath escapes source root");
+  });
+});
+
+describe("readLibraryLockFile", () => {
+  let tempDir: string;
+  let lockPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-core-lock-"));
+    lockPath = join(tempDir, "library-lock.json");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("backs up and resets an unparseable lock file", async () => {
+    await writeFile(lockPath, "{ not json", "utf-8");
+    await expect(readLibraryLockFile(lockPath)).resolves.toEqual(
+      emptyLibraryLock(),
+    );
+    await expect(readFile(lockPath + ".bak", "utf-8")).resolves.toBe(
+      "{ not json",
+    );
+  });
+
+  it("rejects an unsupported lock version", async () => {
+    const raw = JSON.stringify({ version: 2, skills: {} });
+    await writeFile(lockPath, raw, "utf-8");
+    await expect(readLibraryLockFile(lockPath)).resolves.toEqual(
+      emptyLibraryLock(),
+    );
+    await expect(readFile(lockPath + ".bak", "utf-8")).resolves.toBe(raw);
+  });
+
+  it("rejects a null skills map", async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({ version: 1, skills: null }),
+      "utf-8",
+    );
+    await expect(readLibraryLockFile(lockPath)).resolves.toEqual(
+      emptyLibraryLock(),
+    );
+  });
+
+  it("rejects a top-level array", async () => {
+    await writeFile(lockPath, JSON.stringify([]), "utf-8");
+    await expect(readLibraryLockFile(lockPath)).resolves.toEqual(
+      emptyLibraryLock(),
+    );
+  });
+
+  it("returns a well-formed lock unchanged", async () => {
+    const lock = emptyLibraryLock();
+    lock.skills.demo = makeEntry({ name: "demo" });
+    await writeFile(lockPath, JSON.stringify(lock), "utf-8");
+    await expect(readLibraryLockFile(lockPath)).resolves.toEqual(lock);
+  });
+});
+
+describe("persistLibraryLock", () => {
+  let tempDir: string;
+  let lockPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-core-persist-"));
+    lockPath = join(tempDir, "library-lock.json");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("writes pretty-printed JSON with a trailing newline", async () => {
+    const lock = emptyLibraryLock();
+    lock.skills.demo = makeEntry({ name: "demo" });
+
+    await persistLibraryLock(lock, lockPath);
+
+    await expect(readFile(lockPath, "utf-8")).resolves.toBe(
+      JSON.stringify(lock, null, 2) + "\n",
+    );
+    await expect(readdir(tempDir)).resolves.toEqual(["library-lock.json"]);
+  });
+
+  it("overwrites an existing lock file", async () => {
+    await writeFile(lockPath, "stale", "utf-8");
+    await persistLibraryLock(emptyLibraryLock(), lockPath);
+    await expect(readLibraryLockFile(lockPath)).resolves.toEqual(
+      emptyLibraryLock(),
+    );
+  });
+});
+
+describe("hashDirectoryContents", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-core-hash-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function makeTree(name: string): Promise<string> {
+    const dir = join(tempDir, name);
+    await mkdir(join(dir, "nested"), { recursive: true });
+    await writeFile(join(dir, "SKILL.md"), "# demo\n", "utf-8");
+    await writeFile(join(dir, "nested", "a.txt"), "alpha", "utf-8");
+    return dir;
+  }
+
+  it("is stable across identical trees", async () => {
+    const a = await makeTree("a");
+    const b = await makeTree("b");
+    expect(await hashDirectoryContents(a)).toBe(await hashDirectoryContents(b));
+  });
+
+  it("changes when file contents change", async () => {
+    const dir = await makeTree("a");
+    const before = await hashDirectoryContents(dir);
+    await writeFile(join(dir, "nested", "a.txt"), "beta", "utf-8");
+    expect(await hashDirectoryContents(dir)).not.toBe(before);
+  });
+
+  it("changes when a file is renamed but its content is unchanged", async () => {
+    const a = await makeTree("a");
+    const b = await makeTree("b");
+    await rm(join(b, "nested", "a.txt"));
+    await writeFile(join(b, "nested", "z.txt"), "alpha", "utf-8");
+    expect(await hashDirectoryContents(b)).not.toBe(
+      await hashDirectoryContents(a),
+    );
+  });
+
+  it("changes when an empty directory is added", async () => {
+    const dir = await makeTree("a");
+    const before = await hashDirectoryContents(dir);
+    await mkdir(join(dir, "empty"));
+    expect(await hashDirectoryContents(dir)).not.toBe(before);
+  });
+
+  it("ignores the .git directory", async () => {
+    const a = await makeTree("a");
+    const b = await makeTree("b");
+    await mkdir(join(b, ".git", "objects"), { recursive: true });
+    await writeFile(join(b, ".git", "HEAD"), "ref: refs/heads/main\n", "utf-8");
+    expect(await hashDirectoryContents(b)).toBe(await hashDirectoryContents(a));
+  });
+
+  it("rejects when the directory does not exist", async () => {
+    await expect(
+      hashDirectoryContents(join(tempDir, "missing")),
+    ).rejects.toThrow();
+  });
+});
+
+describe("stageLibraryDirectory", () => {
+  let tempDir: string;
+  let sourceDir: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-core-stage-"));
+    sourceDir = join(tempDir, "source");
+    targetDir = join(tempDir, "library", "demo");
+    await mkdir(join(tempDir, "library"), { recursive: true });
+    await mkdir(join(sourceDir, "nested"), { recursive: true });
+    await writeFile(join(sourceDir, "SKILL.md"), "# demo\n", "utf-8");
+    await writeFile(join(sourceDir, "nested", "a.txt"), "alpha", "utf-8");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("copies the source into a sibling staging dir of the target", async () => {
+    const stagedDir = await stageLibraryDirectory(sourceDir, targetDir);
+
+    expect(
+      stagedDir.startsWith(join(tempDir, "library", ".library-update-")),
+    ).toBe(true);
+    await expect(readFile(join(stagedDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "# demo\n",
+    );
+    await expect(
+      readFile(join(stagedDir, "nested", "a.txt"), "utf-8"),
+    ).resolves.toBe("alpha");
+  });
+
+  it("strips the .git directory from the staged copy", async () => {
+    await mkdir(join(sourceDir, ".git"), { recursive: true });
+    await writeFile(join(sourceDir, ".git", "HEAD"), "ref\n", "utf-8");
+
+    const stagedDir = await stageLibraryDirectory(sourceDir, targetDir);
+
+    await expect(readdir(stagedDir)).resolves.not.toContain(".git");
+    await expect(readdir(sourceDir)).resolves.toContain(".git");
+  });
+
+  it("removes the staging dir and rethrows when the source is missing", async () => {
+    await expect(
+      stageLibraryDirectory(join(tempDir, "missing"), targetDir),
+    ).rejects.toThrow();
+
+    await expect(readdir(join(tempDir, "library"))).resolves.toEqual([]);
+  });
+});
+
+describe("replaceDirectoryAtomically", () => {
+  let tempDir: string;
+  let parentDir: string;
+  let targetDir: string;
+  let sourceDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-core-replace-"));
+    parentDir = join(tempDir, "library");
+    targetDir = join(parentDir, "demo");
+    sourceDir = join(tempDir, "source");
+    await mkdir(parentDir, { recursive: true });
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(join(sourceDir, "SKILL.md"), "new\n", "utf-8");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function stage(): Promise<string> {
+    return stageLibraryDirectory(sourceDir, targetDir);
+  }
+
+  it("publishes the staged dir when the target does not exist yet", async () => {
+    const writes: string[] = [];
+    const result = await replaceDirectoryAtomically({
+      stagedDir: await stage(),
+      targetDir,
+      writeLock: async () => {
+        writes.push("lock");
+      },
+    });
+
+    expect(result).toBeNull();
+    expect(writes).toEqual(["lock"]);
+    await expect(readFile(join(targetDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "new\n",
+    );
+    await expect(readdir(parentDir)).resolves.toEqual(["demo"]);
+  });
+
+  it("replaces an existing target and leaves no backup behind", async () => {
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(join(targetDir, "SKILL.md"), "old\n", "utf-8");
+
+    const result = await replaceDirectoryAtomically({
+      stagedDir: await stage(),
+      targetDir,
+      writeLock: async () => {},
+    });
+
+    expect(result).toBeNull();
+    await expect(readFile(join(targetDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "new\n",
+    );
+    await expect(readdir(parentDir)).resolves.toEqual(["demo"]);
+  });
+
+  it("rolls back to the previous target when writeLock fails", async () => {
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(join(targetDir, "SKILL.md"), "old\n", "utf-8");
+
+    const result = await replaceDirectoryAtomically({
+      stagedDir: await stage(),
+      targetDir,
+      writeLock: async () => {
+        throw new Error("lock boom");
+      },
+    });
+
+    expect(result).toMatchObject({ name: "", status: "failed" });
+    expect(result?.reason).toContain("failed to write lock file");
+    expect(result?.reason).toContain("lock boom");
+    await expect(readFile(join(targetDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "old\n",
+    );
+    await expect(readdir(parentDir)).resolves.toEqual(["demo"]);
+  });
+
+  it("reports a lock write failure when there was no previous target", async () => {
+    const result = await replaceDirectoryAtomically({
+      stagedDir: await stage(),
+      targetDir,
+      writeLock: async () => {
+        throw new Error("lock boom");
+      },
+    });
+
+    expect(result).toMatchObject({ name: "", status: "failed" });
+    expect(result?.reason).toContain("failed to write lock file");
+    await expect(readdir(parentDir)).resolves.toEqual([]);
+  });
+
+  it("keeps the new generation when only the durability fsync could not be confirmed", async () => {
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(join(targetDir, "SKILL.md"), "old\n", "utf-8");
+
+    const result = await replaceDirectoryAtomically({
+      stagedDir: await stage(),
+      targetDir,
+      writeLock: async () => {
+        throw new AtomicWritePostRenameError(
+          join(parentDir, "library-lock.json"),
+          new Error("fsync boom"),
+        );
+      },
+    });
+
+    expect(result).toMatchObject({ name: "", status: "failed" });
+    expect(result?.reason).toContain("published as the new generation");
+    expect(result?.reason).toContain("fsync boom");
+    await expect(readFile(join(targetDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "new\n",
+    );
+    await expect(readdir(parentDir)).resolves.toEqual(["demo"]);
+  });
+
+  it("restores the previous target when the staged dir is missing", async () => {
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(join(targetDir, "SKILL.md"), "old\n", "utf-8");
+    let lockWritten = false;
+
+    const result = await replaceDirectoryAtomically({
+      stagedDir: join(parentDir, ".library-update-missing"),
+      targetDir,
+      writeLock: async () => {
+        lockWritten = true;
+      },
+    });
+
+    expect(result).toMatchObject({ name: "", status: "failed" });
+    expect(result?.reason).toContain("Failed to refresh library skill");
+    expect(lockWritten).toBe(false);
+    await expect(readFile(join(targetDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "old\n",
+    );
+    await expect(readdir(parentDir)).resolves.toEqual(["demo"]);
+  });
+});
+
+describe("cloneRemoteLibrarySource", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-core-clone-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("refuses a source that has no remote clone URL without touching the disk", async () => {
+    const lockPath = join(tempDir, "library-lock.json");
+    const result = await cloneRemoteLibrarySource(
+      makeEntry({ source: "local:/srv/skills", sourceType: "local" }),
+      "demo",
+      lockPath,
+    );
+
+    expect(result).toEqual({ reason: "Cannot determine remote URL" });
+    await expect(readdir(tempDir)).resolves.toEqual([]);
+  });
+});

--- a/src/updater-core.test.ts
+++ b/src/updater-core.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Direct-import coverage for `src/updater-core.ts`.
+ *
+ * The module split (#455) exported these helpers for cross-module wiring with
+ * `updater-updates.ts`, but deliberately did NOT forward them through the
+ * `src/updater.ts` facade. `src/updater.test.ts` imports from the facade and so
+ * cannot reach them — everything here imports from `./updater-core` directly.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { join } from "path";
+import {
+  createPinnedGitEnv,
+  resolvedLatestCommits,
+  normalizedTargetIdentity,
+  poolAll,
+  getUpdateSourceDir,
+  checkOutdated,
+} from "./updater-core";
+import type { LockEntry } from "./utils/types";
+import type { RegistryIndex } from "./registry";
+
+// ─── createPinnedGitEnv ─────────────────────────────────────────────────────
+
+describe("createPinnedGitEnv", () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in savedEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, savedEnv);
+  });
+
+  it("sets GIT_DEFAULT_HASH to the requested object format", () => {
+    expect(createPinnedGitEnv("sha1").GIT_DEFAULT_HASH).toBe("sha1");
+    expect(createPinnedGitEnv("sha256").GIT_DEFAULT_HASH).toBe("sha256");
+  });
+
+  it("strips repository-local routing variables", () => {
+    process.env.GIT_DIR = "/somewhere/.git";
+    process.env.GIT_WORK_TREE = "/somewhere";
+    process.env.GIT_COMMON_DIR = "/somewhere/.git";
+    process.env.GIT_INDEX_FILE = "/somewhere/.git/index";
+    process.env.GIT_OBJECT_DIRECTORY = "/somewhere/.git/objects";
+    process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES = "/elsewhere/objects";
+    process.env.GIT_CEILING_DIRECTORIES = "/";
+    process.env.GIT_NAMESPACE = "ns";
+    process.env.GIT_QUARANTINE_PATH = "/quarantine";
+    process.env.GIT_PREFIX = "sub/";
+
+    const env = createPinnedGitEnv("sha1");
+
+    expect(env.GIT_DIR).toBeUndefined();
+    expect(env.GIT_WORK_TREE).toBeUndefined();
+    expect(env.GIT_COMMON_DIR).toBeUndefined();
+    expect(env.GIT_INDEX_FILE).toBeUndefined();
+    expect(env.GIT_OBJECT_DIRECTORY).toBeUndefined();
+    expect(env.GIT_ALTERNATE_OBJECT_DIRECTORIES).toBeUndefined();
+    expect(env.GIT_CEILING_DIRECTORIES).toBeUndefined();
+    expect(env.GIT_NAMESPACE).toBeUndefined();
+    expect(env.GIT_QUARANTINE_PATH).toBeUndefined();
+    expect(env.GIT_PREFIX).toBeUndefined();
+  });
+
+  it("strips inline config overrides, including numbered key/value pairs", () => {
+    process.env.GIT_CONFIG = "/etc/gitconfig";
+    process.env.GIT_CONFIG_COUNT = "1";
+    process.env.GIT_CONFIG_PARAMETERS = "'core.hooksPath=/evil'";
+    process.env.GIT_CONFIG_KEY_0 = "core.hooksPath";
+    process.env.GIT_CONFIG_VALUE_0 = "/evil";
+    process.env.GIT_CONFIG_KEY_12 = "core.pager";
+    process.env.GIT_CONFIG_VALUE_12 = "cat";
+
+    const env = createPinnedGitEnv("sha1");
+
+    expect(env.GIT_CONFIG).toBeUndefined();
+    expect(env.GIT_CONFIG_COUNT).toBeUndefined();
+    expect(env.GIT_CONFIG_PARAMETERS).toBeUndefined();
+    expect(env.GIT_CONFIG_KEY_0).toBeUndefined();
+    expect(env.GIT_CONFIG_VALUE_0).toBeUndefined();
+    expect(env.GIT_CONFIG_KEY_12).toBeUndefined();
+    expect(env.GIT_CONFIG_VALUE_12).toBeUndefined();
+  });
+
+  it("keeps look-alike variables that the anchored pattern does not match", () => {
+    process.env.GIT_CONFIG_KEY_x = "not-numbered";
+    process.env.GIT_CONFIG_KEYS_1 = "plural";
+    process.env.MY_GIT_CONFIG_KEY_1 = "prefixed";
+
+    const env = createPinnedGitEnv("sha1");
+
+    expect(env.GIT_CONFIG_KEY_x).toBe("not-numbered");
+    expect(env.GIT_CONFIG_KEYS_1).toBe("plural");
+    expect(env.MY_GIT_CONFIG_KEY_1).toBe("prefixed");
+  });
+
+  it("preserves transport and auth variables", () => {
+    process.env.GIT_SSH_COMMAND = "ssh -i /key";
+    process.env.GIT_ASKPASS = "/usr/bin/askpass";
+    process.env.GIT_TERMINAL_PROMPT = "0";
+    process.env.PATH = process.env.PATH ?? "/usr/bin";
+
+    const env = createPinnedGitEnv("sha256");
+
+    expect(env.GIT_SSH_COMMAND).toBe("ssh -i /key");
+    expect(env.GIT_ASKPASS).toBe("/usr/bin/askpass");
+    expect(env.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(env.PATH).toBe(process.env.PATH);
+  });
+
+  it("returns a copy that does not mutate process.env", () => {
+    process.env.GIT_DIR = "/somewhere/.git";
+    const before = process.env.GIT_DEFAULT_HASH;
+
+    const env = createPinnedGitEnv("sha256");
+    env.SOME_NEW_VAR = "added";
+
+    expect(process.env.GIT_DIR).toBe("/somewhere/.git");
+    expect(process.env.GIT_DEFAULT_HASH).toBe(before);
+    expect(process.env.SOME_NEW_VAR).toBeUndefined();
+  });
+});
+
+// ─── resolvedLatestCommits ──────────────────────────────────────────────────
+
+describe("resolvedLatestCommits", () => {
+  const FULL_COMMIT = "a".repeat(39) + "9";
+
+  function registryLock(commitHash: string) {
+    return {
+      version: 1 as const,
+      skills: {
+        "code-review": {
+          source: "github:acme/skills",
+          commitHash,
+          ref: null,
+          installedAt: "2026-01-01T00:00:00.000Z",
+          provider: "claude",
+          sourceType: "registry" as const,
+          registryName: "code-review",
+        },
+      },
+    };
+  }
+
+  function registryIndex(commit: string): RegistryIndex {
+    return {
+      generated_at: "2026-01-01T00:00:00.000Z",
+      manifests: [
+        {
+          name: "code-review",
+          author: "acme",
+          description: "Review code",
+          repository: "https://github.com/acme/skills",
+          commit,
+          security_verdict: "pass",
+          published_at: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    };
+  }
+
+  it("is a WeakMap", () => {
+    expect(resolvedLatestCommits).toBeInstanceOf(WeakMap);
+  });
+
+  it("is the same instance the checkOutdated writer path populates", async () => {
+    const summary = await checkOutdated({
+      lock: registryLock("b".repeat(40)),
+      fetchRegistryIndexFn: async () => registryIndex(FULL_COMMIT),
+    });
+
+    expect(summary.entries).toHaveLength(1);
+    expect(summary.entries[0].status).toBe("outdated");
+    // The map holds the FULL oid while the entry exposes only the short hash.
+    expect(resolvedLatestCommits.get(summary.entries[0])).toBe(FULL_COMMIT);
+  });
+
+  it("records the resolved commit for up-to-date entries too", async () => {
+    const summary = await checkOutdated({
+      lock: registryLock(FULL_COMMIT),
+      fetchRegistryIndexFn: async () => registryIndex(FULL_COMMIT),
+    });
+
+    expect(summary.entries[0].status).toBe("up-to-date");
+    expect(resolvedLatestCommits.get(summary.entries[0])).toBe(FULL_COMMIT);
+  });
+
+  it("does not record entries that never resolved a remote commit", async () => {
+    const summary = await checkOutdated({
+      lock: {
+        version: 1,
+        skills: {
+          "my-local": {
+            source: "local:/path/to/skill",
+            commitHash: "abc1234",
+            ref: null,
+            installedAt: "2026-01-01T00:00:00.000Z",
+            provider: "claude",
+            sourceType: "local",
+          },
+        },
+      },
+      fetchRegistryIndexFn: async () => null,
+    });
+
+    expect(resolvedLatestCommits.get(summary.entries[0])).toBeUndefined();
+  });
+
+  it("keys strictly by entry object identity", async () => {
+    const summary = await checkOutdated({
+      lock: registryLock("b".repeat(40)),
+      fetchRegistryIndexFn: async () => registryIndex(FULL_COMMIT),
+    });
+
+    const clone = { ...summary.entries[0] };
+    expect(resolvedLatestCommits.get(clone)).toBeUndefined();
+    expect(resolvedLatestCommits.get(summary.entries[0])).toBe(FULL_COMMIT);
+  });
+});
+
+// ─── normalizedTargetIdentity ───────────────────────────────────────────────
+
+describe("normalizedTargetIdentity", () => {
+  it("lowercases ASCII names", () => {
+    expect(normalizedTargetIdentity("My-Skill")).toBe("my-skill");
+    expect(normalizedTargetIdentity("I")).toBe("i");
+  });
+
+  it("is idempotent", () => {
+    for (const name of ["Café", "MY-SKILL", "éclair", "straße"]) {
+      expect(normalizedTargetIdentity(normalizedTargetIdentity(name))).toBe(
+        normalizedTargetIdentity(name),
+      );
+    }
+  });
+
+  it("maps decomposed and precomposed forms to the same identity", () => {
+    const decomposed = "Cafe\u0301"; // e + combining acute
+    const precomposed = "Caf\u00e9"; // precomposed e-acute
+    expect(normalizedTargetIdentity(decomposed)).toBe(
+      normalizedTargetIdentity(precomposed),
+    );
+    expect(normalizedTargetIdentity(decomposed)).toBe("caf\u00e9");
+  });
+
+  it("does not trim surrounding whitespace", () => {
+    expect(normalizedTargetIdentity("  My Skill  ")).toBe("  my skill  ");
+  });
+
+  it("returns the empty string unchanged", () => {
+    expect(normalizedTargetIdentity("")).toBe("");
+  });
+});
+
+// ─── poolAll ────────────────────────────────────────────────────────────────
+
+describe("poolAll", () => {
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  it("returns results in input order regardless of completion order", async () => {
+    const gates = [deferred<void>(), deferred<void>(), deferred<void>()];
+    const pending = poolAll([0, 1, 2], 3, async (i) => {
+      await gates[i].promise;
+      return `item-${i}`;
+    });
+
+    // Finish in reverse order.
+    gates[2].resolve();
+    gates[1].resolve();
+    gates[0].resolve();
+
+    await expect(pending).resolves.toEqual(["item-0", "item-1", "item-2"]);
+  });
+
+  it("never exceeds the concurrency limit", async () => {
+    const items = [0, 1, 2, 3, 4, 5, 6];
+    const gates = items.map(() => deferred<void>());
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const pending = poolAll(items, 3, async (i) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await gates[i].promise;
+      inFlight--;
+      return i;
+    });
+
+    // Release one at a time so each free slot is immediately refilled.
+    for (const gate of gates) {
+      gate.resolve();
+      await new Promise((r) => setImmediate(r));
+    }
+
+    await pending;
+    expect(maxInFlight).toBe(3);
+  });
+
+  it("runs items sequentially when concurrency is 1", async () => {
+    const order: string[] = [];
+    await poolAll([0, 1, 2], 1, async (i) => {
+      order.push(`start-${i}`);
+      await Promise.resolve();
+      order.push(`end-${i}`);
+      return i;
+    });
+
+    expect(order).toEqual([
+      "start-0",
+      "end-0",
+      "start-1",
+      "end-1",
+      "start-2",
+      "end-2",
+    ]);
+  });
+
+  it("caps worker count at the item count when concurrency exceeds it", async () => {
+    let maxInFlight = 0;
+    let inFlight = 0;
+
+    const results = await poolAll([1, 2], 100, async (n) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight--;
+      return n * 2;
+    });
+
+    expect(results).toEqual([2, 4]);
+    expect(maxInFlight).toBe(2);
+  });
+
+  it("resolves immediately for an empty item list without calling fn", async () => {
+    let calls = 0;
+    const results = await poolAll([], 5, async (item: number) => {
+      calls++;
+      return item;
+    });
+
+    expect(results).toEqual([]);
+    expect(calls).toBe(0);
+  });
+
+  it("spawns no workers when concurrency is 0", async () => {
+    let calls = 0;
+    const results = await poolAll([1, 2, 3], 0, async (n) => {
+      calls++;
+      return n;
+    });
+
+    expect(calls).toBe(0);
+    expect(results).toHaveLength(3);
+  });
+
+  it("rejects with the first error thrown by the mapper", async () => {
+    await expect(
+      poolAll([1, 2, 3], 2, async (n) => {
+        if (n === 1) throw new Error(`boom on ${n}`);
+        return n;
+      }),
+    ).rejects.toThrow("boom on 1");
+  });
+
+  it("propagates a rejected promise returned by the mapper", async () => {
+    await expect(
+      poolAll([1], 1, () => Promise.reject(new Error("rejected"))),
+    ).rejects.toThrow("rejected");
+  });
+});
+
+// ─── getUpdateSourceDir ─────────────────────────────────────────────────────
+
+describe("getUpdateSourceDir", () => {
+  function entryWith(skillPath?: string): LockEntry {
+    return {
+      source: "github:acme/skills",
+      commitHash: "a".repeat(40),
+      ref: null,
+      installedAt: "2026-01-01T00:00:00.000Z",
+      provider: "claude",
+      ...(skillPath === undefined ? {} : { skillPath }),
+    };
+  }
+
+  it("joins the skill path onto the temp dir", () => {
+    expect(getUpdateSourceDir("/tmp/clone", entryWith("skills/review"))).toBe(
+      join("/tmp/clone", "skills/review"),
+    );
+  });
+
+  it("returns the temp dir when skillPath is absent", () => {
+    expect(getUpdateSourceDir("/tmp/clone", entryWith())).toBe("/tmp/clone");
+  });
+
+  it("treats an empty skillPath as the repository root", () => {
+    expect(getUpdateSourceDir("/tmp/clone", entryWith(""))).toBe("/tmp/clone");
+  });
+
+  it("normalizes redundant separators and dot segments", () => {
+    expect(getUpdateSourceDir("/tmp/clone/", entryWith("./a//b"))).toBe(
+      "/tmp/clone/a/b",
+    );
+  });
+
+  it("appends rather than rebases an absolute skillPath", () => {
+    // join() does not reset on a leading separator the way resolve() would.
+    expect(getUpdateSourceDir("/tmp/clone", entryWith("/etc/passwd"))).toBe(
+      "/tmp/clone/etc/passwd",
+    );
+  });
+
+  it("does not guard against parent traversal in skillPath", () => {
+    // Documents current behaviour: `..` segments escape the temp dir.
+    expect(getUpdateSourceDir("/tmp/clone", entryWith("../outside"))).toBe(
+      "/tmp/outside",
+    );
+  });
+});


### PR DESCRIPTION
Two commits: a typecheck repair that unblocks the pre-commit hook, then the
coverage work itself.

## `test(core)` — cover the split core modules and install-inspect

The #455 module split left five modules with no test file beside them.
`src/commands/install-inspect.ts` had **zero** coverage; the four `*-core`
modules were reached only indirectly through their barrels, because
`evaluator.test.ts` and friends import the barrel, never the core.

196 new tests, all under a second. No product code changes.

Per-module coverage, measured by running the full `src/` suite twice —
once with these files excluded, once with them included
(`--coverage.reporter=json-summary`):

| module | before | after |
| --- | --- | --- |
| `src/commands/install-inspect.ts` | 0% L / 0% B | **100% / 95.45%** |
| `src/library-core.ts` | 78.88% / 70.20% | **85.92% / 78.78%** |
| `src/evaluator-core.ts` | 89.77% / 86.43% | **94.24% / 91.95%** |
| `src/formatter-core.ts` | 95.39% / 76.89% | **96.31% / 82.77%** |
| `src/updater-core.ts` | 97.02% / 85.88% | **98.01% / 87.05%** |
| **suite total** | 63.38% / 56.66% | **64.61% / 58.30%** |

Those absolutes are not comparable to the 60.61% baseline in `CLAUDE.md` —
different reporter config. The deltas are the number that matters: **+1.23pp
lines, +1.64pp branches.**

None of the new tests touch `homedir`, `HOME`, `USERPROFILE`, or absolute
paths, so they stay inside the `src/test-setup.ts` sandbox.

## `fix(types)` — repair stats.test.ts fixtures — Closes #576

`npm run typecheck` was already red on `main` with 10 errors in
`src/commands/stats.test.ts`, all fixture drift. The tests passed at
runtime, so only the gate was broken — but the pre-commit hook runs
`tsc --noEmit`, which blocked this branch. Folded in rather than bypassed
with `--no-verify`.

- `IndexedSkill`: `path` → `relPath`, plus the required fields the interface
  has since gained. A `makeSkill` helper supplies inert defaults so the
  fixtures type-check honestly instead of via `as any`.
- `RepoIndex`: `url` → `repoUrl`, and the required `updatedAt`.
- `ParsedArgs`: two hand-built literals used a stale shape (`input`,
  kebab-case `"no-color"`). They now call the real `parseArgs`. It is
  imported **dynamically** — a static `../cli` import loads modules the
  hoisted `vi.mock` factory touches, and the suite dies with
  `Cannot access 'mockIndices' before initialization`.
- Dropped a `@ts-expect-error` that no longer suppressed anything, and
  widened `exitCode` to the type `process.exit` actually passes.

Note that TS reports only one excess-property error per object literal, so
the original 10 errors were not the whole set — fixing `path` surfaced five
more on `url`.

## Verification

- `npm run typecheck` — **clean** (was 10 errors on `main`)
- `CI=true npm test` — 77 files, 2535 tests, all pass
- `npm run lint` — clean
- pre-push hooks — unit tests, build, and e2e all passed

## Follow-up

The same #455 split left seven more modules untested: `installer-core`,
`installer-link`, `evaluator-batch`, `evaluator-fix`, `evaluator-pii-lint`,
`formatter-detail`, `library-update`, `updater-updates`. Same shape of work,
deliberately not folded in here.
