### PR TITLE
refactor(skills): finish skill-auto-improver reference split

### DIFF
--- a/skills/skill-auto-improver/SKILL.md
+++ b/skills/skill-auto-improver/SKILL.md
@@ -6,32 +6,32 @@ compatibility: "Claude Code; requires `asm` on PATH and Python 3 for skill-creat
 allowed-tools: Bash Read Write Edit Grep Glob
 effort: high
 metadata:
-  version: 2.0.0
+  version: 2.1.0
   author: luongnv89
 ---
 
 # Skill Auto-Improver
 
-You run an eval-driven loop that **retrofits an existing SKILL.md to the current skill-creator standard**. This is the remediation tool for skills that did **not** go through skill-creator — external, legacy, manually-authored, or drifted. Fresh skill-creator output is publish-ready by construction (see skill-creator's `predictability-rubric.md` → _Publish-ready — no auto-improver dependency_) and should **not** normally need this skill.
+You run an eval-driven loop that **retrofits an existing SKILL.md to the current skill-creator standard**. It is the remediation tool for skills that did **not** go through skill-creator — external, legacy, manually-authored, or drifted. Fresh skill-creator output is publish-ready by construction and should not normally need it.
 
-The target must clear **two hard gates**, then gets one **advisory** audit:
+The target clears **two hard gates**, then gets one **advisory** audit:
 
-1. **Gate 1 — skill-creator standard (must-pass floor)** — `quick_validate` clean, Frontmatter Audit passes, ≤500 lines (detail below).
+1. **Gate 1 — skill-creator standard (must-pass floor)** — `quick_validate` clean, Frontmatter Audit passes, within the size caps.
 2. **Gate 2 — asm-eval floor (supplementary)** — `overallScore > 85` AND every category `>= 8`.
-3. **Advisory — predictability audit (Phase 2b, not a gate)** — judgment-based findings against skill-creator's rubric, reported separately, **never** blocking.
+3. **Advisory — predictability audit (Phase 2b)** — judgment-based findings against skill-creator's rubric, reported separately, **never** blocking.
 
-A skill that scores 92 but fails `quick_validate.py` is not done; one that passes `quick_validate.py` but scores 70 is not done. **Both gates must clear, or the loop reports a blocker** — open predictability findings alone never make one.
+A skill that scores 92 but fails `quick_validate.py` is not done; one that passes it but scores 70 is not done either. **Both gates must clear, or the loop reports a blocker** — open predictability findings alone never make one.
 
 ## Two modes
 
 Pick one before Phase 0 — they do not share a workflow.
 
-- **Mode 1 — retrofit (default).** Bring the target to the skill-creator standard: the Phase 0–7 loop below, unchanged. Every "improve", "fix", "level up", or "bring up to standard" request is Mode 1.
-- **Mode 2 — delegation conversion (opt-in).** Restructure the target's steps onto **per-step context delegation** — each heavy step names the slice of its own `references/` tree its worker needs and hands it over as the worker's `Input` (skill-creator's `subagent-patterns.md` → _Per-Step Context Delegation_). Runs **outside** the Phase 6 loop, on a target that already clears Gate 1, and only after the user confirms the restructure. A Phase 2b delegability finding routes here — it never starts a conversion by itself. Read `references/delegation-conversion.md` for the whole procedure, including the target's MAJOR bump and when a conversion does not pay for itself.
+- **Mode 1 — retrofit (default).** Bring the target to the skill-creator standard via the Phase 0–7 loop below. Every "improve", "fix", "level up", or "bring up to standard" request is Mode 1.
+- **Mode 2 — delegation conversion (opt-in).** Restructure the target's steps onto **per-step context delegation**: each heavy step names the slice of its own `references/` tree its worker needs and hands it over as that worker's `Input`. Runs **outside** the Phase 6 loop, on a target that already clears Gate 1, and only once the user confirms. A Phase 2b delegability finding routes here but never starts a conversion by itself. Procedure: `references/delegation-conversion.md`.
 
 ## Dependency Preflight (mandatory)
 
-This skill invokes `skill-creator`: it runs that skill's `quick_validate.py` (required — the Gate 1 validator) and reads its `predictability-rubric.md` (fail-soft — Phase 2b). Resolve both once and reuse them **before the repo sync below**, which is the first step that changes anything. The rubric is **fail-soft** — a locally-installed skill-creator may predate the repo and not ship it; a missing file only degrades Phase 2b to a warning and never aborts the run:
+This skill invokes `skill-creator`: it runs that skill's `quick_validate.py` (required — the Gate 1 validator) and reads its `predictability-rubric.md` (**fail-soft** — a local copy may predate the rubric, and a missing one only degrades Phase 2b to a warning). Resolve both **before the repo sync below**, the first step that changes anything:
 
 ```bash
 date +%s >&2                      # anchors the Run stats block below — read it off stderr
@@ -47,13 +47,13 @@ RUBRIC="$HOME/.claude/skills/skill-creator/references/predictability-rubric.md"
 test -f "$RUBRIC" || echo "⚠ predictability rubric missing — Phase 2b degraded (gates unaffected)"
 ```
 
-`-p claude` is required, not decoration: `asm install` refuses to guess a provider in a non-interactive shell and `--yes` does not cover that choice, so a gate that omits it hands the user a command that errors instead of installing. The verification names the same provider the detection path belongs to, so an install landing under a different tool cannot report success while `$QV` is still missing.
+`-p claude` is not decoration: `asm install` refuses to guess a provider non-interactively, `--yes` does not cover that choice, and naming the same provider in the verification stops an install under a different tool from reporting success while `$QV` is still missing.
 
-On a miss, stop before the first mutation and print the three commands above — do not continue with a partial run. This is the same gate this skill audits every target for (`references/skill-creator-checklist.md` → _Dependency preflight_).
+On a miss, stop before the first mutation and print those commands — never continue with a partial run. This is the gate this skill audits every target for (`references/skill-creator-checklist.md` → _Dependency preflight_).
 
 ## Repo Sync Before Edits (mandatory)
 
-This skill mutates files in a git repo. Before any edit, sync the local branch with the remote:
+This skill mutates files in a git repo. Sync the branch with the remote before any edit:
 
 ```bash
 branch="$(git rev-parse --abbrev-ref HEAD)"
@@ -61,57 +61,53 @@ git fetch origin
 git pull --rebase origin "$branch"
 ```
 
-If the working tree is dirty, `git stash`, sync, then `git stash pop`. If `origin` is missing or `git pull` hits conflicts, **stop and ask the user** before continuing — do not skip or force the sync.
+If the tree is dirty, `git stash`, sync, `git stash pop`. If `origin` is missing or the pull conflicts, **stop and ask the user** — never skip or force the sync.
 
 ## When to Use
 
 Reach for this on an **existing, external, legacy, manually-authored, or drifted** skill:
 
 - The user asks to "improve", "level up", "fix", "polish", or "bring up to standard" an existing skill
-- A skill was authored outside skill-creator (hand-written, imported, inherited) and must meet the current bar
-- A skill has **drifted** — predates the standard, or edits left it failing `quick_validate.py` or below the 85/8 floor
+- A skill was authored outside skill-creator — hand-written, imported, inherited — and must meet the current bar
+- A skill has **drifted**: it predates the standard, or edits left it failing `quick_validate.py` or below the 85/8 floor
 - You are preparing such a skill for `asm publish` or a catalog
 
-**Not** for routine cleanup of fresh skill-creator output (publish-ready by construction — use `/skill-creator` to author). Assumes a SKILL.md exists. For a report only, run `asm eval` and `quick_validate.py` directly — not this skill.
+**Not** for fresh skill-creator output (author with `/skill-creator`), and not for a report only (`asm eval` plus `quick_validate.py`, run directly). Assumes a SKILL.md exists.
 
 ## Prerequisites
 
-Verify all of the following before touching any files. Stop and tell the user if any fails.
+Verify all of these before touching any files. Stop and tell the user if any fails.
 
-- `asm` is available on PATH (`command -v asm` or `which asm`)
-- Python 3 is available; skill-creator's `quick_validate.py` is resolved by _Dependency Preflight (mandatory)_ above, which is the only place that handles a miss
-- The target skill path contains a `SKILL.md` file
-- The working tree has no unrelated uncommitted edits (dirty files get mixed into diffs)
+- `asm` is on PATH (`command -v asm`)
+- Python 3 is available — `quick_validate.py` itself is resolved by _Dependency Preflight (mandatory)_, the only place that handles a miss
+- The target skill path contains a `SKILL.md`
+- The working tree has no unrelated uncommitted edits — dirty files get mixed into diffs
 - You have write access to the skill directory
 
 ## Inputs
 
-The user provides one of:
+One of: a local skill path (`skills/foo`, `/abs/path/to/skill`), a `SKILL.md` file path (treated as its parent directory), or a GitHub shorthand (`github:owner/repo[:path/to/skill]`).
 
-- A local skill path: `skills/foo` or `/abs/path/to/skill`
-- A direct `SKILL.md` file path (treated as its parent directory)
-- A GitHub shorthand: `github:owner/repo` or `github:owner/repo:path/to/skill`
-
-For GitHub inputs, ask the user to clone locally first or whether you should open a PR back to that repo. This skill's default path is **local editing** — remote editing is out of scope for v1.
+For a GitHub input, ask the user to clone locally first. This skill edits **locally**; remote editing is out of scope for v1.
 
 ## The Gates
 
-Keep two decision classes separate: **hard gates** (Gate 1, Gate 2) are mechanical and pass/fail — they alone decide PASS vs BLOCKER. **Predictability findings** (Phase 2b) are judgment-based and advisory — both gates green with open findings is still a PASS.
+**Hard gates** (Gate 1, Gate 2) are mechanical and pass/fail — they alone decide PASS vs BLOCKER. **Predictability findings** (Phase 2b) are judgment-based and advisory: both gates green with open findings is still a PASS. Green gates do not guarantee the skill drives the same _process_ each run — that is what Phase 2b catches, and `references/predictability-audit.md` holds its checklist and finding classes.
 
 ### Gate 1 — Skill-creator standard (must-pass floor)
 
-A skill passes this gate when **all** of these are true:
+A skill passes when **all** of these hold:
 
-- `python "$QV" "$SKILL_PATH"` exits 0 (no unexpected keys, name is kebab-case ≤64 chars, description is single-line ≤1024 chars, etc.)
-- The Frontmatter Audit (full checklist in `references/frontmatter-audit.md`) passes
-- `SKILL.md` body is under 500 lines (split to `references/` if not)
-- Description includes a negative-trigger clause naming adjacent domains that should not trigger the skill (`quick_validate.py` warns when missing)
-- `metadata.version` follows `MAJOR.MINOR.PATCH`; `metadata.author` is present
-- If `docs/README.md` exists, it carries the AI-skip HTML comment at the top
-- Any bundled scripts under `scripts/` print descriptive errors on stderr before exiting
-- **If the target skill invokes another skill**, it carries a dependency preflight that names each dependency, its install command, the command that installs the installer itself, and a verification step (`references/skill-creator-checklist.md` → _Dependency preflight_). A skill that invokes no other skill needs no such section — its absence is not a finding, and never add an empty one
+- `python "$QV" "$SKILL_PATH"` exits 0
+- The Frontmatter Audit passes — checklist in `references/frontmatter-audit.md`
+- The body is under 500 lines **and** under 3000 words
+- The description carries a negative-trigger clause naming adjacent domains that should not trigger the skill
+- `metadata.version` is `MAJOR.MINOR.PATCH`; `metadata.author` is present
+- A `docs/README.md`, if present, opens with the AI-skip HTML comment
+- Any bundled script under `scripts/` prints a descriptive error on stderr before exiting
+- **If the target skill invokes another skill**, it carries a dependency preflight naming each dependency, its install command, the command that installs the installer itself, and a verification step (`references/skill-creator-checklist.md` → _Dependency preflight_). A target that invokes none needs no such section — never add an empty one
 
-This gate is **non-negotiable** — `asm publish` and the catalog rely on it.
+This gate is **non-negotiable**: `asm publish` and the catalog rely on it.
 
 ### Gate 2 — asm-eval 85/8 quality floor (supplementary)
 
@@ -119,15 +115,11 @@ This gate is **non-negotiable** — `asm publish` and the catalog rely on it.
 overallScore > 85   AND   min(categories[*].score) >= 8
 ```
 
-Stricter than overall alone — 86 with a 5 in `testability` still fails. Forces balanced quality instead of letting one strong area hide a weak one.
-
-### Advisory — predictability audit (not a gate)
-
-Both gates green does not guarantee the skill drives the same _process_ each run. The Phase 2b audit catches that — see `references/predictability-audit.md` for the checklist and finding classes.
+Stricter than overall alone — 86 with a 5 in `testability` still fails — so one strong area cannot hide a weak one.
 
 ## Workflow
 
-Do these phases in order. Do not skip phases or change the order. **Phase 4 is a continuous sidebar that runs throughout Phase 3 — not a standalone step**, which is why it does not appear in the per-phase Step Completion Reports.
+Do these phases in order; never skip one or reorder them. **Phase 4 is a continuous sidebar running throughout Phase 3, not a standalone step**, which is why it has no Step Completion Report of its own.
 
 ### Phase 0 — Capture baseline against both gates
 
@@ -139,17 +131,11 @@ asm eval "$SKILL_PATH" --json > .asm-improver/baseline.json
 python "$QV" "$SKILL_PATH" > .asm-improver/baseline-quickvalidate.txt 2>&1 || true
 ```
 
-Then perform the **Frontmatter Audit** described in `references/frontmatter-audit.md` and save findings to `.asm-improver/baseline-frontmatter-audit.md`.
+Then run the **Frontmatter Audit** from `references/frontmatter-audit.md`, saving findings to `.asm-improver/baseline-frontmatter-audit.md`. In a git repo, suggest adding `.asm-improver/` to `.gitignore`.
 
-If the target skill lives inside a git repo, suggest adding `.asm-improver/` to `.gitignore` so iteration artifacts stay out of version control.
+Read the JSON and note `overallScore`, `grade`, all 7 `categories[].score`, and `topSuggestions`. Each category's `findings` carry the measured numbers behind its score — body word count among them. Use those; never approximate by hand.
 
-Read the JSON and note:
-
-- `overallScore`, `grade`
-- Every `categories[].score` (7 categories, each out of 10)
-- `topSuggestions` (the evaluator's own priorities)
-
-If the baseline already passes **both** gates, stop immediately — print a one-line summary and skip to the final report. Do not "improve" a skill that already passes (a delegability finding is not a reason to keep going in Mode 1 — offer Mode 2 instead).
+If the baseline passes **both** gates, stop: print a one-line summary and skip to the final report. A delegability finding is not a reason to keep going in Mode 1 — offer Mode 2 instead.
 
 ### Phase 1 — Apply deterministic fixes, then normalize frontmatter
 
@@ -160,77 +146,61 @@ asm eval "$SKILL_PATH" --fix --dry-run   # preview the diff
 asm eval "$SKILL_PATH" --fix              # write, creates SKILL.md.bak
 ```
 
-This handles trailing whitespace, CRLF normalization, missing `effort`, and other mechanical issues. **However, when authorship or version is missing, `asm eval --fix` writes a top-level `author:` (from `git config user.name`) and/or top-level `version: 0.1.0` — both of which `quick_validate.py` rejects as unexpected keys.** Immediately follow with the normalization step below.
+It handles trailing whitespace, CRLF normalization, and a missing `effort`. A dry-run reporting **"No fixes needed"** satisfies this phase — do not apply `--fix` anyway.
 
 #### Frontmatter normalization (mandatory after `--fix`)
 
-Read `references/frontmatter-audit.md` — section "Normalizing `asm eval --fix` output" — for the exact migration. In short:
-
-- Move top-level `author: <name>` → `metadata.author: <name>` (keep the value). The current fixer writes `author:`; older skills may carry a top-level `creator:` instead — treat it the same way and migrate to `metadata.author:`.
-- Move top-level `version: <semver>` → `metadata.version: <semver>` (keep the value)
-- Drop any other top-level keys that aren't in the allowed set (`name`, `description`, `license`, `allowed-tools`, `metadata`, `compatibility`, `effort`) — e.g., legacy `tags:`. Surface non-trivial drops to the user before deleting.
-- Quote any string value containing `:`, `#`, `-`, `<`, `>`, `|`, `{`, `}`, `[`, `]`, `,`, `&`, `*`, `?`, `=`, `!`, `%`, `@`, or `` ` `` per the YAML safety rule
-
-After normalization, re-run **both** checks:
+When it does write, `--fix` adds a top-level `author:` (from `git config user.name`) and/or `version: 0.1.0`, both of which `quick_validate.py` rejects as unexpected keys. Apply `references/frontmatter-audit.md` → _Normalizing `asm eval --fix` output_. Then re-run **both** checks:
 
 ```bash
 asm eval "$SKILL_PATH" --json > .asm-improver/iter-1.json
 python "$QV" "$SKILL_PATH"
 ```
 
-Many skills jump 5–15 points on `asm eval` here without touching the body, and `quick_validate.py` typically goes from fail to pass.
+Many skills jump 5–15 points here without touching the body, and `quick_validate.py` typically goes from fail to pass.
 
 ### Phase 2 — Fix Gate 1 failures first
 
-`quick_validate.py` and the Frontmatter Audit findings come first because they gate publish. Read `references/skill-creator-checklist.md` for the full retrofit playbook. Common fixes:
+`quick_validate.py` and the Frontmatter Audit come first because they gate publish. `references/skill-creator-checklist.md` carries the fix for each failing check — frontmatter, description, body size, the `docs/README.md` AI-skip notice, script stderr, version, and preflight. Work it top to bottom.
 
-- Description missing a negative-trigger clause → append "Don't use for X, Y, Z." naming 2–3 adjacent domains
-- Description over 250 chars → trim hedge words, collapse synonyms (1024 is the hard ceiling, 250 is the runtime-budget target)
-- Body over 500 lines → split dense sections into `references/<topic>.md` and replace inline content with a one-line pointer
-- Missing AI-skip notice in `docs/README.md` → prepend the HTML comment from `references/skill-creator-checklist.md`
-- Bundled script exits silently → add `echo "Error: ..." >&2` lines before each `exit 1` / `sys.exit(1)`
-- Skill invokes another skill with no preflight gate, or with one that never explains installation → report the finding and add the gate from `references/skill-creator-checklist.md` → _Dependency preflight_. Detect it by scanning the target for `/skill-name` invocations, reads under `~/.claude/skills/` or `~/.agents/skills/`, and phases handed to a named skill
+One check has no mechanical validator behind it, so look for it deliberately: **Skill invokes another skill with no preflight gate**, or one that never explains installation. Detect it by scanning for `/skill-name` invocations, reads under `~/.claude/skills/` or `~/.agents/skills/`, and phases handed to a named skill; remediate with the checklist's _Dependency preflight_ section.
 
-Re-run `python "$QV" "$SKILL_PATH"` after every Gate 1 edit. Do not move to Phase 2b until Gate 1 is clean.
+Re-run `python "$QV" "$SKILL_PATH"` after every Gate 1 edit. Do not enter Phase 2b until Gate 1 is clean.
 
 ### Phase 2b — Audit against the predictability rubric (advisory)
 
-With Gate 1 clean, audit against skill-creator's rubric **before** Phase 3 so the findings can steer your category edits. Advisory — never gates, never blocks.
+With Gate 1 clean, audit against skill-creator's rubric **before** Phase 3, so findings can steer your category edits. Advisory — never gates, never blocks.
 
-1. Confirm `$RUBRIC` resolved (_Dependency Preflight (mandatory)_). If missing, **skip fail-soft** — log `⚠ predictability audit skipped (rubric unavailable)` and move to Phase 3.
-2. Walk `references/predictability-audit.md` — record each of the 7 items as `pass` / `advisory` with a specific note, save to `.asm-improver/predictability-audit.md`. Item #4 carries the **delegability sub-check**: a heavy step that names no `references/` slice is an advisory finding naming which step and why it is not delegable, and its remediation is Mode 2 — never a Mode 1 edit.
+1. Confirm `$RUBRIC` resolved (_Dependency Preflight (mandatory)_). If missing, **skip fail-soft**: log `⚠ predictability audit skipped (rubric unavailable)` and go to Phase 3.
+2. Walk `references/predictability-audit.md`, marking each of its 7 items `pass` or `advisory` with a specific note, and save the walk to `.asm-improver/predictability-audit.md`. Item #4's **delegability sub-check** names which step is not delegable and why; its remediation is Mode 2, never a Mode 1 edit.
 
-Act on findings only when _targeted_ (a predictability fix often also lifts an asm-eval category); never bloat to satisfy one. Finding-handling detail and the no-bloat rule live in `references/predictability-audit.md`.
+Act on a finding only when the fix is _targeted_ — one often lifts an asm-eval category too. Never bloat to satisfy one; that rule is in the same reference.
 
 ### Phase 3 — Fix the lowest asm-eval categories
 
-Sort the 7 categories by score ascending. Work on the lowest one first. Stop when all of them are `>= 8`.
+Sort the 7 categories ascending and work the lowest first. Stop when all are `>= 8` — never chase points a passing category does not need.
 
 For each category below 8:
 
-1. Read `references/category-playbook.md` to find the fix patterns for that category
-2. Apply them with `Edit` (small targeted changes) or `Write` (when restructuring a whole section)
-3. Re-run `asm eval "$SKILL_PATH" --json` and `python "$QV" "$SKILL_PATH"` and check the deltas
+1. Read `references/category-playbook.md` for that category's fix patterns
+2. Apply them with `Edit`, or `Write` when restructuring a whole section
+3. Re-run `asm eval "$SKILL_PATH" --json` and `python "$QV" "$SKILL_PATH"`, checking **every** category's delta, not just the one you edited
 
-**Do not batch-edit multiple categories blindly.** Fixes can interact — expanding the body for `testability` can tank `context-efficiency` or push the body over 500 lines (which fails Gate 1). One category at a time, re-eval after each change, keep the ones that help, revert the ones that regress either gate.
+**Never batch-edit categories blindly.** Fixes interact: expanding the body for `testability` can tank `context-efficiency` or breach the 500-line cap. One at a time; keep what helps, revert what regresses either gate.
 
 ### Phase 4 — Watch for cross-gate tradeoffs (sidebar — applies during Phase 3)
 
-A continuous sidebar, not a sequential phase: the two gates pull in opposite directions on body length, so a fix that lifts one asm-eval category can sink another or breach the 500-line cap. Read `references/cross-gate-tradeoffs.md` once before Phase 3 and default to **linking out, not inlining** on every edit.
+A continuous sidebar, not a sequential phase: the gates pull in opposite directions on body length, so a fix that lifts one category can sink another or breach a Gate 1 cap. SKILL.md is loaded whole on every invocation, so each inlined paragraph is a permanent charge against the agent's context window — a budget the `context-efficiency` score is measuring. Read `references/cross-gate-tradeoffs.md` once before Phase 3, then default to **linking out, not inlining** on every edit.
 
 ### Phase 5 — Bump the target skill's `metadata.version`
 
-This phase **runs as the last action inside each iteration of Phase 6's loop**, not as a separate one-time pass after Phase 6. The number is sequential for narrative flow; the actual execution is per-iteration.
+This runs as the **last action inside each Phase 6 iteration**, not as a one-time pass after it — the number is sequential for narrative only. Bump exactly **once per iteration**, never once per edit, or the version churns ahead of meaningful change. Record each bump so the report shows baseline → final.
 
-Per skill-creator's Version Management rule, every edit to a SKILL.md must bump `metadata.version` before saving:
-
-- **Patch** (`x.y.Z`): typo fixes, frontmatter-only normalization, minor wording tweaks
+- **Patch** (`x.y.Z`): typo fixes, frontmatter-only normalization, wording tweaks
 - **Minor** (`x.Y.0`): new sections, new references, expanded triggers, added subagents
 - **Major** (`X.0.0`): restructured workflow, breaking output-format changes
 
-If the target SKILL.md has no `metadata.version`, add one starting at `1.0.0`. Bump exactly **once per loop iteration**, not once per edit within an iteration — otherwise the version churns ahead of meaningful change.
-
-Record the bump in the loop log so the final report can show baseline → final version.
+A target with no `metadata.version` gets one, starting at `1.0.0`.
 
 ### Phase 6 — Loop with a cap
 
@@ -243,25 +213,25 @@ Re-run **both** checks after every iteration. The loop stops when any of these i
 | 3 consecutive iterations with no movement on either gate     | BLOCKER — write report   |
 | 2 consecutive iterations with regression on either gate      | BLOCKER — revert, report |
 
-**Mid-iteration Gate 1 regressions** — a Phase 3 edit can push SKILL.md over the 500-line cap or otherwise break a Gate 1 check (the two gates pull in opposite directions on body length; see Phase 4). When this happens within an iteration, do not let it close the iteration as a regression: drop back into Phase 2, fix the Gate 1 break in the same iteration, then re-run both checks. Only count the iteration as a regression if both gates are still worse than the previous iteration after that fix lands. This prevents the loop from tripping the "2 consecutive regressions" stop condition on a churn that the agent could resolve in-place.
+**Mid-iteration Gate 1 regressions are not regressions.** When a Phase 3 edit breaks a Gate 1 check (see Phase 4), drop back into Phase 2, fix it inside the same iteration, then re-run both checks. Count the iteration as a regression only if both gates are still worse afterwards — otherwise ordinary churn trips the 2-regression stop.
 
-Save every iteration's JSON to `.asm-improver/iter-N.json` and a one-line gate summary to `.asm-improver/iter-N-gates.txt` so the final report can diff them.
+Save every iteration to `.asm-improver/iter-N.json`, with a one-line gate summary in `.asm-improver/iter-N-gates.txt`, so the report can diff them.
 
 ### Phase 7 — Write the final report
 
-Write `.asm-improver/report.md` (full layout in `references/report-template.md`) keeping **three report sections visually distinct**:
+Write `.asm-improver/report.md` (layout: `references/report-template.md`) with **three visually distinct sections**:
 
-1. **Gate status** — baseline vs final for both hard gates (`quick_validate.py`, Frontmatter Audit, `overallScore`, `grade`, per-category before/after). Decides PASS vs BLOCKER.
-2. **Predictability findings** (advisory) — Phase 2b findings per item, open ones with a one-line note; say so if it was skipped fail-soft. Never a gate failure.
-3. **Unresolved blockers** — BLOCKER only; each names the failed **hard gate** (Gate 1 or Gate 2), the specific check, and what was unresolvable. Predictability findings are never promoted here.
+1. **Gate status** — baseline vs final for both hard gates: `quick_validate.py`, Frontmatter Audit, `overallScore`, `grade`, per-category before/after. This decides PASS vs BLOCKER.
+2. **Predictability findings** (advisory) — Phase 2b per item, each open one with a one-line note; say so if it was skipped fail-soft. Never a gate failure.
+3. **Unresolved blockers** — BLOCKER only, each naming the failed **hard gate**, the specific check, and what was unresolvable. Predictability findings are never promoted here.
 
-Also include: skill path, `metadata.version` baseline → final, files changed, iterations (N of 8), key fixes applied. Do not pretend a blocker is a pass. Close the report — and the printed summary — with the **Run stats** block below.
+Add the skill path, `metadata.version` baseline → final, files changed, iterations (N of 8), and key fixes. Never pretend a blocker is a pass. Close the report — and the printed summary — with the **Run stats** block below.
 
 ## Run stats (mandatory)
 
-Every run that updates a skill closes its summary with a run-stats block — the last thing printed, after the Phase 7 report. It reports what the run **cost**, and never repeats a metric the report already carries (iterations, scores, files changed).
+Every run closes its summary with a run-stats block — the last thing printed, after the Phase 7 report. It reports what the run **cost** and never repeats a metric the report already carries.
 
-`run_started_epoch` is captured once, by the `date +%s >&2` in the _Dependency Preflight (mandatory)_ block above; read the value off that block's stderr rather than from a shell variable, which need not survive to a later command. `elapsed` is `now - run_started_epoch`. A stop before that block ran has no anchor, so `elapsed` prints `n/a`.
+`elapsed` is `now - run_started_epoch`, where the epoch is the `date +%s >&2` in _Dependency Preflight (mandatory)_ — read it off that block's stderr, not a shell variable that need not survive. A stop before that block ran has no anchor, so `elapsed` prints `n/a`.
 
 ```
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
@@ -269,22 +239,12 @@ Every run that updates a skill closes its summary with a run-stats block — the
               agents 0 · skills 1 · tool calls 63
 ```
 
-Fields are fixed and in this order — never reordered, renamed, or added to:
+Fields are fixed and in this order — never reordered, renamed, or added to: `elapsed`, `tokens`, `cost`, `agents`, `skills`, `tool calls`. Per-field formatting: `references/run-stats.md`.
 
-| Field        | Value                                                                                            |
-| ------------ | ------------------------------------------------------------------------------------------------ |
-| `elapsed`    | wall-clock duration, `{H}h {M}m {S}s`; drop zero-valued leading units only (`4m 12s`, `48s`)     |
-| `tokens`     | **conditional** — printed only where the host reported a usage figure, with thousands separators |
-| `cost`       | **conditional** — printed only where the host reported a run cost, as `$0.42`                    |
-| `agents`     | subagents this run spawned                                                                       |
-| `skills`     | other skills this run invoked (`skill-creator`'s validator counts as one)                        |
-| `tool calls` | tool invocations this run made                                                                   |
-
-- **`tokens` and `cost` are omitted entirely when the host reported no figure** — no dangling `·`, no placeholder. Never estimate one from output length, file sizes, or iteration counts, and never reconstruct one from host transcripts or logs.
-- **`elapsed`, `agents`, `skills`, and `tool calls` always print.** A value that cannot be determined prints the literal `n/a`; `0` is a determined value and is correct where it is true.
+- **`tokens` and `cost` are omitted entirely when the host reported no figure** — no dangling `·`, no placeholder. Never estimate one, and never reconstruct one from host transcripts or logs.
+- **`elapsed`, `agents`, `skills`, and `tool calls` always print.** A value that cannot be determined prints the literal `n/a`; `0` is a determined value, correct where true.
 - A missing optional figure never suppresses the rest of the block.
-
-Print it at **every** terminal outcome, not only a PASS: a completed loop, a BLOCKER report, the Phase 0 early exit when the baseline already passes both gates, a failed prerequisite, and an aborted run. Only a run that produced no output at all has no block. One epoch read at start, one at the end, two lines of output — never a timing call per phase or a summarization pass.
+- Print the block at **every** terminal outcome — a completed loop, a BLOCKER, the Phase 0 early exit, a failed prerequisite, an aborted run. Only a run with no output at all has none.
 
 ## Step Completion Reports (mandatory)
 
@@ -301,52 +261,42 @@ After each phase, emit a compact status block so pass/fail is scannable:
   Result:              PASS | FAIL | PARTIAL
 ```
 
-Use `√` for pass, `×` for fail, `—` for context. Report per phase: Phase 0 (baseline captured), Phase 1 (deterministic + normalization), Phase 2 (Gate 1 fixes), Phase 2b (predictability audit — report findings count and "advisory" / "skipped fail-soft"; this phase never gates), Phase 3 (asm-eval category fixes), Phase 5 (version bump applied), Phase 6 (loop stop condition), Phase 7 (final report written, run stats printed).
+`√` is pass, `×` is fail, `—` is context. Emit one after each of Phase 0, 1, 2, 2b, 3, 5, 6, and 7. Phase 2b's block reports the findings count plus "advisory" or "skipped fail-soft" — that phase never gates.
 
 ## Acceptance Criteria
 
-- `.asm-improver/baseline.json`, `.asm-improver/baseline-quickvalidate.txt`, and `.asm-improver/baseline-frontmatter-audit.md` captured before any edits
-- `asm eval --fix` applied, then frontmatter normalized so `quick_validate.py` accepts the result
-- Each Gate 1 check addressed at least once before any Gate 2 work
-- A target that invokes another skill ends the run with a dependency preflight naming each dependency, its install command, the command that installs the installer itself, and a verification step; a target that invokes none gains no such section
-- Predictability audit (Phase 2b) run after Gate 1 is clean — findings captured to `.asm-improver/predictability-audit.md`, or the skip logged when the rubric is unavailable. Findings are advisory and never gate the loop
-- Each `asm eval` category below 8 addressed at least once
-- Re-eval against **both** gates after every iteration, captured to `.asm-improver/iter-N.json` and `.asm-improver/iter-N-gates.txt`
-- Target skill's `metadata.version` bumped exactly once per iteration that produced edits
-- Loop stops on one of the 4 conditions in Phase 6 — never unbounded
-- `.asm-improver/report.md` exists on exit, pass or blocker, with gate status, advisory predictability findings, and unresolved blockers as three visually distinct sections
-- Every terminal outcome closes with the Run stats block — `elapsed`, `agents`, `skills`, and `tool calls` always present (`n/a` when undetermined), `tokens` and `cost` printed only where the host reported them and never invented
-- On PASS: `python "$QV" "$SKILL_PATH"` exits 0 AND final eval JSON shows `overallScore > 85` AND `min(categories[*].score) >= 8`
-- On BLOCKER: report names every Gate 1 check still failing and every category still below 8 with a one-line reason. Open predictability findings alone never constitute a blocker
+The bars that decide the outcome. The full run checklist — every artifact and process obligation — is `references/acceptance-criteria.md`; walk it before writing the report.
+
+- Baselines captured to `.asm-improver/` **before any edits**, and every iteration re-evaluated against **both** gates and saved there
+- Each Gate 1 check addressed before any Gate 2 work; each category below 8 addressed at least once
+- Phase 2b run once Gate 1 is clean, or its fail-soft skip logged — findings never gate the loop
+- `metadata.version` bumped once per iteration that produced edits; the loop stopped on one of Phase 6's 4 conditions
+- `.asm-improver/report.md` exists on exit either way, and the summary closes with the Run stats block
+- On PASS: `python "$QV" "$SKILL_PATH"` exits 0 AND `overallScore > 85` AND `min(categories[*].score) >= 8`
+- On BLOCKER: the report names every failing Gate 1 check and every category still below 8 with a one-line reason each
 
 ### Expected output
 
-See `references/report-template.md` for the full PASS and BLOCKER report templates. On BLOCKER, include an `## Unresolved blockers` section naming each failing **hard gate** check with a one-line reason.
+See `references/report-template.md` for the full PASS and BLOCKER layouts. On BLOCKER, add an `## Unresolved blockers` section naming each failing **hard gate** check with a one-line reason.
 
 ## Edge Cases
 
-- **Skill already passes both gates**: do not edit it. Still run the Phase 2b predictability audit read-only and report any advisory findings, then stop — passing gates does not guarantee a predictable process, but open findings here never force an edit. A gate-passing skill with heavy non-delegable steps is a **Mode 2** candidate: offer the conversion, do not edit under Mode 1.
-- **SKILL.md has no frontmatter**: `asm eval --fix` cannot add it. Ask the user whether to scaffold one (using the skill-creator template) or abort.
-- **Iterating regresses either gate**: revert the last edit (`cp SKILL.md.bak SKILL.md` if available, or undo via git) and try a different fix pattern from the playbook.
-- **`asm eval --fix` writes a key `quick_validate.py` rejects**: this is expected — Phase 1's normalization step handles it. Do not skip the normalization.
-- **Description over 250 chars after edits**: trim. The 250-char target prevents tail-first truncation in Claude Code's `/skills` listing, which would chop your negative-trigger clause.
-- **SKILL.md body over 500 lines**: split into `references/` per the progressive-disclosure rule. SKILL.md must drop below 500 before exit.
-- **Loop caps out at 8 iterations**: the skill has structural issues auto-improvement cannot solve. Write the blocker report and hand back to the user.
-- **GitHub shorthand input**: for v1, ask the user to clone locally first. Remote editing is out of scope.
-- **Destructive action**: never `rm -rf` the skill directory. `asm eval --fix` creates `SKILL.md.bak` — leave it in place until the user explicitly cleans up.
+Two rules the phases above do not carry. Every other edge case — no frontmatter, a rejected `--fix` key, an over-250-char description, a content-pinning test, an over-length body, the 8-iteration cap, GitHub shorthand — is in `references/edge-cases.md`, read when it arises.
+
+- **Destructive action**: never `rm -rf` the skill directory. `asm eval --fix` creates `SKILL.md.bak` — leave it until the user explicitly cleans up.
+- **Gate-passing skill with heavy non-delegable steps**: a **Mode 2** candidate. Offer the conversion; never edit it under Mode 1.
 
 ## References
 
-- `references/skill-creator-checklist.md` — Gate 1 retrofit playbook (frontmatter, README, scripts, body length)
-- `references/frontmatter-audit.md` — full audit checklist plus the `asm eval --fix` normalization migration
-- `references/category-playbook.md` — per-category fix patterns for `asm eval` Gate 2
-- `references/predictability-audit.md` — Phase 2b advisory audit checklist (the rubric's operational checklist, applied to the target skill)
-- `references/cross-gate-tradeoffs.md` — Phase 4 sidebar: the body-length tradeoff between the two gates and the link-out rule
-- `references/delegation-conversion.md` — Mode 2: converting an existing skill onto per-step context delegation (opt-in, user-confirmed, outside the Phase 6 loop)
-- `references/report-template.md` — PASS, BLOCKER, and Mode 2 conversion report layouts
-- `~/.claude/skills/skill-creator/scripts/quick_validate.py` — the Gate 1 mechanical validator
-- `~/.claude/skills/skill-creator/references/frontmatter-rules.md` — upstream source of the audit rules
-- `~/.claude/skills/skill-creator/references/predictability-rubric.md` — upstream source of the Phase 2b audit (fail-soft if absent)
-- `~/.claude/skills/skill-creator/references/dependency-preflight.md` — upstream source of the dependency-preflight rule (the checklist above carries everything needed to audit and fix without it)
-- `asm eval --help` — flag reference for the evaluator
-- `src/evaluator.ts` in the ASM repo — source of truth for how each Gate 2 category is scored
+- `references/skill-creator-checklist.md` — Gate 1 retrofit playbook
+- `references/frontmatter-audit.md` — audit checklist and the `asm eval --fix` normalization migration
+- `references/category-playbook.md` — per-category fix patterns for Gate 2
+- `references/predictability-audit.md` — Phase 2b advisory checklist
+- `references/cross-gate-tradeoffs.md` — Phase 4 sidebar: body length and the link-out rule
+- `references/delegation-conversion.md` — the Mode 2 procedure
+- `references/report-template.md` — PASS, BLOCKER, and Mode 2 report layouts
+- `references/acceptance-criteria.md` — the full run checklist
+- `references/run-stats.md` — run-stats field definitions
+- `references/edge-cases.md` — the full edge-case list
+- Under `~/.claude/skills/skill-creator/`: `scripts/quick_validate.py` (the Gate 1 validator), plus `references/frontmatter-rules.md`, `predictability-rubric.md`, and `dependency-preflight.md` — upstream sources the local references restate self-sufficiently
+- `asm eval --help`, and `src/evaluator-core.ts` in the ASM repo — how each Gate 2 category is scored

--- a/skills/skill-auto-improver/references/acceptance-criteria.md
+++ b/skills/skill-auto-improver/references/acceptance-criteria.md
@@ -1,0 +1,26 @@
+# Acceptance criteria (full list)
+
+`SKILL.md` → _Acceptance Criteria_ carries the bars that decide PASS vs BLOCKER. This file is the complete run checklist — the process obligations that hold whichever way the run ends. Walk it before writing the Phase 7 report.
+
+## Artifacts
+
+- `.asm-improver/baseline.json`, `.asm-improver/baseline-quickvalidate.txt`, and `.asm-improver/baseline-frontmatter-audit.md` captured **before any edits**
+- Every iteration's `asm eval --json` saved to `.asm-improver/iter-N.json`, with a one-line gate summary in `.asm-improver/iter-N-gates.txt`
+- `.asm-improver/predictability-audit.md` holds the Phase 2b walk, or records the fail-soft skip when the rubric was unavailable
+- `.asm-improver/report.md` exists on exit, pass or blocker, with gate status, advisory predictability findings, and unresolved blockers as three visually distinct sections
+
+## Process
+
+- `asm eval --fix` run (at minimum `--dry-run`), then frontmatter normalized so `quick_validate.py` accepts the result
+- Each Gate 1 check addressed at least once **before** any Gate 2 work
+- A target that invokes another skill ends the run with a dependency preflight naming each dependency, its install command, the command that installs the installer itself, and a verification step; a target that invokes none gains no such section
+- Each `asm eval` category below 8 addressed at least once
+- Both gates re-evaluated after every iteration
+- The target's `metadata.version` bumped exactly once per iteration that produced edits
+- The loop stopped on one of the 4 conditions in Phase 6 — never unbounded
+
+## Outcome
+
+- On **PASS**: `python "$QV" "$SKILL_PATH"` exits 0 AND the final eval JSON shows `overallScore > 85` AND `min(categories[*].score) >= 8`
+- On **BLOCKER**: the report names every Gate 1 check still failing and every category still below 8, each with a one-line reason. Open predictability findings alone never constitute a blocker
+- Either way, the summary closes with the Run stats block — `elapsed`, `agents`, `skills`, and `tool calls` always present (`n/a` when undetermined), `tokens` and `cost` printed only where the host reported them and never invented

--- a/skills/skill-auto-improver/references/edge-cases.md
+++ b/skills/skill-auto-improver/references/edge-cases.md
@@ -1,0 +1,16 @@
+# Edge cases
+
+The full list. `SKILL.md` → _Edge Cases_ carries the four that change the run's shape; the rest are consulted reactively when the situation arises.
+
+- **Skill already passes both gates**: do not edit it. Still run the Phase 2b predictability audit read-only and report any advisory findings, then stop — passing gates does not guarantee a predictable process, but open findings here never force an edit. A gate-passing skill with heavy non-delegable steps is a **Mode 2** candidate: offer the conversion, do not edit under Mode 1.
+- **SKILL.md has no frontmatter**: `asm eval --fix` cannot add it. Ask the user whether to scaffold one (using the skill-creator template) or abort.
+- **Iterating regresses either gate**: revert the last edit (`cp SKILL.md.bak SKILL.md` if available, or undo via git) and try a different fix pattern from `references/category-playbook.md`.
+- **`asm eval --fix` writes a key `quick_validate.py` rejects**: this is expected — Phase 1's normalization step handles it. Do not skip the normalization.
+- **`asm eval --fix` reports "No fixes needed"**: the dry-run satisfies Phase 1. Do not apply `--fix` anyway — on an already-normalized skill it can write the top-level keys the normalization then has to undo, plus a stray `SKILL.md.bak`.
+- **Description over 250 chars after edits**: trim. The 250-char target prevents tail-first truncation in Claude Code's `/skills` listing, which would chop your negative-trigger clause.
+- **SKILL.md body over 500 lines**: split into `references/` per the progressive-disclosure rule. SKILL.md must drop below 500 before exit.
+- **SKILL.md body over 3000 words**: `context-efficiency` scores 0 on its length bucket and caps the category at 6, failing Gate 2 on its own. Split to `references/` until the body clears 3000 with margin — the evaluator's own count is in `baseline.json` under the Context efficiency findings, not something to approximate by hand.
+- **The target's content is pinned by a test**: grep the repo for the skill name before editing. A contract test that asserts on SKILL.md strings turns a harmless-looking cut into a failing suite; keep the pinned phrasing verbatim or update the test in the same commit.
+- **Loop caps out at 8 iterations**: the skill has structural issues auto-improvement cannot solve. Write the blocker report and hand back to the user.
+- **GitHub shorthand input**: for v1, ask the user to clone locally first. Remote editing is out of scope.
+- **Destructive action**: never `rm -rf` the skill directory. `asm eval --fix` creates `SKILL.md.bak` — leave it in place until the user explicitly cleans up.

--- a/skills/skill-auto-improver/references/run-stats.md
+++ b/skills/skill-auto-improver/references/run-stats.md
@@ -1,0 +1,20 @@
+# Run stats — field definitions
+
+The per-field contract behind the run-stats block in `SKILL.md` → _Run stats (mandatory)_. That section carries the block's shape, its ordering rule, and the never-invent rule; this file carries the formatting detail for each field. If the two diverge, SKILL.md wins.
+
+| Field        | Value                                                                                            |
+| ------------ | ------------------------------------------------------------------------------------------------ |
+| `elapsed`    | wall-clock duration, `{H}h {M}m {S}s`; drop zero-valued leading units only (`4m 12s`, `48s`)     |
+| `tokens`     | **conditional** — printed only where the host reported a usage figure, with thousands separators |
+| `cost`       | **conditional** — printed only where the host reported a run cost, as `$0.42`                    |
+| `agents`     | subagents this run spawned                                                                       |
+| `skills`     | other skills this run invoked (`skill-creator`'s validator counts as one)                        |
+| `tool calls` | tool invocations this run made                                                                   |
+
+## Cost of the block itself
+
+One epoch read at the start (the `date +%s >&2` in _Dependency Preflight (mandatory)_), one at the end, two lines of output. Never a timing call per phase, and never a summarization pass to reconstruct the counts.
+
+## Why `tokens` and `cost` are conditional
+
+Not every host surfaces a usage or cost figure to the agent. A run that cannot read one omits the field rather than estimating it — an estimate reads as a measurement in the report and is unfalsifiable after the fact. This is why the block has no placeholder for these two, while the four unconditional fields fall back to the literal `n/a`.


### PR DESCRIPTION
Type: refactor
## What

`skills/skill-auto-improver` had `references/run-stats.md`, `references/acceptance-criteria.md` and `references/edge-cases.md` added, but only `## Edge Cases` was trimmed back to a pointer. The other two sections still carried their content inline, leaving ~400 words duplicated between `SKILL.md` and its own references.

That put the body at **3006 words** — past the "under 3000 words" bar the skill's *own* Gate 1 enforces. It failed the bar it audits every other skill for, and scored `context-efficiency` 5/10 on `asm eval`.

## Changes

- **Run stats** — keep the block contract and its hard rules inline; per-field formatting stays in `references/run-stats.md`
- **Acceptance Criteria** — keep the bars that decide PASS vs BLOCKER; the full run checklist stays in `references/acceptance-criteria.md`
- **`### Advisory — predictability audit`** folded into `## The Gates` — it restated the preamble
- **Phase 4 sidebar** now names the real currency: `SKILL.md` is loaded whole on every invocation, so each inlined paragraph is a permanent charge against the agent's context window
- Prose compression across Phases 0, 1, 2, 2b, 5, the Gate 1/2 definitions, `## When to Use`, `## Prerequisites` and `## References`
- The three reference files themselves are added here (previously uncommitted)

No operational content removed, no new inlining, no section rewritten wholesale.

## Result

| | Before | After |
| --- | --- | --- |
| `quick_validate.py` | exit 0 | exit 0 |
| Body | 310 lines / **3006 words** | 303 lines / **2924 words** |
| `overallScore` | 90 (A) | **96 (A)** |
| `min(categories)` | **5** | **8** |
| `metadata.version` | 2.0.0 | 2.1.0 |

Per-category: `context-efficiency` 5 → **8**, `prompt-engineering` 8 → **9**; the other five stay at 10.

Both hard gates green — Gate 1 (`quick_validate` + frontmatter audit + size caps) and Gate 2 (`overallScore > 85` AND `min(categories) >= 8`).

## Predictability audit (advisory)

Ran against `skill-creator`'s rubric. Three findings — #4 progressive disclosure, #6 duplication, #7 publish-ready — shared this one root cause and are closed by this PR. Items 1, 2, 3, 5 pass. No open findings; no Mode 2 delegation conversion warranted.

## Testing

`src/skills-authoring-contract.test.ts` pins exact `SKILL.md` strings. The trim initially broke four assertions — two were rewordings, but two run-stats clauses (`prints the literal \`n/a\``, `A missing optional figure never suppresses the rest of the block.`) were genuinely dropped. All four restored verbatim.

```
CI=true npm test  → 77 files, 2547 tests, all passing
```

Pre-push hooks (unit, build, e2e) all green.
