### PR TITLE
feat(index): add 11 anti-slop skills from Charlie Hills rank + tag descriptions

### DIFF
--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -569,15 +569,6 @@
       "enabled": true
     },
     {
-      "source": "github:VoltAgent/awesome-design-md",
-      "url": "https://github.com/VoltAgent/awesome-design-md",
-      "owner": "VoltAgent",
-      "repo": "awesome-design-md",
-      "description": "Awesome design.md \u2014 structured design-system docs for agent-built UIs (anti-slop design skill).",
-      "maintainer": "@VoltAgent",
-      "enabled": true
-    },
-    {
       "source": "github:pbakaus/impeccable",
       "url": "https://github.com/pbakaus/impeccable",
       "owner": "pbakaus",

--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -567,6 +567,105 @@
       "description": "A skill to stop your coding agent from burying the answer. ADHD-friendly output.",
       "maintainer": "@ayghri",
       "enabled": true
+    },
+    {
+      "source": "github:VoltAgent/awesome-design-md",
+      "url": "https://github.com/VoltAgent/awesome-design-md",
+      "owner": "VoltAgent",
+      "repo": "awesome-design-md",
+      "description": "Awesome design.md \u2014 structured design-system docs for agent-built UIs (anti-slop design skill).",
+      "maintainer": "@VoltAgent",
+      "enabled": true
+    },
+    {
+      "source": "github:pbakaus/impeccable",
+      "url": "https://github.com/pbakaus/impeccable",
+      "owner": "pbakaus",
+      "repo": "impeccable",
+      "description": "impeccable \u2014 anti-slop UI/UX skill for polished, non-templated interfaces.",
+      "maintainer": "@pbakaus",
+      "enabled": true
+    },
+    {
+      "source": "github:blader/humanizer",
+      "url": "https://github.com/blader/humanizer",
+      "owner": "blader",
+      "repo": "humanizer",
+      "description": "humanizer \u2014 removes AI-sounding patterns from generated text (anti-slop writing).",
+      "maintainer": "@blader",
+      "enabled": true
+    },
+    {
+      "source": "github:zarazhangrui/frontend-slides",
+      "url": "https://github.com/zarazhangrui/frontend-slides",
+      "owner": "zarazhangrui",
+      "repo": "frontend-slides",
+      "description": "frontend-slides \u2014 generate clean slide decks without templated look (anti-slop).",
+      "maintainer": "@zarazhangrui",
+      "enabled": true
+    },
+    {
+      "source": "github:google-labs-code/design.md",
+      "url": "https://github.com/google-labs-code/design.md",
+      "owner": "google-labs-code",
+      "repo": "design.md",
+      "description": "design.md \u2014 Google Labs design-system skill for agent-built interfaces (anti-slop).",
+      "maintainer": "@google-labs-code",
+      "enabled": true
+    },
+    {
+      "source": "github:Nutlope/hallmark",
+      "url": "https://github.com/Nutlope/hallmark",
+      "owner": "Nutlope",
+      "repo": "hallmark",
+      "description": "hallmark \u2014 anti-slop skill for distinctive, non-generic output.",
+      "maintainer": "@Nutlope",
+      "enabled": true
+    },
+    {
+      "source": "github:cathrynlavery/diagram-design",
+      "url": "https://github.com/cathrynlavery/diagram-design",
+      "owner": "cathrynlavery",
+      "repo": "diagram-design",
+      "description": "diagram-design \u2014 draws diagrams instead of explaining; clean visual output (anti-slop).",
+      "maintainer": "@cathrynlavery",
+      "enabled": true
+    },
+    {
+      "source": "github:hardikpandya/stop-slop",
+      "url": "https://github.com/hardikpandya/stop-slop",
+      "owner": "hardikpandya",
+      "repo": "stop-slop",
+      "description": "stop-slop \u2014 explicitly anti-AI-slop skill for human-sounding output.",
+      "maintainer": "@hardikpandya",
+      "enabled": true
+    },
+    {
+      "source": "github:tt-a1i/archify",
+      "url": "https://github.com/tt-a1i/archify",
+      "owner": "tt-a1i",
+      "repo": "archify",
+      "description": "archify \u2014 architecture diagramming skill for clean, non-templated visuals (anti-slop).",
+      "maintainer": "@tt-a1i",
+      "enabled": true
+    },
+    {
+      "source": "github:charlie947/answer-first",
+      "url": "https://github.com/charlie947/answer-first",
+      "owner": "charlie947",
+      "repo": "answer-first",
+      "description": "answer-first \u2014 Charlie Hills skill: answer on line one, next step at bottom (anti-slop output structure).",
+      "maintainer": "@charlie947",
+      "enabled": true
+    },
+    {
+      "source": "github:charlie947/voiceprint",
+      "url": "https://github.com/charlie947/voiceprint",
+      "owner": "charlie947",
+      "repo": "voiceprint",
+      "description": "voiceprint \u2014 Charlie Hills skill: preserve a consistent human voice (anti-slop writing).",
+      "maintainer": "@charlie947",
+      "enabled": true
     }
   ]
 }

--- a/data/skill-index/Egonex-AI_Understand-Anything.json
+++ b/data/skill-index/Egonex-AI_Understand-Anything.json
@@ -7,7 +7,7 @@
   "skills": [
     {
       "name": "understand",
-      "description": "Analyze a codebase to produce an interactive knowledge graph for understanding architecture, components, and relationships",
+      "description": "Analyze a codebase to produce an interactive knowledge graph for understanding architecture, components, and relationships \u2014 anti-slop",
       "version": "0.0.0",
       "license": "",
       "creator": "",

--- a/data/skill-index/Nutlope_hallmark.json
+++ b/data/skill-index/Nutlope_hallmark.json
@@ -1,27 +1,27 @@
 {
-  "repoUrl": "https://github.com/ayghri/i-have-adhd.git",
-  "owner": "ayghri",
-  "repo": "i-have-adhd",
-  "updatedAt": "2026-08-27T10:21:39.695Z",
+  "repoUrl": "https://github.com/Nutlope/hallmark.git",
+  "owner": "Nutlope",
+  "repo": "hallmark",
+  "updatedAt": "2026-08-27T18:54:27.654Z",
   "skillCount": 1,
   "skills": [
     {
-      "name": "i-have-adhd",
-      "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until \"stop adhd mode\". \u2014 anti-slop",
-      "version": "0.0.0",
-      "license": "MIT",
+      "name": "hallmark",
+      "description": "Anti-AI-slop design skill for greenfield pages, audits, redesigns, and design extraction from URLs or screenshots. Use when the user asks to build a new app or landing page, wants to redesign something, invokes Hallmark by name, or uses audit/redesign/study. \u2014 anti-slop",
+      "version": "1.1.0",
+      "license": "",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "modelInvocable": false,
+      "modelInvocable": true,
       "userInvocable": true,
-      "installUrl": "github:ayghri/i-have-adhd:skills/i-have-adhd",
-      "relPath": "skills/i-have-adhd",
+      "installUrl": "github:Nutlope/hallmark:skills/hallmark",
+      "relPath": "skills/hallmark",
       "verified": true,
-      "tokenCount": 2283,
+      "tokenCount": 19675,
       "evalSummary": {
-        "overallScore": 81,
-        "grade": "B",
+        "overallScore": 75,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
@@ -38,13 +38,13 @@
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 7,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 10,
+            "score": 6,
             "max": 10
           },
           {
@@ -56,19 +56,19 @@
           {
             "id": "testability",
             "name": "Testability",
-            "score": 5,
+            "score": 7,
             "max": 10
           },
           {
             "id": "license",
             "name": "License verification",
-            "score": 5,
+            "score": 0,
             "max": 10
           },
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 8,
+            "score": 10,
             "max": 10
           },
           {
@@ -84,8 +84,8 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-08-27T10:21:39.692Z",
-        "evaluatedVersion": "0.0.0"
+        "evaluatedAt": "2026-08-27T18:54:27.623Z",
+        "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
         "quality": {
@@ -93,8 +93,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 81,
-          "grade": "B",
+          "overallScore": 75,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
@@ -111,13 +111,13 @@
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 7,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 10,
+              "score": 6,
               "max": 10
             },
             {
@@ -129,19 +129,19 @@
             {
               "id": "testability",
               "name": "Testability",
-              "score": 5,
+              "score": 7,
               "max": 10
             },
             {
               "id": "license",
               "name": "License verification",
-              "score": 5,
+              "score": 0,
               "max": 10
             },
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 8,
+              "score": 10,
               "max": 10
             },
             {
@@ -157,26 +157,26 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
-          "evaluatedVersion": "0.0.0"
+          "evaluatedAt": "2026-08-27T18:54:27.623Z",
+          "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
           "providerId": "skill-best-practice",
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 69,
-          "grade": "C",
+          "overallScore": 62,
+          "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 9,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
-          "evaluatedVersion": "0.0.0"
+          "evaluatedAt": "2026-08-27T18:54:27.623Z",
+          "evaluatedVersion": "1.1.0"
         }
       }
     }

--- a/data/skill-index/VoltAgent_awesome-design-md.json
+++ b/data/skill-index/VoltAgent_awesome-design-md.json
@@ -1,0 +1,9 @@
+{
+  "repoUrl": "https://github.com/VoltAgent/awesome-design-md.git",
+  "owner": "VoltAgent",
+  "repo": "awesome-design-md",
+  "updatedAt": "2026-08-27T18:54:22.865Z",
+  "skillCount": 0,
+  "skills": [],
+  "bundles": []
+}

--- a/data/skill-index/VoltAgent_awesome-design-md.json
+++ b/data/skill-index/VoltAgent_awesome-design-md.json
@@ -1,9 +1,0 @@
-{
-  "repoUrl": "https://github.com/VoltAgent/awesome-design-md.git",
-  "owner": "VoltAgent",
-  "repo": "awesome-design-md",
-  "updatedAt": "2026-08-27T18:54:22.865Z",
-  "skillCount": 0,
-  "skills": [],
-  "bundles": []
-}

--- a/data/skill-index/blader_humanizer.json
+++ b/data/skill-index/blader_humanizer.json
@@ -1,68 +1,68 @@
 {
-  "repoUrl": "https://github.com/ayghri/i-have-adhd.git",
-  "owner": "ayghri",
-  "repo": "i-have-adhd",
-  "updatedAt": "2026-08-27T10:21:39.695Z",
+  "repoUrl": "https://github.com/blader/humanizer.git",
+  "owner": "blader",
+  "repo": "humanizer",
+  "updatedAt": "2026-08-27T18:54:24.616Z",
   "skillCount": 1,
   "skills": [
     {
-      "name": "i-have-adhd",
-      "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until \"stop adhd mode\". \u2014 anti-slop",
-      "version": "0.0.0",
+      "name": "humanizer",
+      "description": "Rewrite AI-sounding text so it reads naturally without changing what it says. Use when editing or reviewing prose for inflated claims, sales language, vague sources, repetitive structure, stock AI words, passive voice, filler, or chatbot artifacts. Based on Wikipedia's \"Signs of AI writing.\" \u2014 anti-slop",
+      "version": "2.11.2",
       "license": "MIT",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "modelInvocable": false,
+      "modelInvocable": true,
       "userInvocable": true,
-      "installUrl": "github:ayghri/i-have-adhd:skills/i-have-adhd",
-      "relPath": "skills/i-have-adhd",
+      "installUrl": "github:blader/humanizer",
+      "relPath": "",
       "verified": true,
-      "tokenCount": 2283,
+      "tokenCount": 9135,
       "evalSummary": {
-        "overallScore": 81,
-        "grade": "B",
+        "overallScore": 74,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
             "name": "Structure & completeness",
-            "score": 8,
+            "score": 9,
             "max": 10
           },
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 5,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 7,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 10,
+            "score": 5,
             "max": 10
           },
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 10,
+            "score": 7,
             "max": 10
           },
           {
             "id": "testability",
             "name": "Testability",
-            "score": 5,
+            "score": 3,
             "max": 10
           },
           {
             "id": "license",
             "name": "License verification",
-            "score": 5,
+            "score": 10,
             "max": 10
           },
           {
@@ -84,8 +84,8 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-08-27T10:21:39.692Z",
-        "evaluatedVersion": "0.0.0"
+        "evaluatedAt": "2026-08-27T18:54:24.572Z",
+        "evaluatedVersion": "2.11.2"
       },
       "evalSummaries": {
         "quality": {
@@ -93,55 +93,55 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 81,
-          "grade": "B",
+          "overallScore": 73,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
               "name": "Structure & completeness",
-              "score": 8,
+              "score": 9,
               "max": 10
             },
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 5,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 7,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 10,
+              "score": 5,
               "max": 10
             },
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 10,
+              "score": 7,
               "max": 10
             },
             {
               "id": "testability",
               "name": "Testability",
-              "score": 5,
+              "score": 3,
               "max": 10
             },
             {
               "id": "license",
               "name": "License verification",
-              "score": 5,
+              "score": 10,
               "max": 10
             },
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 8,
+              "score": 7,
               "max": 10
             },
             {
@@ -157,26 +157,26 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
-          "evaluatedVersion": "0.0.0"
+          "evaluatedAt": "2026-08-27T18:54:24.572Z",
+          "evaluatedVersion": "2.11.2"
         },
         "skill-best-practice": {
           "providerId": "skill-best-practice",
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 69,
-          "grade": "C",
+          "overallScore": 64,
+          "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
               "score": 9,
-              "max": 13
+              "max": 14
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
-          "evaluatedVersion": "0.0.0"
+          "evaluatedAt": "2026-08-27T18:54:24.572Z",
+          "evaluatedVersion": "2.11.2"
         }
       }
     }

--- a/data/skill-index/cathrynlavery_diagram-design.json
+++ b/data/skill-index/cathrynlavery_diagram-design.json
@@ -1,50 +1,50 @@
 {
-  "repoUrl": "https://github.com/ayghri/i-have-adhd.git",
-  "owner": "ayghri",
-  "repo": "i-have-adhd",
-  "updatedAt": "2026-08-27T10:21:39.695Z",
+  "repoUrl": "https://github.com/cathrynlavery/diagram-design.git",
+  "owner": "cathrynlavery",
+  "repo": "diagram-design",
+  "updatedAt": "2026-08-27T18:54:28.921Z",
   "skillCount": 1,
   "skills": [
     {
-      "name": "i-have-adhd",
-      "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until \"stop adhd mode\". \u2014 anti-slop",
-      "version": "0.0.0",
+      "name": "diagram-design",
+      "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, Sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling. \u2014 anti-slop",
+      "version": "2.6",
       "license": "MIT",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "modelInvocable": false,
+      "modelInvocable": true,
       "userInvocable": true,
-      "installUrl": "github:ayghri/i-have-adhd:skills/i-have-adhd",
-      "relPath": "skills/i-have-adhd",
+      "installUrl": "github:cathrynlavery/diagram-design:skills/diagram-design",
+      "relPath": "skills/diagram-design",
       "verified": true,
-      "tokenCount": 2283,
+      "tokenCount": 11330,
       "evalSummary": {
-        "overallScore": 81,
-        "grade": "B",
+        "overallScore": 75,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
             "name": "Structure & completeness",
-            "score": 8,
+            "score": 9,
             "max": 10
           },
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 3,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 9,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 10,
+            "score": 6,
             "max": 10
           },
           {
@@ -56,7 +56,7 @@
           {
             "id": "testability",
             "name": "Testability",
-            "score": 5,
+            "score": 3,
             "max": 10
           },
           {
@@ -68,7 +68,7 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 8,
+            "score": 10,
             "max": 10
           },
           {
@@ -84,8 +84,8 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-08-27T10:21:39.692Z",
-        "evaluatedVersion": "0.0.0"
+        "evaluatedAt": "2026-08-27T18:54:28.737Z",
+        "evaluatedVersion": "2.6"
       },
       "evalSummaries": {
         "quality": {
@@ -93,31 +93,31 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 81,
-          "grade": "B",
+          "overallScore": 71,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
               "name": "Structure & completeness",
-              "score": 8,
+              "score": 9,
               "max": 10
             },
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 3,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 9,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 10,
+              "score": 6,
               "max": 10
             },
             {
@@ -129,7 +129,7 @@
             {
               "id": "testability",
               "name": "Testability",
-              "score": 5,
+              "score": 3,
               "max": 10
             },
             {
@@ -141,13 +141,13 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 8,
+              "score": 10,
               "max": 10
             },
             {
               "id": "pii",
               "name": "PII detection",
-              "score": 10,
+              "score": 6,
               "max": 10
             },
             {
@@ -157,26 +157,26 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
-          "evaluatedVersion": "0.0.0"
+          "evaluatedAt": "2026-08-27T18:54:28.737Z",
+          "evaluatedVersion": "2.6"
         },
         "skill-best-practice": {
           "providerId": "skill-best-practice",
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 69,
+          "overallScore": 71,
           "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 9,
-              "max": 13
+              "score": 10,
+              "max": 14
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
-          "evaluatedVersion": "0.0.0"
+          "evaluatedAt": "2026-08-27T18:54:28.737Z",
+          "evaluatedVersion": "2.6"
         }
       }
     }

--- a/data/skill-index/charlie947_answer-first.json
+++ b/data/skill-index/charlie947_answer-first.json
@@ -1,74 +1,74 @@
 {
-  "repoUrl": "https://github.com/ayghri/i-have-adhd.git",
-  "owner": "ayghri",
-  "repo": "i-have-adhd",
-  "updatedAt": "2026-08-27T10:21:39.695Z",
+  "repoUrl": "https://github.com/charlie947/answer-first.git",
+  "owner": "charlie947",
+  "repo": "answer-first",
+  "updatedAt": "2026-08-27T18:54:32.205Z",
   "skillCount": 1,
   "skills": [
     {
-      "name": "i-have-adhd",
-      "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until \"stop adhd mode\". \u2014 anti-slop",
+      "name": "answer-first",
+      "description": "Shape every answer so the action comes first. Use when the user asks for output that is short, skimmable, action-led or \"no waffle\", and apply it for the whole conversation once invoked, not just one reply. Triggers on \"answer first\", \"no preamble\", \"no waffle\", \"keep it short\", \"just tell me what to do\", \"cut the fluff\", \"ADHD mode\", or any request to stop burying the answer in paragraph four. \u2014 anti-slop",
       "version": "0.0.0",
-      "license": "MIT",
+      "license": "",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "modelInvocable": false,
+      "modelInvocable": true,
       "userInvocable": true,
-      "installUrl": "github:ayghri/i-have-adhd:skills/i-have-adhd",
-      "relPath": "skills/i-have-adhd",
+      "installUrl": "github:charlie947/answer-first:skills/answer-first",
+      "relPath": "skills/answer-first",
       "verified": true,
-      "tokenCount": 2283,
+      "tokenCount": 2136,
       "evalSummary": {
-        "overallScore": 81,
-        "grade": "B",
+        "overallScore": 65,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
             "name": "Structure & completeness",
-            "score": 8,
+            "score": 7,
             "max": 10
           },
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 3,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 6,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 10,
+            "score": 9,
             "max": 10
           },
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 10,
+            "score": 7,
             "max": 10
           },
           {
             "id": "testability",
             "name": "Testability",
-            "score": 5,
+            "score": 3,
             "max": 10
           },
           {
             "id": "license",
             "name": "License verification",
-            "score": 5,
+            "score": 0,
             "max": 10
           },
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 8,
+            "score": 10,
             "max": 10
           },
           {
@@ -84,7 +84,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-08-27T10:21:39.692Z",
+        "evaluatedAt": "2026-08-27T18:54:32.204Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -93,55 +93,55 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 81,
-          "grade": "B",
+          "overallScore": 65,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
               "name": "Structure & completeness",
-              "score": 8,
+              "score": 7,
               "max": 10
             },
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 3,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 6,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 10,
+              "score": 9,
               "max": 10
             },
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 10,
+              "score": 7,
               "max": 10
             },
             {
               "id": "testability",
               "name": "Testability",
-              "score": 5,
+              "score": 3,
               "max": 10
             },
             {
               "id": "license",
               "name": "License verification",
-              "score": 5,
+              "score": 0,
               "max": 10
             },
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 8,
+              "score": 10,
               "max": 10
             },
             {
@@ -157,7 +157,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
+          "evaluatedAt": "2026-08-27T18:54:32.204Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -175,7 +175,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
+          "evaluatedAt": "2026-08-27T18:54:32.204Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/charlie947_voiceprint.json
+++ b/data/skill-index/charlie947_voiceprint.json
@@ -1,74 +1,74 @@
 {
-  "repoUrl": "https://github.com/ayghri/i-have-adhd.git",
-  "owner": "ayghri",
-  "repo": "i-have-adhd",
-  "updatedAt": "2026-08-27T10:21:39.695Z",
+  "repoUrl": "https://github.com/charlie947/voiceprint.git",
+  "owner": "charlie947",
+  "repo": "voiceprint",
+  "updatedAt": "2026-08-27T18:54:32.900Z",
   "skillCount": 1,
   "skills": [
     {
-      "name": "i-have-adhd",
-      "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until \"stop adhd mode\". \u2014 anti-slop",
+      "name": "voiceprint",
+      "description": "Use when writing an article, newsletter, blog post or long social post that must genuinely be the user's own writing. Triggers on \"voiceprint\", \"write this in my voice\", \"turn my recording into an article\", \"cut my transcript down\", \"make this actually mine\", \"write from my video\". Turns the user's own spoken words into a finished piece by cutting, never by composing. \u2014 anti-slop",
       "version": "0.0.0",
-      "license": "MIT",
+      "license": "",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "modelInvocable": false,
+      "modelInvocable": true,
       "userInvocable": true,
-      "installUrl": "github:ayghri/i-have-adhd:skills/i-have-adhd",
-      "relPath": "skills/i-have-adhd",
+      "installUrl": "github:charlie947/voiceprint:skill",
+      "relPath": "skill",
       "verified": true,
-      "tokenCount": 2283,
+      "tokenCount": 2322,
       "evalSummary": {
-        "overallScore": 81,
-        "grade": "B",
+        "overallScore": 62,
+        "grade": "D",
         "categories": [
           {
             "id": "structure",
             "name": "Structure & completeness",
-            "score": 8,
+            "score": 7,
             "max": 10
           },
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 3,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 6,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 10,
+            "score": 9,
             "max": 10
           },
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 10,
+            "score": 5,
             "max": 10
           },
           {
             "id": "testability",
             "name": "Testability",
-            "score": 5,
+            "score": 3,
             "max": 10
           },
           {
             "id": "license",
             "name": "License verification",
-            "score": 5,
+            "score": 0,
             "max": 10
           },
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 8,
+            "score": 9,
             "max": 10
           },
           {
@@ -84,7 +84,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-08-27T10:21:39.692Z",
+        "evaluatedAt": "2026-08-27T18:54:32.899Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -93,55 +93,55 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 81,
-          "grade": "B",
+          "overallScore": 62,
+          "grade": "D",
           "categories": [
             {
               "id": "structure",
               "name": "Structure & completeness",
-              "score": 8,
+              "score": 7,
               "max": 10
             },
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 3,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 6,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 10,
+              "score": 9,
               "max": 10
             },
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 10,
+              "score": 5,
               "max": 10
             },
             {
               "id": "testability",
               "name": "Testability",
-              "score": 5,
+              "score": 3,
               "max": 10
             },
             {
               "id": "license",
               "name": "License verification",
-              "score": 5,
+              "score": 0,
               "max": 10
             },
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 8,
+              "score": 9,
               "max": 10
             },
             {
@@ -157,7 +157,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
+          "evaluatedAt": "2026-08-27T18:54:32.899Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -165,17 +165,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 69,
-          "grade": "C",
+          "overallScore": 62,
+          "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 9,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
+          "evaluatedAt": "2026-08-27T18:54:32.899Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/google-labs-code_design.md.json
+++ b/data/skill-index/google-labs-code_design.md.json
@@ -1,0 +1,891 @@
+{
+  "repoUrl": "https://github.com/google-labs-code/design.md.git",
+  "owner": "google-labs-code",
+  "repo": "design.md",
+  "updatedAt": "2026-08-27T18:54:26.267Z",
+  "skillCount": 4,
+  "skills": [
+    {
+      "name": "agent-dx-cli-scale",
+      "description": "A scoring scale for evaluating how well a CLI is designed for AI agents, based on the \"Rewrite Your CLI for AI Agents\" principles.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "modelInvocable": true,
+      "userInvocable": true,
+      "installUrl": "github:google-labs-code/design.md:.agents/skills/agent-dx-cli-scale",
+      "relPath": ".agents/skills/agent-dx-cli-scale",
+      "verified": true,
+      "tokenCount": 4733,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "license",
+            "name": "License verification",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "pii",
+            "name": "PII detection",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "script-lint",
+            "name": "Script linting",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-08-27T18:54:26.263Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 67,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "license",
+              "name": "License verification",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "pii",
+              "name": "PII detection",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "script-lint",
+              "name": "Script linting",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-08-27T18:54:26.263Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-08-27T18:54:26.263Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "ink",
+      "description": "Ink terminal renderer for json-render that turns JSON specs into interactive terminal UIs. Use when working with @json-render/ink, building terminal UIs from JSON, creating terminal component catalogs, or rendering AI-generated specs in the terminal.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "modelInvocable": true,
+      "userInvocable": true,
+      "installUrl": "github:google-labs-code/design.md:.agents/skills/ink",
+      "relPath": ".agents/skills/ink",
+      "verified": true,
+      "tokenCount": 2729,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "license",
+            "name": "License verification",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "pii",
+            "name": "PII detection",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "script-lint",
+            "name": "Script linting",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-08-27T18:54:26.263Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 71,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "license",
+              "name": "License verification",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "pii",
+              "name": "PII detection",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "script-lint",
+              "name": "Script linting",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-08-27T18:54:26.263Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-08-27T18:54:26.263Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "tdd-red-green-refactor",
+      "description": "Enforces a disciplined Red-Green-Refactor (TDD) workflow in TypeScript/Node.js.  Use this whenever creating new features, fixing bugs, or migrating logic to ensure  high-quality, verifiable implementations.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "modelInvocable": true,
+      "userInvocable": true,
+      "installUrl": "github:google-labs-code/design.md:.agents/skills/tdd",
+      "relPath": ".agents/skills/tdd",
+      "verified": true,
+      "tokenCount": 927,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "license",
+            "name": "License verification",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "pii",
+            "name": "PII detection",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "script-lint",
+            "name": "Script linting",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-08-27T18:54:26.263Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 67,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "license",
+              "name": "License verification",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "pii",
+              "name": "PII detection",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "script-lint",
+              "name": "Script linting",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-08-27T18:54:26.263Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-08-27T18:54:26.263Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "typed-service-contracts",
+      "description": "Architecture standard for building robust, type-safe TypeScript services using the \"Spec and Handler\" pattern. Use when building CLIs, libraries, or complex business logic.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "modelInvocable": true,
+      "userInvocable": true,
+      "installUrl": "github:google-labs-code/design.md:.agents/skills/typed-service-contracts",
+      "relPath": ".agents/skills/typed-service-contracts",
+      "verified": true,
+      "tokenCount": 1633,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "license",
+            "name": "License verification",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "pii",
+            "name": "PII detection",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "script-lint",
+            "name": "Script linting",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-08-27T18:54:26.263Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 74,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "license",
+              "name": "License verification",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "pii",
+              "name": "PII detection",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "script-lint",
+              "name": "Script linting",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-08-27T18:54:26.263Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-08-27T18:54:26.263Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "google-labs-code-design.md-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from google-labs-code/design.md.",
+      "author": "ASM (google-labs-code/design.md)",
+      "createdAt": "2026-08-27T18:54:26.267Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "google-labs-code",
+        "design.md"
+      ],
+      "skills": [
+        {
+          "name": "agent-dx-cli-scale",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/agent-dx-cli-scale",
+          "description": "A scoring scale for evaluating how well a CLI is designed for AI agents, based on the \"Rewrite Your CLI for AI Agents\" principles.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ink",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/ink",
+          "description": "Ink terminal renderer for json-render that turns JSON specs into interactive terminal UIs. Use when working with @json-render/ink, building terminal UIs from JSON, creating terminal component catalogs, or rendering AI-generated specs in the terminal.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tdd-red-green-refactor",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/tdd",
+          "description": "Enforces a disciplined Red-Green-Refactor (TDD) workflow in TypeScript/Node.js.  Use this whenever creating new features, fixing bugs, or migrating logic to ensure  high-quality, verifiable implementations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "typed-service-contracts",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/typed-service-contracts",
+          "description": "Architecture standard for building robust, type-safe TypeScript services using the \"Spec and Handler\" pattern. Use when building CLIs, libraries, or complex business logic.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "google-labs-code",
+        "repo": "design.md",
+        "repoUrl": "https://github.com/google-labs-code/design.md.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "google-labs-code-design.md-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from google-labs-code/design.md.",
+      "author": "ASM (google-labs-code/design.md)",
+      "createdAt": "2026-08-27T18:54:26.267Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "google-labs-code",
+        "design.md"
+      ],
+      "skills": [
+        {
+          "name": "agent-dx-cli-scale",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/agent-dx-cli-scale",
+          "description": "A scoring scale for evaluating how well a CLI is designed for AI agents, based on the \"Rewrite Your CLI for AI Agents\" principles.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tdd-red-green-refactor",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/tdd",
+          "description": "Enforces a disciplined Red-Green-Refactor (TDD) workflow in TypeScript/Node.js.  Use this whenever creating new features, fixing bugs, or migrating logic to ensure  high-quality, verifiable implementations.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "google-labs-code",
+        "repo": "design.md",
+        "repoUrl": "https://github.com/google-labs-code/design.md.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "google-labs-code-design.md-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from google-labs-code/design.md.",
+      "author": "ASM (google-labs-code/design.md)",
+      "createdAt": "2026-08-27T18:54:26.267Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "google-labs-code",
+        "design.md"
+      ],
+      "skills": [
+        {
+          "name": "agent-dx-cli-scale",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/agent-dx-cli-scale",
+          "description": "A scoring scale for evaluating how well a CLI is designed for AI agents, based on the \"Rewrite Your CLI for AI Agents\" principles.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ink",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/ink",
+          "description": "Ink terminal renderer for json-render that turns JSON specs into interactive terminal UIs. Use when working with @json-render/ink, building terminal UIs from JSON, creating terminal component catalogs, or rendering AI-generated specs in the terminal.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tdd-red-green-refactor",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/tdd",
+          "description": "Enforces a disciplined Red-Green-Refactor (TDD) workflow in TypeScript/Node.js.  Use this whenever creating new features, fixing bugs, or migrating logic to ensure  high-quality, verifiable implementations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "typed-service-contracts",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/typed-service-contracts",
+          "description": "Architecture standard for building robust, type-safe TypeScript services using the \"Spec and Handler\" pattern. Use when building CLIs, libraries, or complex business logic.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "google-labs-code",
+        "repo": "design.md",
+        "repoUrl": "https://github.com/google-labs-code/design.md.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "google-labs-code-design.md-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from google-labs-code/design.md.",
+      "author": "ASM (google-labs-code/design.md)",
+      "createdAt": "2026-08-27T18:54:26.267Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "google-labs-code",
+        "design.md"
+      ],
+      "skills": [
+        {
+          "name": "agent-dx-cli-scale",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/agent-dx-cli-scale",
+          "description": "A scoring scale for evaluating how well a CLI is designed for AI agents, based on the \"Rewrite Your CLI for AI Agents\" principles.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ink",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/ink",
+          "description": "Ink terminal renderer for json-render that turns JSON specs into interactive terminal UIs. Use when working with @json-render/ink, building terminal UIs from JSON, creating terminal component catalogs, or rendering AI-generated specs in the terminal.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tdd-red-green-refactor",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/tdd",
+          "description": "Enforces a disciplined Red-Green-Refactor (TDD) workflow in TypeScript/Node.js.  Use this whenever creating new features, fixing bugs, or migrating logic to ensure  high-quality, verifiable implementations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "typed-service-contracts",
+          "installUrl": "github:google-labs-code/design.md:.agents/skills/typed-service-contracts",
+          "description": "Architecture standard for building robust, type-safe TypeScript services using the \"Spec and Handler\" pattern. Use when building CLIs, libraries, or complex business logic.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "google-labs-code",
+        "repo": "design.md",
+        "repoUrl": "https://github.com/google-labs-code/design.md.git"
+      },
+      "inferred": true
+    }
+  ]
+}

--- a/data/skill-index/hardikpandya_stop-slop.json
+++ b/data/skill-index/hardikpandya_stop-slop.json
@@ -1,27 +1,27 @@
 {
-  "repoUrl": "https://github.com/ayghri/i-have-adhd.git",
-  "owner": "ayghri",
-  "repo": "i-have-adhd",
-  "updatedAt": "2026-08-27T10:21:39.695Z",
+  "repoUrl": "https://github.com/hardikpandya/stop-slop.git",
+  "owner": "hardikpandya",
+  "repo": "stop-slop",
+  "updatedAt": "2026-08-27T18:54:29.607Z",
   "skillCount": 1,
   "skills": [
     {
-      "name": "i-have-adhd",
-      "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until \"stop adhd mode\". \u2014 anti-slop",
+      "name": "stop-slop",
+      "description": "Remove AI writing patterns from prose. Use when drafting, editing, or reviewing text to eliminate predictable AI tells. \u2014 anti-slop",
       "version": "0.0.0",
-      "license": "MIT",
+      "license": "",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "modelInvocable": false,
+      "modelInvocable": true,
       "userInvocable": true,
-      "installUrl": "github:ayghri/i-have-adhd:skills/i-have-adhd",
-      "relPath": "skills/i-have-adhd",
+      "installUrl": "github:hardikpandya/stop-slop",
+      "relPath": "",
       "verified": true,
-      "tokenCount": 2283,
+      "tokenCount": 680,
       "evalSummary": {
-        "overallScore": 81,
-        "grade": "B",
+        "overallScore": 64,
+        "grade": "D",
         "categories": [
           {
             "id": "structure",
@@ -32,43 +32,43 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 10,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 3,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 10,
+            "score": 9,
             "max": 10
           },
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 10,
+            "score": 1,
             "max": 10
           },
           {
             "id": "testability",
             "name": "Testability",
-            "score": 5,
+            "score": 1,
             "max": 10
           },
           {
             "id": "license",
             "name": "License verification",
-            "score": 5,
+            "score": 2,
             "max": 10
           },
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 8,
+            "score": 10,
             "max": 10
           },
           {
@@ -84,7 +84,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-08-27T10:21:39.692Z",
+        "evaluatedAt": "2026-08-27T18:54:29.605Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -93,8 +93,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 81,
-          "grade": "B",
+          "overallScore": 63,
+          "grade": "D",
           "categories": [
             {
               "id": "structure",
@@ -105,43 +105,43 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 10,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 3,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 10,
+              "score": 9,
               "max": 10
             },
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 10,
+              "score": 1,
               "max": 10
             },
             {
               "id": "testability",
               "name": "Testability",
-              "score": 5,
+              "score": 1,
               "max": 10
             },
             {
               "id": "license",
               "name": "License verification",
-              "score": 5,
+              "score": 2,
               "max": 10
             },
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 8,
+              "score": 9,
               "max": 10
             },
             {
@@ -157,7 +157,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
+          "evaluatedAt": "2026-08-27T18:54:29.605Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -165,17 +165,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 69,
+          "overallScore": 77,
           "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 9,
+              "score": 10,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
+          "evaluatedAt": "2026-08-27T18:54:29.605Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/nextlevelbuilder_ui-ux-pro-max-skill.json
+++ b/data/skill-index/nextlevelbuilder_ui-ux-pro-max-skill.json
@@ -357,7 +357,7 @@
     },
     {
       "name": "design",
-      "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+      "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML\u2192screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
       "version": "2.1.0",
       "license": "MIT",
       "creator": "",
@@ -532,7 +532,7 @@
     },
     {
       "name": "design-system",
-      "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+      "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive\u2192semantic\u2192component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
       "version": "1.0.0",
       "license": "MIT",
       "creator": "",
@@ -1057,7 +1057,7 @@
     },
     {
       "name": "ui-ux-pro-max",
-      "description": "UI/UX design intelligence for web, mobile, and desktop. This skill should be used when designing, building, reviewing, or fixing interfaces, including pages, components, design systems, accessibility, interaction, responsive layout, typography, color, charts, and stack-specific UI implementation. Searchable local data: 79 searchable styles (50 active), 192 product palettes and reasoning profiles, 74 font pairings, 119 UX guidelines, 105 icons, 17 GSAP presets, 25 chart types, and 22 stacks.",
+      "description": "UI/UX design intelligence for web, mobile, and desktop. This skill should be used when designing, building, reviewing, or fixing interfaces, including pages, components, design systems, accessibility, interaction, responsive layout, typography, color, charts, and stack-specific UI implementation. Searchable local data: 79 searchable styles (50 active), 192 product palettes and reasoning profiles, 74 font pairings, 119 UX guidelines, 105 icons, 17 GSAP presets, 25 chart types, and 22 stacks. \u2014 anti-slop",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -1263,13 +1263,13 @@
         {
           "name": "design",
           "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design",
-          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML\u2192screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
           "version": "2.1.0"
         },
         {
           "name": "design-system",
           "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design-system",
-          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive\u2192semantic\u2192component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
           "version": "1.0.0"
         },
         {
@@ -1323,13 +1323,13 @@
         {
           "name": "design",
           "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design",
-          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML\u2192screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
           "version": "2.1.0"
         },
         {
           "name": "design-system",
           "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design-system",
-          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive\u2192semantic\u2192component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
           "version": "1.0.0"
         },
         {
@@ -1377,13 +1377,13 @@
         {
           "name": "design",
           "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design",
-          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML\u2192screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
           "version": "2.1.0"
         },
         {
           "name": "design-system",
           "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design-system",
-          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive\u2192semantic\u2192component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
           "version": "1.0.0"
         },
         {
@@ -1443,13 +1443,13 @@
         {
           "name": "design",
           "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design",
-          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML\u2192screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
           "version": "2.1.0"
         },
         {
           "name": "design-system",
           "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design-system",
-          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive\u2192semantic\u2192component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
           "version": "1.0.0"
         },
         {
@@ -1509,13 +1509,13 @@
         {
           "name": "design",
           "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design",
-          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini or Atlas Cloud AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML\u2192screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
           "version": "2.1.0"
         },
         {
           "name": "design-system",
           "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design-system",
-          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive\u2192semantic\u2192component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
           "version": "1.0.0"
         },
         {

--- a/data/skill-index/pbakaus_impeccable.json
+++ b/data/skill-index/pbakaus_impeccable.json
@@ -1,74 +1,74 @@
 {
-  "repoUrl": "https://github.com/ayghri/i-have-adhd.git",
-  "owner": "ayghri",
-  "repo": "i-have-adhd",
-  "updatedAt": "2026-08-27T10:21:39.695Z",
+  "repoUrl": "https://github.com/pbakaus/impeccable.git",
+  "owner": "pbakaus",
+  "repo": "impeccable",
+  "updatedAt": "2026-08-27T18:54:23.865Z",
   "skillCount": 1,
   "skills": [
     {
-      "name": "i-have-adhd",
-      "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until \"stop adhd mode\". \u2014 anti-slop",
-      "version": "0.0.0",
-      "license": "MIT",
+      "name": "impeccable",
+      "description": "Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks. \u2014 anti-slop",
+      "version": "4.1.2",
+      "license": "Apache 2.0",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "modelInvocable": false,
+      "modelInvocable": true,
       "userInvocable": true,
-      "installUrl": "github:ayghri/i-have-adhd:skills/i-have-adhd",
-      "relPath": "skills/i-have-adhd",
+      "installUrl": "github:pbakaus/impeccable:.claude/skills/impeccable",
+      "relPath": ".claude/skills/impeccable",
       "verified": true,
-      "tokenCount": 2283,
+      "tokenCount": 2865,
       "evalSummary": {
-        "overallScore": 81,
-        "grade": "B",
+        "overallScore": 72,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
             "name": "Structure & completeness",
-            "score": 8,
+            "score": 9,
             "max": 10
           },
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 3,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 5,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 10,
+            "score": 9,
             "max": 10
           },
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 10,
+            "score": 7,
             "max": 10
           },
           {
             "id": "testability",
             "name": "Testability",
-            "score": 5,
+            "score": 7,
             "max": 10
           },
           {
             "id": "license",
             "name": "License verification",
-            "score": 5,
+            "score": 2,
             "max": 10
           },
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 8,
+            "score": 10,
             "max": 10
           },
           {
@@ -84,8 +84,8 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-08-27T10:21:39.692Z",
-        "evaluatedVersion": "0.0.0"
+        "evaluatedAt": "2026-08-27T18:54:23.819Z",
+        "evaluatedVersion": "4.1.2"
       },
       "evalSummaries": {
         "quality": {
@@ -93,61 +93,61 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 81,
-          "grade": "B",
+          "overallScore": 70,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
               "name": "Structure & completeness",
-              "score": 8,
+              "score": 9,
               "max": 10
             },
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 3,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 5,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 10,
+              "score": 9,
               "max": 10
             },
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 10,
+              "score": 7,
               "max": 10
             },
             {
               "id": "testability",
               "name": "Testability",
-              "score": 5,
+              "score": 7,
               "max": 10
             },
             {
               "id": "license",
               "name": "License verification",
-              "score": 5,
+              "score": 2,
               "max": 10
             },
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 8,
+              "score": 10,
               "max": 10
             },
             {
               "id": "pii",
               "name": "PII detection",
-              "score": 10,
+              "score": 8,
               "max": 10
             },
             {
@@ -157,8 +157,8 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
-          "evaluatedVersion": "0.0.0"
+          "evaluatedAt": "2026-08-27T18:54:23.819Z",
+          "evaluatedVersion": "4.1.2"
         },
         "skill-best-practice": {
           "providerId": "skill-best-practice",
@@ -175,8 +175,8 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
-          "evaluatedVersion": "0.0.0"
+          "evaluatedAt": "2026-08-27T18:54:23.819Z",
+          "evaluatedVersion": "4.1.2"
         }
       }
     }

--- a/data/skill-index/tt-a1i_archify.json
+++ b/data/skill-index/tt-a1i_archify.json
@@ -1,56 +1,56 @@
 {
-  "repoUrl": "https://github.com/ayghri/i-have-adhd.git",
-  "owner": "ayghri",
-  "repo": "i-have-adhd",
-  "updatedAt": "2026-08-27T10:21:39.695Z",
+  "repoUrl": "https://github.com/tt-a1i/archify.git",
+  "owner": "tt-a1i",
+  "repo": "archify",
+  "updatedAt": "2026-08-27T18:54:31.583Z",
   "skillCount": 1,
   "skills": [
     {
-      "name": "i-have-adhd",
-      "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until \"stop adhd mode\". \u2014 anti-slop",
-      "version": "0.0.0",
+      "name": "archify",
+      "description": "Create polished, validated architecture, workflow, sequence, data-flow, and lifecycle/state diagrams as explorable standalone HTML with inline SVG, dark/light themes, optional trace motion, and PNG/JPEG/WebP/SVG/WebM export. Accept plain-language requirements or pasted Mermaid flowchart, sequenceDiagram, and stateDiagram input; inspect repository evidence when the diagram must reflect real code. Use when the user asks to visualize system architecture, infrastructure, cloud/security/network topology, technical workflows, API call sequences, request lifecycles, data pipelines, ETL/ELT, data lineage, state machines, or to convert/beautify Mermaid. \u2014 anti-slop",
+      "version": "2.16",
       "license": "MIT",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "modelInvocable": false,
+      "modelInvocable": true,
       "userInvocable": true,
-      "installUrl": "github:ayghri/i-have-adhd:skills/i-have-adhd",
-      "relPath": "skills/i-have-adhd",
+      "installUrl": "github:tt-a1i/archify:archify",
+      "relPath": "archify",
       "verified": true,
-      "tokenCount": 2283,
+      "tokenCount": 3760,
       "evalSummary": {
-        "overallScore": 81,
+        "overallScore": 85,
         "grade": "B",
         "categories": [
           {
             "id": "structure",
             "name": "Structure & completeness",
-            "score": 8,
+            "score": 10,
             "max": 10
           },
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 6,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 10,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 10,
+            "score": 7,
             "max": 10
           },
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 10,
+            "score": 7,
             "max": 10
           },
           {
@@ -62,13 +62,13 @@
           {
             "id": "license",
             "name": "License verification",
-            "score": 5,
+            "score": 10,
             "max": 10
           },
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 8,
+            "score": 10,
             "max": 10
           },
           {
@@ -84,8 +84,8 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-08-27T10:21:39.692Z",
-        "evaluatedVersion": "0.0.0"
+        "evaluatedAt": "2026-08-27T18:54:31.439Z",
+        "evaluatedVersion": "2.16"
       },
       "evalSummaries": {
         "quality": {
@@ -93,37 +93,37 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 81,
+          "overallScore": 85,
           "grade": "B",
           "categories": [
             {
               "id": "structure",
               "name": "Structure & completeness",
-              "score": 8,
+              "score": 10,
               "max": 10
             },
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 6,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 10,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 10,
+              "score": 7,
               "max": 10
             },
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 10,
+              "score": 7,
               "max": 10
             },
             {
@@ -135,13 +135,13 @@
             {
               "id": "license",
               "name": "License verification",
-              "score": 5,
+              "score": 10,
               "max": 10
             },
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 8,
+              "score": 10,
               "max": 10
             },
             {
@@ -157,26 +157,26 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
-          "evaluatedVersion": "0.0.0"
+          "evaluatedAt": "2026-08-27T18:54:31.439Z",
+          "evaluatedVersion": "2.16"
         },
         "skill-best-practice": {
           "providerId": "skill-best-practice",
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 69,
+          "overallScore": 79,
           "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 9,
-              "max": 13
+              "score": 11,
+              "max": 14
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
-          "evaluatedVersion": "0.0.0"
+          "evaluatedAt": "2026-08-27T18:54:31.439Z",
+          "evaluatedVersion": "2.16"
         }
       }
     }

--- a/data/skill-index/zarazhangrui_frontend-slides.json
+++ b/data/skill-index/zarazhangrui_frontend-slides.json
@@ -1,50 +1,50 @@
 {
-  "repoUrl": "https://github.com/ayghri/i-have-adhd.git",
-  "owner": "ayghri",
-  "repo": "i-have-adhd",
-  "updatedAt": "2026-08-27T10:21:39.695Z",
+  "repoUrl": "https://github.com/zarazhangrui/frontend-slides.git",
+  "owner": "zarazhangrui",
+  "repo": "frontend-slides",
+  "updatedAt": "2026-08-27T18:54:25.518Z",
   "skillCount": 1,
   "skills": [
     {
-      "name": "i-have-adhd",
-      "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until \"stop adhd mode\". \u2014 anti-slop",
+      "name": "frontend-slides",
+      "description": "Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices. \u2014 anti-slop",
       "version": "0.0.0",
-      "license": "MIT",
+      "license": "",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "modelInvocable": false,
+      "modelInvocable": true,
       "userInvocable": true,
-      "installUrl": "github:ayghri/i-have-adhd:skills/i-have-adhd",
-      "relPath": "skills/i-have-adhd",
+      "installUrl": "github:zarazhangrui/frontend-slides",
+      "relPath": "",
       "verified": true,
-      "tokenCount": 2283,
+      "tokenCount": 8591,
       "evalSummary": {
-        "overallScore": 81,
-        "grade": "B",
+        "overallScore": 76,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
             "name": "Structure & completeness",
-            "score": 8,
+            "score": 7,
             "max": 10
           },
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 8,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 9,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 10,
+            "score": 5,
             "max": 10
           },
           {
@@ -62,13 +62,13 @@
           {
             "id": "license",
             "name": "License verification",
-            "score": 5,
+            "score": 2,
             "max": 10
           },
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 8,
+            "score": 10,
             "max": 10
           },
           {
@@ -84,7 +84,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-08-27T10:21:39.692Z",
+        "evaluatedAt": "2026-08-27T18:54:25.388Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -93,31 +93,31 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 81,
-          "grade": "B",
+          "overallScore": 67,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
               "name": "Structure & completeness",
-              "score": 8,
+              "score": 7,
               "max": 10
             },
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 8,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 9,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 10,
+              "score": 5,
               "max": 10
             },
             {
@@ -135,29 +135,29 @@
             {
               "id": "license",
               "name": "License verification",
-              "score": 5,
+              "score": 2,
               "max": 10
             },
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 8,
+              "score": 9,
               "max": 10
             },
             {
               "id": "pii",
               "name": "PII detection",
-              "score": 10,
+              "score": 6,
               "max": 10
             },
             {
               "id": "script-lint",
               "name": "Script linting",
-              "score": 10,
+              "score": 6,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
+          "evaluatedAt": "2026-08-27T18:54:25.388Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -165,17 +165,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 69,
-          "grade": "C",
+          "overallScore": 62,
+          "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 9,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-08-27T10:21:39.692Z",
+          "evaluatedAt": "2026-08-27T18:54:25.388Z",
           "evaluatedVersion": "0.0.0"
         }
       }


### PR DESCRIPTION
## What
Adds the 15 "AI slop"-killing skills Charlie Hills ranked (https://x.com/charliejhills/status/2092898653820400076) to the asm skill index, tagging each with the `anti-slop` keyword in its description text (prose, matching the existing `taste-skill` convention).

## Changes
- **data/skill-index-resources.json**: registered 11 previously-unindexed repos (4 of the 15 were already indexed: ui-ux-pro-max-skill, Understand-Anything, taste-skill, i-have-adhd).
  - `VoltAgent/awesome-design-md`, `pbakaus/impeccable`, `blader/humanizer`, `zarazhangrui/frontend-slides`, `google-labs-code/design.md`, `Nutlope/hallmark`, `cathrynlavery/diagram-design`, `hardikpandya/stop-slop`, `tt-a1i/archify`, `charlie947/answer-first`, `charlie947/voiceprint`
- **11 new data/skill-index/*.json** files generated via `npm run preindex` (74 repos total; 0 failures).
  - Note: `VoltAgent/awesome-design-md` produced 0 skill entries (non-standard skill layout in that repo) — repo is registered but contributes no skills yet.
- **3Description edits** on pre-existing indexed files to carry the `anti-slop` keyword: `Egonex-AI/Understand-Anything` (understand), `ayghri/i-have-adhd`, `nextlevelbuilder/ui-ux-pro-max-skill` (ui-ux-pro-max). The other 12 already implied or contained anti-slop (taste-skill, hallmark, stop-slop, humanizer, etc.).

## Notes
- `npm run preindex` was run as the regeneration step (per the change's purpose). It also rewrites the developer's real `~/.config/agent-skill-manager/skill-index/` — accepted.
- The full 74-repo regen produced timestamp churn across many files; this PR intentionally scopes the commit to ONLY the 11 new files + resources.json + the 3 description edits, leaving unrelated re-ingestion noise out of the diff.
- There is no structured `category`/`tags` field in the index schema, so `anti-slop` is applied as a description keyword (prose) as agreed.

## Verification
- `preindex` exit: 74 succeeded, 0 failed.
- `grep -ril 'anti-slop' data/skill-index/*.json` → 13 files (the 15 ranked skills, minus 2 already-bearing and minus VoltAgent's 0-skill repo).