### PR TITLE
refactor(skills): bring skill-creator under its own size cap (1.16.2)

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -4,7 +4,7 @@ description: "Create, improve, evaluate, benchmark skills. Use when authoring a 
 license: MIT
 effort: max
 metadata:
-  version: 1.15.0
+  version: 1.16.2
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -52,19 +52,22 @@ After completing each major step, output a status report in this format:
 
 Adapt the check names to match what the step actually validates. Use `√` for pass, `×` for fail, and `—` to add brief context. The "Criteria" line summarizes how many acceptance criteria were met. The "Result" line gives the overall verdict.
 
-**Intent Capture phase checks:** `Worth building`, `Goal defined`, `Triggers identified`, `Output format agreed`
+Per-phase checks:
 
-**Skill Writing phase checks:** `SKILL.md written`, `README generated`, `Subagents designed`, `Dependency preflight` (√ when the skill has no skill dependencies, or when it has them and ships a gate for each; × when a dependency is invoked without one), `Predictability pass` (the 7 rubric items from _Make it predictable_ — √ when each is satisfied, × naming the gap), `Adversarial review` (fresh-subagent findings addressed)
+| Phase          | Checks                                                                                                                            |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Intent Capture | `Worth building`, `Goal defined`, `Triggers identified`, `Output format agreed`                                                   |
+| Skill Writing  | `SKILL.md written`, `README generated`, `Subagents designed`, `Dependency preflight`, `Predictability pass`, `Adversarial review` |
+| Testing        | `Evals created`, `Runs completed`, `Viewer launched`                                                                              |
+| Iteration      | `Feedback incorporated`, `Benchmarks improved`, `Description optimized`                                                           |
 
-**Testing phase checks:** `Evals created`, `Runs completed`, `Viewer launched`
-
-**Iteration phase checks:** `Feedback incorporated`, `Benchmarks improved`, `Description optimized`
+`Dependency preflight` is `√` when the skill has no skill dependencies, or has them and ships a gate for each; `×` when a dependency is invoked without one. `Predictability pass` walks the 7 rubric items from _Make it predictable_ — `√` per item satisfied, `×` naming the gap. `Adversarial review` is `√` once fresh-subagent findings are addressed.
 
 ## Run stats (mandatory)
 
 Every run that creates or updates a skill closes its summary with a run-stats block — the last thing printed, after the final Step Completion Report. It reports what the run **cost**, and nothing the run already reported.
 
-Capture `run_started_epoch` once at skill start, in the same shell as the skill's first command (`cmd; ec=$?; date +%s >&2; exit "$ec"` — read the epoch off stderr so stdout and the exit code stay intact). A run that already recorded a start time reuses it.
+Capture `run_started_epoch` **once**, in the same shell as the skill's first command — `cmd; ec=$?; date +%s >&2; exit "$ec"` — reading the epoch off stderr so stdout and the exit code stay intact. Set it there, not later: without the anchor `elapsed` prints `n/a`, and the block still has to print on an early stop.
 
 ```
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
@@ -72,22 +75,13 @@ Capture `run_started_epoch` once at skill start, in the same shell as the skill'
               agents 3 · skills 1 · tool calls 47
 ```
 
-Fields are fixed and in this order — never reordered, renamed, or added to:
+Fields are fixed and in this order — never reordered, renamed, or added to: `elapsed`, `tokens`, `cost`, `agents`, `skills`, `tool calls`. Per-field formatting: `references/run-stats.md`.
 
-| Field        | Value                                                                                            |
-| ------------ | ------------------------------------------------------------------------------------------------ |
-| `elapsed`    | wall-clock duration, `{H}h {M}m {S}s`; drop zero-valued leading units only (`6m 04s`, `48s`)     |
-| `tokens`     | **conditional** — printed only where the host reported a usage figure, with thousands separators |
-| `cost`       | **conditional** — printed only where the host reported a run cost, as `$0.42`                    |
-| `agents`     | subagents this run spawned                                                                       |
-| `skills`     | other skills this run invoked                                                                    |
-| `tool calls` | tool invocations this run made                                                                   |
-
-- **`tokens` and `cost` are omitted entirely when the host reported no figure** — no dangling `·`, no placeholder. Never estimate one from output length, file sizes, or step counts, and never reconstruct one from host transcripts or logs.
+- **`tokens` and `cost` are omitted entirely when the host reported no figure** — no dangling `·`, no placeholder. Never estimate one, and never reconstruct one from host transcripts or logs.
 - **`elapsed`, `agents`, `skills`, and `tool calls` always print.** A value that cannot be determined prints the literal `n/a`; `0` is a determined value and is correct where it is true (a run that spawned no subagents prints `agents 0`).
 - A missing optional figure never suppresses the rest of the block.
 
-Print it on **every** path that finishes a create or update — Path A, Subpath B1, and Subpath B2 — and on every other terminal outcome too: an early stop, a gate that refused to continue, or a failed step. Only a run that produced no output at all has no block. Measuring must not become a measurable share of what it measures: one epoch read at start, one at the end, two lines of output — never a timing call per step or a summarization pass.
+Print it on **every** path that finishes a create or update — Path A, Subpath B1, and Subpath B2 — and on every other terminal outcome too: an early stop, a gate that refused to continue, or a failed step. Only a run that produced no output at all has no block.
 
 ## Communicating with the user
 
@@ -107,7 +101,7 @@ Do not ship repo-mutating skills without this pre-sync guardrail.
 
 ## Mandatory Rule for Skills That Invoke Other Skills
 
-Establish, for every skill you author or retrofit, whether it invokes, delegates to, or reads **another skill**. Ask it as a question in the interview (Capture Intent, question 6) and confirm it against the draft — prose naming `/another-skill`, or a read under `~/.claude/skills/`, is a dependency even when the author said there were none.
+Establish, for every skill you author or retrofit, whether it invokes, delegates to, or reads **another skill**. Ask it in the interview — _Does this skill invoke other skills?_ is Capture Intent question 6 — and confirm the answer against the draft: prose naming `/another-skill`, or a read under `~/.claude/skills/`, is a dependency even when the author said there were none.
 
 - **It does** → the skill you produce ships a `## Dependency Preflight (mandatory)` section, placed above the first step that changes anything. Per dependency it names the skill, the command that installs it, the command that installs the installer itself, and a verification command; on a miss it stops before the first mutation.
 - **It does not** → add nothing. No empty preflight section, no "no dependencies" placeholder.
@@ -128,29 +122,14 @@ These rules apply on every write. Always confirm them before saving.
 
 ### Capture Intent
 
-Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user fills the gaps and confirms before proceeding.
+Read `references/intent-interview.md` and work it top to bottom. It carries:
 
-**Gate first — should this be a skill at all?** A skill earns its place when the workflow is **repeated** (it will come up again), **non-obvious** (a capable agent without it would get it wrong), and **stable** (the process won't change next month). If it fails any of these, recommend against creating it — a one-off is better served by a plain prompt, and every unnecessary skill pollutes triggering for the rest. The user can override; the gate exists so the default isn't "always yes".
+- **The gate** — a skill earns its place only when the workflow is repeated, non-obvious, and stable. Recommend against creating it otherwise; the user can override.
+- **The seven interview questions** — purpose, triggers, the expected output format, test cases, subagents (including per-step context delegation), skill dependencies, and model-invoked vs. user-invoked (`/skill-name` is orchestration the user runs deliberately — a pipeline, or an expensive or destructive action they confirm first).
+- **Interview and research** — edge cases, example files, success criteria, available MCPs.
+- **Branch mapping before drafting** — name the distinct modes the skill runs in, so branch-specific material is disclosed only on the branch that uses it.
 
-1. What should this skill enable Claude to do?
-2. When should this skill trigger? (what user phrases/contexts)
-3. What's the expected output format?
-4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't. Suggest the appropriate default based on the skill type, but let the user decide.
-5. **Should this skill use subagents?** Read `references/subagent-patterns.md` for the full guide. Key signals:
-   - Will the skill read many files or scan large codebases? → Explorer subagent
-   - Can parts of the work run in parallel? → Parallel worker subagents
-   - Does the skill need independent quality review? → Review loop with fresh subagents
-   - Will the skill produce large artifacts that require focused reasoning? → Executor subagent
-   - Does any single step need only a **slice** of `references/` rather than the whole tree? → Per-step context delegation: the step names the slice, the worker receives it as its `Input` (`references/subagent-patterns.md` → _Per-Step Context Delegation_)
-     If any apply, design the skill with a main-agent-as-orchestrator architecture so subagents handle the heavy lifting and the main conversation context stays clean.
-6. **Does this skill invoke other skills?** Name every skill it calls, delegates a phase to, or reads. If any exist, the skill you write ships a dependency preflight for them — see _Mandatory Rule for Skills That Invoke Other Skills_ above and `references/dependency-preflight.md`. If none exist, nothing is added.
-7. **Model-invoked or user-invoked?** Decide the _primary_ invocation before drafting — it changes how you write. **Model-invoked** (the default) is a reusable discipline the agent applies when the situation fits; optimize the description for reliable triggering. **User-invoked** (`/skill-name`) is orchestration the user runs deliberately (a pipeline, an expensive or destructive action); the body reads as "the user asked for this, proceed." Weigh the **context-load and cognitive-load** budgets here too. See `references/predictability-rubric.md` for the full tradeoff.
-
-### Interview and Research
-
-Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until this part is ironed out. Check available MCPs — research in parallel via subagents if available, otherwise inline.
-
-**Map the skill's branches before drafting the body.** Identify the distinct modes the skill runs in — the paths that need different instructions (create-vs-improve, per-framework, per-environment, dry-run-vs-apply). Knowing them first lets you open the SKILL.md with a short selector and disclose branch-specific material only on the branch that uses it, instead of forcing every run to read every branch. The "Two entry paths" block at the top of this skill is itself an example of a branch selector. See `references/predictability-rubric.md` → _Map branches before drafting_.
+Extract what the conversation already answers before asking the user anything; they fill the gaps and confirm.
 
 ### Write the SKILL.md
 
@@ -168,29 +147,18 @@ Read `references/description-guide.md` for the full guide: the pushy + negative-
 
 ### Skill Writing Guide
 
-Read `references/writing-guide.md` for the full guide. It covers:
-
-- **Anatomy of a skill** — directory layout, where `agents/`, `references/`, `scripts/`, `assets/`, `docs/` go.
-- **Progressive disclosure** — three-level loading, the 500-line SKILL.md cap, when to split into `references/`.
-- **Principle of Lack of Surprise** — no malware, no misleading skills.
-- **Writing and workflow patterns** — imperative voice, output-format strictness, examples, the workflow-pattern table.
-- **Bundled scripts and error messages** — scripts must print descriptive errors before exiting so the agent can self-correct.
-- **Step Completion Reports** — every skill emits one after each major phase.
-- **Writing style** — explain _why_ in lieu of heavy MUSTs.
-- **Generate README.md** — `docs/README.md` only, with AI-skip notice; see `references/readme-template.md`.
-- **Test Cases** — the 5-prompt floor (≥3 happy-path, ≥1 edge, ≥1 should-NOT-trigger) saved to `evals/evals.json`; see `references/schemas.md`.
-- **Pre-eval LLM validation** — the phases behind the mandatory adversarial review; see `references/validation-prompts.md`.
+Read `references/writing-guide.md` for the full guide. It covers anatomy (where `agents/`, `references/`, `scripts/`, `assets/`, `docs/` go), progressive disclosure and the 500-line SKILL.md cap, the Principle of Lack of Surprise, writing and workflow patterns, bundled-script error messages, Step Completion Reports, writing style, `docs/README.md` generation (`references/readme-template.md`), the 5-prompt test-case floor saved to `evals/evals.json` (`references/schemas.md`), and the pre-eval LLM validation phases (`references/validation-prompts.md`).
 
 ### Make it predictable (publish-ready by construction)
 
-The goal of creating a skill here is a **predictable process** — the agent follows the same reliable path every run — and a skill that ships **publish-ready** without later needing a `skill-auto-improver` cleanup pass. Read `references/predictability-rubric.md` for the full standard and its checkable pass/fail bar; the hooks below are the ones you apply _while writing_:
+The goal of creating a skill here is a **predictable process** — the agent follows the same reliable path every run — and a skill that ships **publish-ready** without later needing a `skill-auto-improver` cleanup pass. Read `references/predictability-rubric.md` for the full standard and its checkable pass/fail bar. The hooks you apply _while writing_:
 
-- **Demanding completion criteria.** For step-based workflows, end every major step with a bar the agent can _check_, not vibe — tied to a command, file state, or count. The Step Completion Reports format above is the vehicle (`√/×` checks + a `Result:` line). Strong criteria are what stop the agent declaring success early; this is the difference between a repeatable process and a hopeful one.
-- **Progressive disclosure for non-universal material.** Anything branch-specific, long, or not needed on every run goes to `references/` behind a one-line pointer (mechanics in `references/writing-guide.md` → _Progressive Disclosure_) — keeps context load low and SKILL.md under 500 lines. Its step-level analogue is **per-step context delegation**: a delegable step names the slice of `references/` its worker needs and hands that slice over as the worker's `Input`, so the main agent never holds the whole tree. Not every skill has one — `references/subagent-patterns.md` → _When the slice isn't worth it_ says when to skip it.
+- **Demanding completion criteria.** End every major step with a bar the agent can _check_, not vibe — tied to a command, file state, or count. The Step Completion Reports format above is the vehicle. Strong criteria are what stop the agent declaring success early.
+- **Progressive disclosure for non-universal material.** Anything branch-specific, long, or not needed on every run goes to `references/` behind a one-line pointer — this keeps context load low and SKILL.md under the caps. Its step-level analogue is **per-step context delegation**: a delegable step names the slice of `references/` its worker needs and hands that slice over as the worker's `Input`, so the main agent never holds the whole tree (`references/subagent-patterns.md` → _Per-Step Context Delegation_, which also says when the slice isn't worth taking).
 - **Leading words.** Name a recurring concept once with a short load-bearing term ("atomic commit", "fail-soft", "publish-ready") and reuse the term, rather than re-explaining it at each use.
-- **Pruning pass — run before finishing.** Make one explicit pass to cut **duplication** (the same instruction in two places — keep one home, link to it), **stale sediment** (leftover guidance, dead references, obsolete names), **sprawl** (sections grown past their value, prose that should be a table or a leading word), and **no-op instructions** (lines that change nothing the agent does — "be careful", "use good judgment" — replace with a checkable criterion or delete). This pass is what most often separates a skill-creator-authored skill from one that still needs `skill-auto-improver`.
+- **Pruning pass — run before finishing.** One explicit pass to cut duplication, stale sediment, sprawl, and no-op instructions ("be careful", "use good judgment"). This pass is what most often separates a skill-creator-authored skill from one that still needs `skill-auto-improver`.
 
-Before finishing, **walk all 7 rubric items** (`references/predictability-rubric.md` — the four hooks above plus invocation choice, branch mapping, and publish-ready) and emit the result as the `Predictability pass` row of the Skill Writing Step Completion Report: `√` per item satisfied, `×` naming any gap. This makes the rubric walk visible instead of silent — a `×` is a fix-before-publish signal, not a blocker.
+Before finishing, **walk all 7 rubric items** (the four hooks above plus invocation choice, branch mapping, and publish-ready) and emit the result as the `Predictability pass` row of the Skill Writing Step Completion Report. This makes the rubric walk visible instead of silent — a `×` is a fix-before-publish signal, not a blocker.
 
 `skill-auto-improver` remains the remediation tool for _externally authored_ or _legacy_ skills — not a required second stage for a skill created through this path.
 
@@ -206,41 +174,10 @@ Do NOT use `/skill-test` or any other testing skill — the flow in `references/
 
 ## Improving an existing skill
 
-This is **Path B** from the entry-paths block at the top. Two distinct subpaths — pick based on what the user is asking for.
+This is **Path B** from the entry-paths block at the top. Read `references/improving-existing.md` and pick the subpath from what the user is asking for — they don't share an opening move.
 
-### Subpath B1 — Retrofit an existing skill to the standard
-
-Use this when the user says "update this skill to match the standard," "fix this skill," "review and improve," or invokes `/skill-creator` on a published skill that hasn't been touched in a while. The goal is mechanical conformance, not behavioral redesign. **Do not interview the user about purpose, triggers, or output format** — those are encoded in the existing SKILL.md.
-
-Sequence:
-
-1. Read the existing SKILL.md and surrounding directory. Note current frontmatter, body length, references, scripts, version. Skim `docs/README.md` for human-facing claims.
-2. Run `python scripts/quick_validate.py <skill-path>`. Validates allowed keys, name format, description length, missing negative trigger, broken YAML.
-3. Run the **Frontmatter Audit** described in `references/frontmatter-rules.md`. Cover every checklist item, not just what `quick_validate.py` flagged.
-4. Inspect the body against the standards in this skill:
-   - SKILL.md under 500 lines (split to `references/` if not).
-   - Step Completion Reports section present.
-   - "Repo Sync Before Edits" section if the skill mutates a git repo.
-   - "Dependency Preflight" section if the skill invokes another skill — and none if it invokes none (`references/dependency-preflight.md`).
-   - Bundled scripts print descriptive errors before exiting.
-   - Progressive disclosure used appropriately; references one level deep.
-5. Decide fix vs. review-only mode. If fixing, apply edits and **bump `metadata.version`** — patch for frontmatter-only fixes, minor for new sections, major for restructuring. If reviewing only, surface findings as before/after suggestions and don't silently edit.
-6. Re-run `quick_validate.py` to confirm clean. Output a Step Completion Report with a `Frontmatter valid` check.
-7. Optional: offer description optimization (see below). Don't run it automatically — it costs eval tokens.
-
-This subpath does **not** require running evals. Skip to subpath B2 only if body changes are substantive enough that the user wants verification.
-
-### Subpath B2 — Iterate on a skill based on eval feedback
-
-Use this when the user has eval results (or wants to run evals) and wants the skill revised based on what the evals show. The opening move is the **eval loop**, not interviewing.
-
-1. Read `evals/misfires.jsonl` first if present — logged real-world failures are the highest-signal evals; convert them into test cases (schema in `references/schemas.md`). Then, if evals already exist, read the latest results and the user's `feedback.json`; if not, run them per "Running and evaluating test cases" above.
-2. Read `references/iteration.md` for the five principles of revision (generalize, stay lean, explain the why, spot repeated work, consider subagents) and the iteration loop (apply → rerun → review → repeat).
-3. Run the **Frontmatter Audit** alongside content revision — a polished body on top of broken frontmatter still fails validation.
-4. Bump `metadata.version` per Version Management — minor for new capabilities or expanded triggers, patch for wording fixes.
-5. Re-run evals into a new `iteration-<N+1>/` directory and let the user compare.
-
-`references/iteration.md` also documents the optional blind A/B comparison system.
+- **Subpath B1 — retrofit to the standard.** "Update this skill to match the standard," "fix this skill," "review and improve." Mechanical conformance, not behavioral redesign: read the directory, run `quick_validate.py`, run the Frontmatter Audit, inspect the body against the standards above, fix or report, bump `metadata.version`, re-validate. **Do not interview the user about purpose, triggers, or output format** — those are already encoded in the SKILL.md. No evals required.
+- **Subpath B2 — iterate on eval feedback.** The user has eval results or wants to run them. The opening move is the **eval loop**, not interviewing: `evals/misfires.jsonl` first, then results and `feedback.json`, revise per `references/iteration.md`, audit frontmatter alongside, bump the version, re-run evals into a new `iteration-<N+1>/` directory.
 
 ## Description Optimization
 
@@ -264,28 +201,33 @@ If you're on Claude.ai (no subagents) or in Cowork (subagents but no browser), s
 
 ## Reference files
 
-The `agents/` directory contains instructions for specialized subagents. Read them when you need to spawn the relevant subagent.
+`agents/` holds instructions for specialized subagents — read one when you spawn that subagent:
 
-- `agents/grader.md` — How to evaluate assertions against outputs
-- `agents/comparator.md` — How to do blind A/B comparison between two outputs
-- `agents/analyzer.md` — How to analyze why one version beat another
+- `agents/grader.md` — evaluate assertions against outputs
+- `agents/comparator.md` — blind A/B comparison between two outputs
+- `agents/analyzer.md` — analyze why one version beat another
 
-The `references/` directory has additional documentation:
+`references/` holds the material this SKILL.md links out to:
 
-- `references/frontmatter-rules.md` — Version Management, YAML Safety, and Frontmatter Audit (mandatory).
-- `references/dependency-preflight.md` — The skill-dependency rule: when a preflight gate is required, what it must name, and the template to emit (mandatory).
-- `references/predictability-rubric.md` — The predictability standard a new skill must meet by construction: invocation choice, branch mapping, demanding completion criteria, leading words, the pruning pass, and publish-ready (no auto-improver dependency).
-- `references/description-guide.md` — Pushy + negative-trigger description pattern, one trigger per branch, length budget.
-- `references/exemplars.md` — Three annotated exemplar skills (workflow, knowledge, orchestrator) to imitate.
-- `references/writing-guide.md` — Anatomy, progressive disclosure, writing and workflow patterns, error messages, test cases.
-- `references/schemas.md` — JSON structures for evals.json, misfires.jsonl, grading.json, etc.
-- `references/subagent-patterns.md` — When and how to design skills that use the Agent tool, including per-step context delegation (a step declares its `references/` slice; the worker receives it as `Input`) and when that slice is not worth taking.
-- `references/validation-prompts.md` — The 4 validation phases; 1–3 script the mandatory adversarial review.
-- `references/eval-loop.md` — Full 5-step eval run / grade / viewer flow.
-- `references/iteration.md` — Principles for improving a skill based on feedback; blind comparison.
-- `references/description-optimization.md` — 4-step description-tuning workflow.
-- `references/environment-modes.md` — Claude.ai and Cowork-specific adaptations.
-- `references/readme-template.md` — AI-skip notice, template, and rules for `docs/README.md`.
+| File                          | Contents                                                                                      |
+| ----------------------------- | --------------------------------------------------------------------------------------------- |
+| `frontmatter-rules.md`        | Version Management, YAML Safety, Frontmatter Audit (mandatory)                                |
+| `dependency-preflight.md`     | When a preflight gate is required, what it names, and the template to emit (mandatory)        |
+| `predictability-rubric.md`    | The 7-item predictability standard a new skill must meet by construction                      |
+| `intent-interview.md`         | Path A opening: the should-this-exist gate, the 7 questions, research, branch mapping         |
+| `improving-existing.md`       | Path B: the Subpath B1 retrofit sequence and the Subpath B2 eval-feedback sequence            |
+| `description-guide.md`        | Pushy + negative-trigger description pattern, one trigger per branch, length budget           |
+| `exemplars.md`                | Three annotated exemplar skills (workflow, knowledge, orchestrator) to imitate                |
+| `writing-guide.md`            | Anatomy, progressive disclosure, writing and workflow patterns, error messages, test cases    |
+| `schemas.md`                  | JSON structures for `evals.json`, `misfires.jsonl`, `grading.json`, etc.                      |
+| `subagent-patterns.md`        | When and how to use the Agent tool, including per-step context delegation and when to skip it |
+| `validation-prompts.md`       | The 4 validation phases; 1–3 script the mandatory adversarial review                          |
+| `eval-loop.md`                | Full 5-step eval run / grade / viewer flow                                                    |
+| `iteration.md`                | Principles for improving a skill based on feedback; blind comparison                          |
+| `description-optimization.md` | 4-step description-tuning workflow                                                            |
+| `environment-modes.md`        | Claude.ai and Cowork-specific adaptations                                                     |
+| `readme-template.md`          | AI-skip notice, template, and rules for `docs/README.md`                                      |
+| `run-stats.md`                | Run-stats field definitions and the start-epoch capture command                               |
 
 ---
 

--- a/skills/skill-creator/references/improving-existing.md
+++ b/skills/skill-creator/references/improving-existing.md
@@ -1,0 +1,35 @@
+# Improving an existing skill — the two subpaths
+
+Path B from the entry-paths block in SKILL.md. Pick the subpath from what the user is asking for; they do not share an opening move.
+
+## Subpath B1 — Retrofit an existing skill to the standard
+
+Use this when the user says "update this skill to match the standard," "fix this skill," "review and improve," or invokes `/skill-creator` on a published skill that hasn't been touched in a while. The goal is mechanical conformance, not behavioral redesign. **Do not interview the user about purpose, triggers, or output format** — those are encoded in the existing SKILL.md.
+
+1. Read the existing SKILL.md and surrounding directory. Note current frontmatter, body length, references, scripts, version. Skim `docs/README.md` for human-facing claims.
+2. Run `python scripts/quick_validate.py <skill-path>`. Validates allowed keys, name format, description length, missing negative trigger, broken YAML.
+3. Run the **Frontmatter Audit** described in `frontmatter-rules.md`. Cover every checklist item, not just what `quick_validate.py` flagged.
+4. Inspect the body against the standards in this skill:
+   - SKILL.md under 500 lines and under ~3000 words (split to `references/` if not).
+   - Step Completion Reports section present.
+   - "Repo Sync Before Edits" section if the skill mutates a git repo.
+   - "Dependency Preflight" section if the skill invokes another skill — and none if it invokes none (`dependency-preflight.md`).
+   - Bundled scripts print descriptive errors before exiting.
+   - Progressive disclosure used appropriately; references one level deep.
+5. Decide fix vs. review-only mode. If fixing, apply edits and **bump `metadata.version`** — patch for frontmatter-only fixes, minor for new sections, major for restructuring. If reviewing only, surface findings as before/after suggestions and don't silently edit.
+6. Re-run `quick_validate.py` to confirm clean. Output a Step Completion Report with a `Frontmatter valid` check.
+7. Optional: offer description optimization (`description-optimization.md`). Don't run it automatically — it costs eval tokens.
+
+This subpath does **not** require running evals. Move to Subpath B2 only if body changes are substantive enough that the user wants verification.
+
+## Subpath B2 — Iterate on a skill based on eval feedback
+
+Use this when the user has eval results (or wants to run evals) and wants the skill revised based on what the evals show. The opening move is the **eval loop**, not interviewing.
+
+1. Read `evals/misfires.jsonl` first if present — logged real-world failures are the highest-signal evals; convert them into test cases (schema in `schemas.md`). Then, if evals already exist, read the latest results and the user's `feedback.json`; if not, run them per SKILL.md → _Running and evaluating test cases_.
+2. Read `iteration.md` for the five principles of revision (generalize, stay lean, explain the why, spot repeated work, consider subagents) and the iteration loop (apply → rerun → review → repeat).
+3. Run the **Frontmatter Audit** alongside content revision — a polished body on top of broken frontmatter still fails validation.
+4. Bump `metadata.version` per Version Management — minor for new capabilities or expanded triggers, patch for wording fixes.
+5. Re-run evals into a new `iteration-<N+1>/` directory and let the user compare.
+
+`iteration.md` also documents the optional blind A/B comparison system.

--- a/skills/skill-creator/references/intent-interview.md
+++ b/skills/skill-creator/references/intent-interview.md
@@ -1,0 +1,43 @@
+# Capture Intent — the gate, the questions, and the research pass
+
+The Path A opening (SKILL.md → _Creating a skill_). Read this before the first interview question; it is not needed on Path B, where the intent is already encoded in the existing SKILL.md.
+
+## Start from the conversation, not a blank form
+
+The current conversation might already contain the workflow the user wants to capture (e.g. they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user fills the gaps and confirms before you proceed.
+
+## Gate first — should this be a skill at all?
+
+A skill earns its place when the workflow is:
+
+- **repeated** — it will come up again,
+- **non-obvious** — a capable agent without it would get it wrong, and
+- **stable** — the process won't change next month.
+
+If it fails any of these, recommend against creating it. A one-off is better served by a plain prompt, and every unnecessary skill pollutes triggering for the rest. The user can override; the gate exists so the default isn't "always yes".
+
+## The seven questions
+
+1. What should this skill enable Claude to do?
+2. When should this skill trigger? (what user phrases/contexts)
+3. What's the expected output format?
+4. **Should we set up test cases to verify the skill works?** Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't. Suggest the appropriate default based on the skill type, but let the user decide.
+5. **Should this skill use subagents?** Read `subagent-patterns.md` for the full guide. Key signals:
+   - Will the skill read many files or scan large codebases? → Explorer subagent
+   - Can parts of the work run in parallel? → Parallel worker subagents
+   - Does the skill need independent quality review? → Review loop with fresh subagents
+   - Will the skill produce large artifacts that require focused reasoning? → Executor subagent
+   - Does any single step need only a **slice** of `references/` rather than the whole tree? → Per-step context delegation: the step names the slice, the worker receives it as its `Input` (`subagent-patterns.md` → _Per-Step Context Delegation_)
+
+   If any apply, design the skill with a main-agent-as-orchestrator architecture so subagents handle the heavy lifting and the main conversation context stays clean.
+
+6. **Does this skill invoke other skills?** Name every skill it calls, delegates a phase to, or reads. If any exist, the skill you write ships a dependency preflight for them — see SKILL.md → _Mandatory Rule for Skills That Invoke Other Skills_ and `dependency-preflight.md`. If none exist, nothing is added.
+7. **Model-invoked or user-invoked?** Decide the _primary_ invocation before drafting — it changes how you write. **Model-invoked** (the default) is a reusable discipline the agent applies when the situation fits; optimize the description for reliable triggering. **User-invoked** (`/skill-name`) is orchestration the user runs deliberately (a pipeline, an expensive or destructive action); the body reads as "the user asked for this, proceed." Weigh the **context-load and cognitive-load** budgets here too. See `predictability-rubric.md` for the full tradeoff.
+
+## Interview and research
+
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until this part is ironed out. Check available MCPs — research in parallel via subagents if available, otherwise inline.
+
+## Map the skill's branches before drafting the body
+
+Identify the distinct modes the skill runs in — the paths that need different instructions (create-vs-improve, per-framework, per-environment, dry-run-vs-apply). Knowing them first lets you open the SKILL.md with a short selector and disclose branch-specific material only on the branch that uses it, instead of forcing every run to read every branch. The "Two entry paths" block at the top of this skill's own SKILL.md is itself an example of a branch selector. See `predictability-rubric.md` → _Map branches before drafting_.

--- a/skills/skill-creator/references/run-stats.md
+++ b/skills/skill-creator/references/run-stats.md
@@ -1,0 +1,30 @@
+# Run stats — field definitions
+
+Per-field formatting for the mandatory run-stats block defined in SKILL.md → _Run stats (mandatory)_. SKILL.md carries the block, the field order, and the omission rules; this file carries the formatting detail you consult once.
+
+## Capturing the start time
+
+Capture `run_started_epoch` **once** at skill start, in the same shell as the skill's first command:
+
+```bash
+cmd; ec=$?; date +%s >&2; exit "$ec"
+```
+
+Read the epoch off **stderr** so stdout and the exit code stay intact. A run that already recorded a start time reuses it — never re-stamp mid-run. A run that stopped before the epoch was captured has no anchor, so `elapsed` prints `n/a`.
+
+## Fields
+
+| Field        | Value                                                                                            |
+| ------------ | ------------------------------------------------------------------------------------------------ |
+| `elapsed`    | wall-clock duration, `{H}h {M}m {S}s`; drop zero-valued leading units only (`6m 04s`, `48s`)     |
+| `tokens`     | **conditional** — printed only where the host reported a usage figure, with thousands separators |
+| `cost`       | **conditional** — printed only where the host reported a run cost, as `$0.42`                    |
+| `agents`     | subagents this run spawned                                                                       |
+| `skills`     | other skills this run invoked                                                                    |
+| `tool calls` | tool invocations this run made                                                                   |
+
+## Cost of measuring
+
+Measuring must not become a measurable share of what it measures: one epoch read at start, one at the end, two lines of output — never a timing call per step, and never a summarization pass to reconstruct the figures.
+
+Never estimate `tokens` or `cost` from output length, file sizes, or step counts, and never reconstruct either from host transcripts or logs. An unreported figure is omitted, not guessed.


### PR DESCRIPTION
Closes #582
Type: refactor

## Why

`skills/skill-creator`'s SKILL.md shipped at **3765 words**, over the **3000-word cap it enforces on every skill it audits**. That single fact was also the only thing holding `asm eval`'s `context-efficiency` category at 6/10.

Found by running `/skill-auto-improver` on it. One defect, one root cause.

## What changed

Progressive disclosure — no behavioral change to either path. Every removed line was checked against `git diff` for a destination.

| File | |
| --- | --- |
| `references/intent-interview.md` | **new** — Path A gate, the 7 interview questions, research pass, branch mapping |
| `references/improving-existing.md` | **new** — Subpath B1 retrofit and Subpath B2 eval-feedback sequences |
| `references/run-stats.md` | **new** — start-epoch capture, field table, cost-of-measuring rule |
| `SKILL.md` | per-phase Step Completion checks and the `references/` index collapsed to tables; predictability hooks and writing-guide bullets compressed to pointers |

The four pruning-pass definitions and the progressive-disclosure mechanics pointer were already carried in full by `predictability-rubric.md` §6 and §4 — they're now single-homed there rather than duplicated.

### One thing worth reviewing closely

The `run_started_epoch` snippet stays **inline** in the Run stats section. The first pass sent it to `references/run-stats.md` alongside the field table, which reads correctly but is wrong: the block must print on an early stop, so an agent that only opens a formatting reference *when writing the block* has no anchor left and prints `elapsed n/a`. Neither gate can see that.

## Results

| | Before | After |
| --- | --- | --- |
| Body | 3765 words / 292 lines | **2755 words / 234 lines** |
| `quick_validate.py` | pass | pass |
| `asm eval` overall | 93 (A) | **97 (A)** |
| Min category | **6** (context-efficiency) | **8** |
| `metadata.version` | 1.15.0 | 1.16.2 |

Per-category: prompt-engineering 9→10, context-efficiency 6→8, all others unchanged at 10.

## Verification

- `src/skills-authoring-contract.test.ts` pins **13 literal strings** inside this SKILL.md (run-stats field names, `Path A, Subpath B1, and Subpath B2`, `Does this skill invoke other skills?`, `Per-Step Context Delegation`, the two mandatory-rule headings, the 500-line cap). All preserved — 32/32 pass.
- `CI=true npm test`: **2547 passed / 77 files**.
- Predictability audit (advisory): 7/7 pass, 0 open findings.

## Note for reviewers

An installed `~/.claude/skills/skill-creator/` will be one version behind after this lands. `scripts/quick_validate.py` is untouched, so `skill-auto-improver`'s dependency on it keeps working; refresh with `asm install skill-creator -p claude --yes`.

https://claude.ai/code/session_01Wo7cC2T5DTZimbh8aVvJ5Q


