### PR TITLE
feat(tags): add skill tag assignment and catalog tag filtering (#584)

### DIFF
--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -25,6 +25,7 @@ import {
   repoBundlesForIndex,
   type RepoBundleManifest,
 } from "../src/repo-bundles";
+import { normalizeTags } from "../src/utils/frontmatter";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const indexDir = join(root, "data", "skill-index");
@@ -257,6 +258,7 @@ interface IndexedSkill {
   creator: string;
   compatibility: string;
   allowedTools: string[];
+  tags?: string[];
   installUrl: string;
   relPath: string;
   verified?: boolean;
@@ -284,6 +286,7 @@ interface CatalogSkill {
   creator: string;
   compatibility: string;
   allowedTools: string[];
+  tags: string[];
   installUrl: string;
   skillUrl: string;
   owner: string;
@@ -419,6 +422,7 @@ for (const file of files) {
       creator: skill.creator,
       compatibility: skill.compatibility,
       allowedTools: skill.allowedTools || [],
+      tags: normalizeTags(skill.tags || []),
       installUrl: skill.installUrl,
       skillUrl,
       owner: repoIndex.owner,
@@ -601,6 +605,7 @@ interface SkillsMinRow {
   version: string;
   verified: boolean;
   featured?: boolean;
+  tags: string[];
   /** Derived flag — avoids shipping the full allowedTools array on the list. */
   hasTools: boolean;
   tokenCount?: number;
@@ -640,6 +645,7 @@ const slimSkills: SkillsMinRow[] = skills.map((s) => {
     license: s.license,
     version: s.version,
     verified: s.verified,
+    tags: s.tags,
     hasTools: Array.isArray(s.allowedTools) && s.allowedTools.length > 0,
   };
   if (s.featured === true) row.featured = true;
@@ -686,7 +692,7 @@ miniSearch.addAll(
     id: i,
     name: s.name,
     description: s.description,
-    categoriesStr: (s.categories || []).join(" "),
+    categoriesStr: [...(s.categories || []), ...(s.tags || [])].join(" "),
   })),
 );
 
@@ -719,6 +725,7 @@ interface SkillDetail {
   creator: string;
   compatibility: string;
   allowedTools: string[];
+  tags: string[];
   installUrl: string;
   skillUrl: string;
   owner: string;
@@ -744,6 +751,7 @@ for (const s of skills) {
     creator: s.creator,
     compatibility: s.compatibility,
     allowedTools: s.allowedTools,
+    tags: s.tags,
     installUrl: s.installUrl,
     skillUrl: s.skillUrl,
     owner: s.owner,

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -101,6 +101,18 @@ describe("parseArgs", () => {
     expect(result.subcommand).toBe("code-review");
   });
 
+  test("parses repeatable and comma-separated tag filters", () => {
+    const result = parse("list", "--tag", "cli,testing", "--tag", "frontend");
+    expect(result.flags.tagFilters).toEqual(["cli,testing", "frontend"]);
+  });
+
+  test("parses tag editing command arguments", () => {
+    const result = parse("tag", "add", "code-review", "cli,testing");
+    expect(result.command).toBe("tag");
+    expect(result.subcommand).toBe("add");
+    expect(result.positional).toEqual(["code-review", "cli,testing"]);
+  });
+
   test("parses inspect with skill name", () => {
     const result = parse("inspect", "blog-draft");
     expect(result.command).toBe("inspect");
@@ -6371,5 +6383,102 @@ One line of body text.
     // The registry metadata cache is deliberately NOT asserted on: it is
     // resolution metadata, not an installed skill, and the local path used
     // here never reaches the registry rung anyway.
+  });
+});
+
+// ─── CLI integration: local skill tags (#584) ───────────────────────────────
+
+describe("CLI integration: local skill tags", () => {
+  const skillName = "issue-584-tag-fixture";
+  const skillDir = join(homedir(), ".claude", "skills", skillName);
+
+  beforeEach(async () => {
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      `---\nname: ${skillName}\ndescription: Tag CLI fixture\ntags: [cli, testing]\n---\nBody\n`,
+    );
+    await rm(join(process.env.ASM_CONFIG_DIR!, "skill-tags.json"), {
+      force: true,
+    });
+  });
+
+  afterEach(async () => {
+    await rm(skillDir, { recursive: true, force: true });
+    await rm(join(process.env.ASM_CONFIG_DIR!, "skill-tags.json"), {
+      force: true,
+    });
+  });
+
+  test("adds and removes persisted tags without changing SKILL.md", async () => {
+    const before = await readFile(join(skillDir, "SKILL.md"), "utf-8");
+    const added = await runCLI(
+      "tag",
+      "add",
+      skillName,
+      "automation,CLI",
+      "--json",
+    );
+    expect(added.exitCode).toBe(0);
+    expect(JSON.parse(added.stdout)[0].tags).toEqual([
+      "cli",
+      "testing",
+      "automation",
+    ]);
+
+    const removed = await runCLI(
+      "tag",
+      "remove",
+      skillName,
+      "testing",
+      "--json",
+    );
+    expect(removed.exitCode).toBe(0);
+    expect(JSON.parse(removed.stdout)[0].tags).toEqual(["cli", "automation"]);
+    expect(await readFile(join(skillDir, "SKILL.md"), "utf-8")).toBe(before);
+  });
+
+  test("list and search accept repeatable AND tag filters", async () => {
+    await runCLI("tag", "add", skillName, "automation", "--json");
+
+    const listed = await runCLI(
+      "list",
+      "--tag",
+      "cli,automation",
+      "--tag",
+      "testing",
+      "--json",
+    );
+    expect(listed.exitCode).toBe(0);
+    expect(
+      JSON.parse(listed.stdout).map((skill: { name: string }) => skill.name),
+    ).toContain(skillName);
+
+    const searched = await runCLI(
+      "search",
+      skillName,
+      "--installed",
+      "--tag",
+      "cli,automation",
+      "--json",
+    );
+    expect(searched.exitCode).toBe(0);
+    expect(JSON.parse(searched.stdout)).toMatchObject([
+      { name: skillName, tags: ["cli", "testing", "automation"] },
+    ]);
+
+    const noMatch = await runCLI("list", "--tag", "cli,missing-tag", "--json");
+    expect(noMatch.exitCode).toBe(0);
+    expect(JSON.parse(noMatch.stdout)).toEqual([]);
+  });
+
+  test("rejects invalid and missing tag arguments", async () => {
+    const invalid = await runCLI("tag", "add", skillName, "bad tag");
+    expect(invalid.exitCode).toBe(2);
+    expect(invalid.stderr).toContain("Invalid tag value");
+
+    const missing = await runCLI("list", "--tag");
+    expect(missing.exitCode).toBe(2);
+    expect(missing.stderr).toContain("Missing value");
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,8 @@ export interface ParsedArgs {
     missing: string[];
     modelInvocable: boolean;
     userInvocable: boolean;
+    /** Repeatable/comma-separated tag filters for list and search. */
+    tagFilters: string[];
     dryRun: boolean;
     /** `asm import --diff` — show unified diffs for conflicts. */
     diff: boolean;
@@ -129,6 +131,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       missing: [],
       modelInvocable: false,
       userInvocable: false,
+      tagFilters: [],
       dryRun: false,
       diff: false,
       machine: false,
@@ -296,6 +299,13 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.flags.modelInvocable = true;
     } else if (arg === "--user-invocable") {
       result.flags.userInvocable = true;
+    } else if (arg === "--tag") {
+      i++;
+      if (!args[i]) {
+        error('Missing value for "--tag".');
+        process.exit(2);
+      }
+      result.flags.tagFilters.push(args[i]);
     } else if (arg === "--add") {
       i++;
       result.flags.add = args[i] || null;
@@ -368,6 +378,7 @@ ${ansi.bold("Usage:")}
 ${ansi.bold("Commands:")}
   list                   List all discovered skills
   search <query>         Search skills by name/description/tool
+  tag add|remove         Edit local tags for an installed skill
   inspect <skill-name>   Show detailed info for a skill
   get <skill>            Print a skill's SKILL.md body (installs nothing)
   uninstall <skill-name> Remove a skill (with confirmation)
@@ -407,6 +418,7 @@ ${ansi.bold("Global Options:")}
   --machine              Stable machine-readable JSON envelope (v1)
   -s, --scope <scope>    Filter: global, project, or both (default: both)
   -p, --tool <name>      Filter by tool (list, search)
+  --tag <tag[,tag]>      Filter by all tags; repeatable (list, search)
   --no-color             Disable ANSI colors
   --sort <field>         Sort by: name, version, or location (default: name)
   --flat                 Show one row per tool instance (list, search)
@@ -417,6 +429,7 @@ ${ansi.bold("Global Options:")}
 // ─── Command handlers ──────────────────────────────────────────────────────
 import { cmdList } from "./commands/list";
 import { cmdSearch } from "./commands/search";
+import { cmdTag } from "./commands/tag";
 import { cmdInspect } from "./commands/inspect";
 import { cmdGet } from "./commands/get";
 import { cmdUninstall } from "./commands/uninstall";
@@ -518,6 +531,9 @@ export async function runCLI(argv: string[]): Promise<void> {
     case "search":
       await cmdSearch(args);
       break;
+    case "tag":
+      await cmdTag(args);
+      break;
     case "inspect":
       await cmdInspect(args);
       break;
@@ -607,6 +623,7 @@ export function isCLIMode(argv: string[]): boolean {
   const commands = [
     "list",
     "search",
+    "tag",
     "inspect",
     "get",
     "uninstall",

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -3,6 +3,12 @@ import { scanAllSkills, sortSkills } from "../scanner";
 import { matchesInvocabilityFilters } from "../utils/frontmatter";
 import { loadSkillState } from "../skill-state";
 import {
+  applySkillTagState,
+  loadSkillTagState,
+  matchesAllTags,
+  parseTagInputs,
+} from "../skill-tags";
+import {
   formatSkillTable,
   formatGroupedTable,
   formatJSON,
@@ -15,7 +21,7 @@ import {
 } from "../formatter";
 import { formatMachineOutput } from "../utils/machine";
 
-import { enrichWithHealth } from "./shared";
+import { enrichWithHealth, error } from "./shared";
 import { reconstructDisabledSkills } from "./toggle";
 import type { ParsedArgs } from "../cli";
 
@@ -38,6 +44,7 @@ ${ansi.bold("Options:")}
   --limit <N>          Limit rendered rows (0 = no limit)
   --model-invocable    Only skills the model can invoke
   --user-invocable     Only skills the user can invoke (slash command)
+  --tag <tag[,tag]>    Require every tag; repeatable
   --json               Output as JSON array
   --machine            Output in stable machine-readable v1 envelope format
   --no-color           Disable ANSI colors
@@ -54,6 +61,7 @@ ${ansi.bold("Examples:")}
   asm list --limit 20               ${ansi.dim("Show first 20 rows only")}
   asm list -p claude                ${ansi.dim("Only Claude Code skills")}
   asm list -s project               ${ansi.dim("Only project-scoped skills")}
+  asm list --tag cli --tag testing  ${ansi.dim("Require both tags")}
   asm list --sort version           ${ansi.dim("Sort by version")}
   asm list --json                   ${ansi.dim("Output as JSON")}
   asm list --machine                ${ansi.dim("Machine-readable v1 envelope output")}`);
@@ -62,6 +70,15 @@ ${ansi.bold("Examples:")}
 export async function cmdList(args: ParsedArgs) {
   if (args.flags.help) {
     printListHelp();
+    return;
+  }
+
+  const parsedTags = parseTagInputs(args.flags.tagFilters);
+  if (parsedTags.invalid.length > 0) {
+    error(
+      `Invalid tag value(s): ${parsedTags.invalid.map((tag) => JSON.stringify(tag)).join(", ")}.`,
+    );
+    process.exitCode = 2;
     return;
   }
 
@@ -85,6 +102,14 @@ export async function cmdList(args: ParsedArgs) {
     activeKeys,
   );
   allSkills = [...allSkills, ...disabledSkills];
+
+  const tagState = await loadSkillTagState();
+  applySkillTagState(allSkills, tagState);
+  if (parsedTags.tags.length > 0) {
+    allSkills = allSkills.filter((skill) =>
+      matchesAllTags(skill.tags, parsedTags.tags),
+    );
+  }
 
   // Provider filter (for list/search — not for install/init where it means target)
   if (args.flags.provider && args.command === "list") {
@@ -110,6 +135,7 @@ export async function cmdList(args: ParsedArgs) {
       scope: s.scope,
       provider: s.provider,
       path: s.path,
+      tags: s.tags || [],
     }));
     console.log(formatMachineOutput("list", data, startTime));
     return;

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -18,6 +18,12 @@ import {
   redirectConsoleToStderr,
 } from "../utils/machine";
 import { searchSkills as searchIndexSkills } from "../skill-index";
+import {
+  applySkillTagState,
+  loadSkillTagState,
+  matchesAllTags,
+  parseTagInputs,
+} from "../skill-tags";
 
 import { error } from "./shared";
 import type { ParsedArgs } from "../cli";
@@ -36,6 +42,7 @@ ${ansi.bold("Options:")}
   --available          Show only available (not installed) skills
   --model-invocable    Only skills the model can invoke
   --user-invocable     Only skills the user can invoke (slash command)
+  --tag <tag[,tag]>    Require every tag; repeatable
   --flat               Show one row per tool instance (ungrouped)
   --json               Output as JSON array
   --machine            Output in stable machine-readable v1 envelope format
@@ -47,6 +54,7 @@ ${ansi.bold("Examples:")}
   asm search review -p claude       ${ansi.dim("Search within Claude Code only")}
   asm search "test" --installed     ${ansi.dim("Search installed skills only")}
   asm search "test" --available     ${ansi.dim("Search available skills only")}
+  asm search code --tag cli,testing  ${ansi.dim("Require both tags")}
   asm search openspec --json        ${ansi.dim("Output matches as JSON")}
   asm search openspec --machine     ${ansi.dim("Machine-readable v1 envelope output")}`);
 }
@@ -81,6 +89,16 @@ export async function cmdSearch(args: ParsedArgs) {
     process.exit(2);
   }
 
+  const parsedTags = parseTagInputs(args.flags.tagFilters);
+  if (parsedTags.invalid.length > 0) {
+    restoreConsole?.();
+    error(
+      `Invalid tag value(s): ${parsedTags.invalid.map((tag) => JSON.stringify(tag)).join(", ")}.`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+
   const showInstalled = !args.flags.available;
   const showAvailable = !args.flags.installed;
 
@@ -89,6 +107,12 @@ export async function cmdSearch(args: ParsedArgs) {
   if (showInstalled) {
     const config = await loadConfig();
     let allSkills = await scanAllSkills(config, args.flags.scope);
+    applySkillTagState(allSkills, await loadSkillTagState());
+    if (parsedTags.tags.length > 0) {
+      allSkills = allSkills.filter((skill) =>
+        matchesAllTags(skill.tags, parsedTags.tags),
+      );
+    }
     if (args.flags.provider) {
       allSkills = allSkills.filter((s) => s.provider === args.flags.provider);
     }
@@ -107,16 +131,12 @@ export async function cmdSearch(args: ParsedArgs) {
   // --- Available (index) skills ---
   let indexResults: Awaited<ReturnType<typeof searchIndexSkills>> = [];
   if (showAvailable) {
-    indexResults = await searchIndexSkills(
-      query,
-      20,
-      args.flags.modelInvocable || args.flags.userInvocable
-        ? {
-            modelInvocable: args.flags.modelInvocable || undefined,
-            userInvocable: args.flags.userInvocable || undefined,
-          }
-        : undefined,
-    );
+    const filters = {
+      modelInvocable: args.flags.modelInvocable || undefined,
+      userInvocable: args.flags.userInvocable || undefined,
+      tags: parsedTags.tags.length > 0 ? parsedTags.tags : undefined,
+    };
+    indexResults = await searchIndexSkills(query, 20, filters);
     // Deduplicate: remove index results that match an installed skill by name
     if (installedResults.length > 0) {
       const installedNames = new Set(
@@ -136,6 +156,7 @@ export async function cmdSearch(args: ParsedArgs) {
       description: s.description,
       source: "installed" as const,
       url: null,
+      tags: s.tags || [],
       match_count: 1,
     }));
     const available = indexResults.map((r) => ({
@@ -143,6 +164,7 @@ export async function cmdSearch(args: ParsedArgs) {
       description: r.skill.description,
       source: "index" as const,
       url: r.skill.installUrl,
+      tags: r.skill.tags || [],
       match_count: 1,
     }));
     console.log(
@@ -158,6 +180,7 @@ export async function cmdSearch(args: ParsedArgs) {
       version: s.version,
       scope: s.scope,
       provider: s.provider,
+      tags: s.tags || [],
       status: "installed" as const,
     }));
     const available = indexResults.map((r) => ({
@@ -166,6 +189,7 @@ export async function cmdSearch(args: ParsedArgs) {
       version: r.skill.version,
       repo: `${r.repo.owner}/${r.repo.repo}`,
       installCommand: `asm install ${r.skill.installUrl}`,
+      tags: r.skill.tags || [],
       status: "available" as const,
     }));
     console.log(formatJSON([...installed, ...available]));

--- a/src/commands/tag.ts
+++ b/src/commands/tag.ts
@@ -1,0 +1,108 @@
+import { loadConfig } from "../config";
+import { ansi, formatJSON, formatTagUpdates } from "../formatter";
+import { scanAllSkills } from "../scanner";
+import {
+  addSkillTags,
+  effectiveSkillTags,
+  loadSkillTagState,
+  parseTagInputs,
+  removeSkillTags,
+  saveSkillTagState,
+  skillTagKey,
+} from "../skill-tags";
+import { formatMachineOutput } from "../utils/machine";
+import { matchSkills } from "../skill-state";
+import type { ParsedArgs } from "../cli";
+import type { TagUpdateResult } from "../formatter";
+import { error, groupBySource } from "./shared";
+
+function printTagHelp(): void {
+  console.log(`${ansi.bold("Usage:")} asm tag add <skill> <tag> [tag...]
+       asm tag remove <skill> <tag> [tag...]
+
+Edit local tags for installed skills without changing their SKILL.md files.
+Tags are lowercase identifiers and may also be comma-separated.
+
+${ansi.bold("Options:")}
+  -s, --scope <s>      Limit matches to global, project, or both
+  -p, --tool <p>       Limit matches to one tool/provider
+  --json               Output updated skills as JSON
+  --machine            Output a stable machine-readable v1 envelope
+
+${ansi.bold("Examples:")}
+  asm tag add code-review testing cli
+  asm tag add code-review testing,automation
+  asm tag remove code-review automation`);
+}
+
+export async function cmdTag(args: ParsedArgs): Promise<void> {
+  if (args.flags.help) {
+    printTagHelp();
+    return;
+  }
+
+  const action = args.subcommand;
+  if (action !== "add" && action !== "remove") {
+    error('Missing or invalid action. Use "tag add" or "tag remove".');
+    process.exitCode = 2;
+    return;
+  }
+
+  const target = args.positional[0];
+  const parsedTags = parseTagInputs(args.positional.slice(1));
+  if (parsedTags.invalid.length > 0) {
+    const shown = parsedTags.invalid
+      .map((tag) => JSON.stringify(tag))
+      .join(", ");
+    error(
+      `Invalid tag value(s): ${shown}. Use 1-32 lowercase letters, numbers, hyphens, or underscores.`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+  if (!target || parsedTags.tags.length === 0) {
+    error(`Usage: asm tag ${action} <skill> <tag> [tag...]`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const startedAt = performance.now();
+  const config = await loadConfig();
+  let skills = await scanAllSkills(config, args.flags.scope);
+  if (args.flags.provider) {
+    skills = skills.filter((skill) => skill.provider === args.flags.provider);
+  }
+  const matched = matchSkills(skills, target);
+  if (matched.length === 0) {
+    error(`Skill not found: "${target}".`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const state = await loadSkillTagState();
+  const results: TagUpdateResult[] = [];
+  for (const group of groupBySource(matched, skills)) {
+    const skill = group.representative;
+    const key = skillTagKey(skill);
+    const before = effectiveSkillTags(skill.tags, state.skills[key]);
+    const tags =
+      action === "add"
+        ? addSkillTags(state, key, skill.tags, parsedTags.tags)
+        : removeSkillTags(state, key, skill.tags, parsedTags.tags);
+    results.push({
+      name: skill.name,
+      path: skill.realPath,
+      tags,
+      changed: JSON.stringify(before) !== JSON.stringify(tags),
+    });
+  }
+  await saveSkillTagState(state);
+
+  if (args.flags.machine) {
+    console.log(formatMachineOutput("tag", results, startedAt));
+  } else if (args.flags.json) {
+    console.log(formatJSON(results));
+  } else {
+    console.log(formatTagUpdates(action, results));
+  }
+}

--- a/src/commands/toggle.ts
+++ b/src/commands/toggle.ts
@@ -3,6 +3,7 @@ import { scanAllSkills } from "../scanner";
 import {
   parseFrontmatter,
   resolveModelInvocable,
+  resolveTags,
   resolveUserInvocable,
 } from "../utils/frontmatter";
 import {
@@ -166,6 +167,7 @@ export async function reconstructDisabledSkills(
           license: (fm.license || "").trim(),
           compatibility: (fm.compatibility || "").trim(),
           allowedTools: [],
+          tags: resolveTags(fm),
           modelInvocable: resolveModelInvocable(fm),
           userInvocable: resolveUserInvocable(fm),
           dirName,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -5,6 +5,7 @@ import {
   getConfigDir,
   getConfigPath,
   getIndexDir,
+  getSkillTagsPath,
   loadConfig,
   saveConfig,
   saveSelectedTools,
@@ -142,6 +143,7 @@ describe("getConfigDir", () => {
       process.env.ASM_CONFIG_DIR = override;
       expect(getConfigDir()).toBe(override);
       expect(getConfigPath()).toBe(join(override, "config.json"));
+      expect(getSkillTagsPath()).toBe(join(override, "skill-tags.json"));
     } finally {
       if (previous === undefined) delete process.env.ASM_CONFIG_DIR;
       else process.env.ASM_CONFIG_DIR = previous;

--- a/src/config.ts
+++ b/src/config.ts
@@ -190,6 +190,11 @@ export function getSkillStatePath(): string {
   return join(getConfigDir(), "skill-state.json");
 }
 
+/** Local tag additions/removals for installed skills. */
+export function getSkillTagsPath(): string {
+  return join(getConfigDir(), "skill-tags.json");
+}
+
 export function getIndexDir(): string {
   return join(getConfigDir(), "skill-index");
 }

--- a/src/formatter-core.ts
+++ b/src/formatter-core.ts
@@ -770,6 +770,29 @@ export function wordWrap(text: string, maxWidth: number): string[] {
   return lines;
 }
 
+// ─── Tag editing ─────────────────────────────────────────────────────────────
+
+export interface TagUpdateResult {
+  name: string;
+  path: string;
+  tags: string[];
+  changed: boolean;
+}
+
+export function formatTagUpdates(
+  action: "add" | "remove",
+  results: TagUpdateResult[],
+): string {
+  const verb = action === "add" ? "Added tags to" : "Removed tags from";
+  return results
+    .map((result) => {
+      const tags = result.tags.length > 0 ? result.tags.join(", ") : "(none)";
+      const suffix = result.changed ? "" : " (unchanged)";
+      return `${verb} ${ansi.bold(result.name)}: ${tags}${suffix}`;
+    })
+    .join("\n");
+}
+
 // ─── JSON formatter ─────────────────────────────────────────────────────────
 
 export function formatJSON(data: unknown): string {

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -10,6 +10,7 @@ import {
   colorProvider,
   colorEffort,
   formatJSON,
+  formatTagUpdates,
   ansi,
   colorTool,
   formatAllowedTools,
@@ -369,6 +370,19 @@ describe("formatSkillInspect", () => {
     ];
     const output = await formatSkillInspect(skills);
     expect(output).not.toContain("Warnings");
+  });
+});
+
+// ─── tag update formatter ──────────────────────────────────────────────────
+
+describe("formatTagUpdates", () => {
+  test("formats changed and unchanged effective tags", () => {
+    expect(
+      formatTagUpdates("add", [
+        { name: "review", path: "/review", tags: ["cli"], changed: true },
+        { name: "test", path: "/test", tags: [], changed: false },
+      ]),
+    ).toBe("Added tags to review: cli\nAdded tags to test: (none) (unchanged)");
   });
 });
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -29,6 +29,9 @@ export {
   formatSearchResults,
   type AvailableSkillResult,
   formatAvailableSearchResults,
+  // ── Tag editing ──
+  formatTagUpdates,
+  type TagUpdateResult,
   // ── Allowed-tools risk ──
   HIGH_RISK_TOOLS,
   MEDIUM_RISK_TOOLS,

--- a/src/ingester.test.ts
+++ b/src/ingester.test.ts
@@ -114,6 +114,7 @@ description: Evaluate deterministic indexing behavior for concurrency tests
 version: 1.0.0
 license: MIT
 creator: Test Author
+tags: [Testing, concurrency]
 ---
 
 # ${name}
@@ -431,6 +432,11 @@ describe("parallel skill ingestion (issue #372)", () => {
     expect(
       concurrentResult.repoIndex!.skills.map((skill) => skill.name),
     ).toEqual(inputOrder);
+    expect(
+      concurrentResult.repoIndex!.skills.every(
+        (skill) => JSON.stringify(skill.tags) === '["testing","concurrency"]',
+      ),
+    ).toBe(true);
     expect(
       concurrentResult.repoIndex!.skills.map(withoutEvaluationTimes),
     ).toEqual(sequentialSkills.map(withoutEvaluationTimes));

--- a/src/ingester.ts
+++ b/src/ingester.ts
@@ -213,6 +213,7 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
           creator: skill.creator,
           compatibility: skill.compatibility,
           allowedTools: skill.allowedTools,
+          tags: skill.tags,
           modelInvocable: skill.modelInvocable !== false,
           userInvocable: skill.userInvocable !== false,
           installUrl: buildSkillInstallUrl(source, skill.relPath),

--- a/src/installer-core.ts
+++ b/src/installer-core.ts
@@ -25,6 +25,7 @@ import {
   resolveAllowedTools,
   resolveModelInvocable,
   resolveUserInvocable,
+  resolveTags,
 } from "./utils/frontmatter";
 import { estimateTokenCount } from "./utils/token-count";
 import { resolveProviderPath } from "./config";
@@ -535,6 +536,7 @@ export async function discoverSkills(
       creator: (fm["metadata.creator"] || "").trim(),
       compatibility: (fm.compatibility || "").trim(),
       allowedTools: resolveAllowedTools(fm),
+      tags: resolveTags(fm),
       modelInvocable: resolveModelInvocable(fm),
       userInvocable: resolveUserInvocable(fm),
       tokenCount: estimateTokenCount(content),
@@ -579,6 +581,7 @@ export async function discoverSkills(
           creator: (fm["metadata.creator"] || "").trim(),
           compatibility: (fm.compatibility || "").trim(),
           allowedTools: resolveAllowedTools(fm),
+          tags: resolveTags(fm),
           modelInvocable: resolveModelInvocable(fm),
           userInvocable: resolveUserInvocable(fm),
           tokenCount: estimateTokenCount(content),

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -605,7 +605,7 @@ describe("discoverSkills", () => {
     await mkdir(join(tempDir, "child"), { recursive: true });
     await writeFile(
       join(tempDir, "SKILL.md"),
-      "---\nname: root-skill\nversion: 1.0.0\ndescription: Root skill\n---\n# Root\n",
+      "---\nname: root-skill\nversion: 1.0.0\ndescription: Root skill\ntags: [CLI, testing]\n---\n# Root\n",
     );
     await writeFile(
       join(tempDir, "child", "SKILL.md"),
@@ -617,7 +617,9 @@ describe("discoverSkills", () => {
     const root = discovered.find((s) => s.relPath === "");
     const child = discovered.find((s) => s.relPath === "child");
     expect(root?.name).toBe("root-skill");
+    expect(root?.tags).toEqual(["cli", "testing"]);
     expect(child?.name).toBe("child-skill");
+    expect(child?.tags).toEqual([]);
   });
 
   test("discovers skills in subdirectories", async () => {

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -445,7 +445,7 @@ describe("scanAllSkills", () => {
     const skillDir = join(tempDir, "my-skill");
     await mkdir(skillDir, { recursive: true });
     const skillMdContent =
-      "---\nname: My Skill\nversion: 1.0.0\ndescription: A test\n---\nBody";
+      "---\nname: My Skill\nversion: 1.0.0\ndescription: A test\ntags: [CLI, testing]\n---\nBody";
     await writeFile(join(skillDir, "SKILL.md"), skillMdContent);
 
     const config = {
@@ -468,6 +468,7 @@ describe("scanAllSkills", () => {
     expect(found!.version).toBe("1.0.0");
     expect(found!.scope).toBe("global");
     expect(found!.provider).toBe("test");
+    expect(found!.tags).toEqual(["cli", "testing"]);
     expect(found!.isSymlink).toBe(false);
     expect(found!._skillMdContent).toBe(skillMdContent);
     expect(JSON.stringify(found)).not.toContain("_skillMdContent");
@@ -1149,6 +1150,7 @@ describe("scanPluginMarketplaces", () => {
         "compatibility: Claude 3+",
         "effort: medium",
         "allowed-tools: Bash, Read",
+        "tags: Frontend, accessibility, frontend",
         "disable-model-invocation: true",
         "user-invocable: true",
         "---",
@@ -1167,6 +1169,7 @@ describe("scanPluginMarketplaces", () => {
     expect(s.effort).toBe("medium");
     expect(s.allowedTools).toContain("Bash");
     expect(s.allowedTools).toContain("Read");
+    expect(s.tags).toEqual(["frontend", "accessibility"]);
     expect(s.modelInvocable).toBe(false);
     expect(s.userInvocable).toBe(true);
   });

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -14,6 +14,7 @@ import {
   resolveAllowedTools,
   resolveModelInvocable,
   resolveUserInvocable,
+  resolveTags,
 } from "./utils/frontmatter";
 import { estimateTokenCount } from "./utils/token-count";
 import { resolveProviderPath } from "./config";
@@ -256,10 +257,7 @@ export async function countFiles(dir: string): Promise<number> {
  * the non-enumerable definition here is what keeps `_skillMdContent` out
  * of serialized reports, so writers must go through this helper.
  */
-export function cacheSkillMdContent(
-  skill: SkillInfo,
-  content: string,
-): void {
+export function cacheSkillMdContent(skill: SkillInfo, content: string): void {
   Object.defineProperty(skill, "_skillMdContent", {
     value: content,
     writable: true,
@@ -335,6 +333,7 @@ async function scanDirectory(
         license: (fm.license || "").trim(),
         compatibility: (fm.compatibility || "").trim(),
         allowedTools: resolveAllowedTools(fm),
+        tags: resolveTags(fm),
         modelInvocable: resolveModelInvocable(fm),
         userInvocable: resolveUserInvocable(fm),
         effort: fm.effort || fm["metadata.effort"] || undefined,
@@ -477,6 +476,7 @@ export async function scanPluginMarketplaces(
         license: (fm.license || "").trim(),
         compatibility: (fm.compatibility || "").trim(),
         allowedTools: resolveAllowedTools(fm),
+        tags: resolveTags(fm),
         modelInvocable: resolveModelInvocable(fm),
         userInvocable: resolveUserInvocable(fm),
         effort: fm.effort || fm["metadata.effort"] || undefined,

--- a/src/skill-index.test.ts
+++ b/src/skill-index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { readdir } from "fs/promises";
+import { mkdir, readdir, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import {
   searchSkills,
@@ -237,6 +237,63 @@ describe("getMissingMetadataFields", () => {
     expect(missing).toContain("version");
     expect(missing).not.toContain("license");
     expect(missing).not.toContain("creator");
+  });
+});
+
+describe("searchSkills with tag filters", () => {
+  const fixturePath = join(getIndexDir(), "issue-584_tag-fixture.json");
+
+  beforeEach(async () => {
+    await mkdir(getIndexDir(), { recursive: true });
+    await writeFile(
+      fixturePath,
+      JSON.stringify({
+        repoUrl: "https://github.com/issue-584/tag-fixture",
+        owner: "issue-584",
+        repo: "tag-fixture",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        skillCount: 3,
+        skills: [
+          { ...fixtureSkill("tagged-cli", "cli"), tags: ["CLI", "Testing"] },
+          { ...fixtureSkill("tagged-web", "web"), tags: ["frontend"] },
+          fixtureSkill("legacy-untagged", "legacy"),
+        ],
+      }),
+      "utf-8",
+    );
+    _resetMemo();
+  });
+
+  afterEach(async () => {
+    await rm(fixturePath, { force: true });
+    _resetMemo();
+  });
+
+  it("normalizes loaded tags and backfills legacy records", async () => {
+    const fixture = (await loadAllIndices()).find(
+      (index) => index.owner === "issue-584",
+    );
+    expect(fixture?.skills.map((skill) => skill.tags)).toEqual([
+      ["cli", "testing"],
+      ["frontend"],
+      [],
+    ]);
+  });
+
+  it("uses AND semantics for one or more tag filters", async () => {
+    expect(
+      (await searchSkills("tagged", 20, { tags: ["CLI"] })).map(
+        (result) => result.skill.name,
+      ),
+    ).toEqual(["tagged-cli"]);
+    expect(
+      (await searchSkills("tagged", 20, { tags: ["cli", "testing"] })).map(
+        (result) => result.skill.name,
+      ),
+    ).toEqual(["tagged-cli"]);
+    expect(
+      await searchSkills("tagged", 20, { tags: ["cli", "frontend"] }),
+    ).toEqual([]);
   });
 });
 

--- a/src/skill-index.ts
+++ b/src/skill-index.ts
@@ -2,7 +2,7 @@ import { readdir, readFile } from "fs/promises";
 import { join } from "path";
 import { getIndexDir, getBundledIndexDir } from "./config";
 import type { RepoIndex, IndexedSkill } from "./utils/types";
-import { matchesInvocabilityFilters } from "./utils/frontmatter";
+import { matchesInvocabilityFilters, normalizeTags } from "./utils/frontmatter";
 
 // ─── Memoization (issue #461) ──────────────────────────────────────────────
 
@@ -102,6 +102,11 @@ async function loadIndicesFromDir(
         if (!("allowedTools" in s) || s.allowedTools === undefined)
           s.allowedTools = [];
         if (!("verified" in s) || s.verified === undefined) s.verified = false;
+        s.tags = Array.isArray(s.tags)
+          ? normalizeTags(
+              s.tags.filter((tag): tag is string => typeof tag === "string"),
+            )
+          : [];
       }
       indices.set(`${index.owner}/${index.repo}`, index);
     } catch {
@@ -199,6 +204,7 @@ export interface SearchFilters {
   missing?: string[];
   modelInvocable?: boolean;
   userInvocable?: boolean;
+  tags?: string[];
 }
 
 const FILTERABLE_FIELDS = ["license", "creator", "version"] as const;
@@ -227,6 +233,12 @@ function matchesFilters(skill: IndexedSkill, filters: SearchFilters): boolean {
     for (const field of filters.missing) {
       if (!isFilterableField(field)) continue;
       if (getFilterableValue(skill, field)) return false;
+    }
+  }
+  if (filters.tags && filters.tags.length > 0) {
+    const skillTags = new Set(normalizeTags(skill.tags || []));
+    if (!normalizeTags(filters.tags).every((tag) => skillTags.has(tag))) {
+      return false;
     }
   }
   return true;

--- a/src/skill-index.ts
+++ b/src/skill-index.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { getIndexDir, getBundledIndexDir } from "./config";
 import type { RepoIndex, IndexedSkill } from "./utils/types";
 import { matchesInvocabilityFilters, normalizeTags } from "./utils/frontmatter";
+import { matchesAllTags } from "./skill-tags";
 
 // ─── Memoization (issue #461) ──────────────────────────────────────────────
 
@@ -236,8 +237,8 @@ function matchesFilters(skill: IndexedSkill, filters: SearchFilters): boolean {
     }
   }
   if (filters.tags && filters.tags.length > 0) {
-    const skillTags = new Set(normalizeTags(skill.tags || []));
-    if (!normalizeTags(filters.tags).every((tag) => skillTags.has(tag))) {
+    const requested = normalizeTags(filters.tags);
+    if (requested.length === 0 || !matchesAllTags(skill.tags, requested)) {
       return false;
     }
   }

--- a/src/skill-tags.test.ts
+++ b/src/skill-tags.test.ts
@@ -8,6 +8,8 @@ import {
   effectiveSkillTags,
   emptySkillTagState,
   loadSkillTagState,
+  matchesAllTags,
+  parseTagInputs,
   removeSkillTags,
   saveSkillTagState,
 } from "./skill-tags";
@@ -35,6 +37,24 @@ function skill(realPath: string, tags: string[] = []): SkillInfo {
     realPath,
   };
 }
+
+describe("skill tag parsing and filtering", () => {
+  it("accepts repeatable and comma-separated tag values", () => {
+    expect(parseTagInputs(["CLI,testing", "frontend"])).toEqual({
+      tags: ["cli", "testing", "frontend"],
+      invalid: [],
+    });
+  });
+
+  it("reports empty and malformed tag values", () => {
+    expect(parseTagInputs(["cli,,bad tag"]).invalid).toEqual(["", "bad tag"]);
+  });
+
+  it("matches multiple tags with AND semantics", () => {
+    expect(matchesAllTags(["CLI", "testing"], ["cli", "TESTING"])).toBe(true);
+    expect(matchesAllTags(["cli"], ["cli", "testing"])).toBe(false);
+  });
+});
 
 describe("skill tag overlay edits", () => {
   it("merges normalized additions with authoritative frontmatter tags", () => {

--- a/src/skill-tags.test.ts
+++ b/src/skill-tags.test.ts
@@ -1,0 +1,151 @@
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  addSkillTags,
+  applySkillTagState,
+  effectiveSkillTags,
+  emptySkillTagState,
+  loadSkillTagState,
+  removeSkillTags,
+  saveSkillTagState,
+} from "./skill-tags";
+import type { SkillInfo } from "./utils/types";
+
+function skill(realPath: string, tags: string[] = []): SkillInfo {
+  return {
+    name: "example",
+    version: "1.0.0",
+    description: "",
+    creator: "",
+    license: "",
+    compatibility: "",
+    allowedTools: [],
+    tags,
+    dirName: "example",
+    path: realPath,
+    originalPath: realPath,
+    location: "global-claude",
+    scope: "global",
+    provider: "claude",
+    providerLabel: "Claude Code",
+    isSymlink: false,
+    symlinkTarget: null,
+    realPath,
+  };
+}
+
+describe("skill tag overlay edits", () => {
+  it("merges normalized additions with authoritative frontmatter tags", () => {
+    const state = emptySkillTagState();
+    expect(
+      addSkillTags(state, "/skills/example", ["CLI"], ["Testing", "cli"]),
+    ).toEqual(["cli", "testing"]);
+    expect(state.skills["/skills/example"]).toEqual({
+      added: ["testing"],
+      removed: [],
+    });
+  });
+
+  it("removes frontmatter tags with tombstones and restores them on add", () => {
+    const state = emptySkillTagState();
+    expect(
+      removeSkillTags(state, "/skills/example", ["cli", "testing"], ["CLI"]),
+    ).toEqual(["testing"]);
+    expect(state.skills["/skills/example"].removed).toEqual(["cli"]);
+
+    expect(
+      addSkillTags(state, "/skills/example", ["cli", "testing"], ["cli"]),
+    ).toEqual(["cli", "testing"]);
+    expect(state.skills).toEqual({});
+  });
+
+  it("removes local additions and prunes empty entries", () => {
+    const state = emptySkillTagState();
+    addSkillTags(state, "/skills/example", [], ["frontend"]);
+    expect(removeSkillTags(state, "/skills/example", [], ["frontend"])).toEqual(
+      [],
+    );
+    expect(state.skills).toEqual({});
+  });
+
+  it("applies independent overlays to canonical skill identities", () => {
+    const first = skill("/skills/one", ["cli"]);
+    const second = skill("/skills/two", ["cli"]);
+    const state = emptySkillTagState();
+    addSkillTags(state, first.realPath, first.tags, ["testing"]);
+    removeSkillTags(state, second.realPath, second.tags, ["cli"]);
+
+    applySkillTagState([first, second], state);
+    expect(first.tags).toEqual(["cli", "testing"]);
+    expect(second.tags).toEqual([]);
+  });
+
+  it("treats missing overlays as normalized frontmatter-only tags", () => {
+    expect(effectiveSkillTags(["CLI", "cli"], undefined)).toEqual(["cli"]);
+  });
+});
+
+describe("skill tag state persistence", () => {
+  let dir: string;
+  let statePath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "asm-skill-tags-"));
+    statePath = join(dir, "skill-tags.json");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns empty state for a missing file", async () => {
+    await expect(loadSkillTagState(statePath)).resolves.toEqual({
+      version: 1,
+      skills: {},
+    });
+  });
+
+  it("persists edits across loads", async () => {
+    const state = emptySkillTagState();
+    addSkillTags(state, "/skills/example", ["cli"], ["testing"]);
+    removeSkillTags(state, "/skills/example", ["cli"], ["cli"]);
+    await saveSkillTagState(state, statePath);
+
+    const loaded = await loadSkillTagState(statePath);
+    expect(loaded).toEqual(state);
+    expect(await readFile(statePath, "utf-8")).toMatch(/"testing"/);
+  });
+
+  it("normalizes valid entries while loading", async () => {
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        skills: {
+          "/skills/example": {
+            added: ["CLI", "cli", 7],
+            removed: ["Testing", null],
+          },
+          empty: { added: [], removed: [] },
+        },
+      }),
+    );
+    await expect(loadSkillTagState(statePath)).resolves.toEqual({
+      version: 1,
+      skills: {
+        "/skills/example": { added: ["cli"], removed: ["testing"] },
+      },
+    });
+  });
+
+  it("backs up malformed state and starts empty", async () => {
+    await writeFile(statePath, "{not-json", "utf-8");
+    await expect(loadSkillTagState(statePath)).resolves.toEqual({
+      version: 1,
+      skills: {},
+    });
+    await expect(access(`${statePath}.bak`)).resolves.toBeUndefined();
+  });
+});

--- a/src/skill-tags.ts
+++ b/src/skill-tags.ts
@@ -2,7 +2,7 @@ import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { getSkillTagsPath } from "./config";
 import { debug } from "./logger";
-import { normalizeTags } from "./utils/frontmatter";
+import { normalizeTag, normalizeTags } from "./utils/frontmatter";
 import type { SkillInfo, SkillTagStateFile } from "./utils/types";
 
 export function emptySkillTagState(): SkillTagStateFile {
@@ -87,6 +87,23 @@ export async function saveSkillTagState(
 
 export function skillTagKey(skill: Pick<SkillInfo, "realPath">): string {
   return skill.realPath;
+}
+
+export function parseTagInputs(inputs: string[]): {
+  tags: string[];
+  invalid: string[];
+} {
+  const values = inputs.flatMap((input) => input.split(","));
+  const invalid = values.filter((value) => normalizeTag(value) === null);
+  return { tags: normalizeTags(values), invalid };
+}
+
+export function matchesAllTags(
+  skillTags: string[] | undefined,
+  requestedTags: string[],
+): boolean {
+  const available = new Set(normalizeTags(skillTags || []));
+  return normalizeTags(requestedTags).every((tag) => available.has(tag));
 }
 
 export function effectiveSkillTags(

--- a/src/skill-tags.ts
+++ b/src/skill-tags.ts
@@ -1,0 +1,166 @@
+import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { getSkillTagsPath } from "./config";
+import { debug } from "./logger";
+import { normalizeTags } from "./utils/frontmatter";
+import type { SkillInfo, SkillTagStateFile } from "./utils/types";
+
+export function emptySkillTagState(): SkillTagStateFile {
+  return { version: 1, skills: {} };
+}
+
+function normalizeEntry(value: unknown): {
+  added: string[];
+  removed: string[];
+} {
+  if (!value || typeof value !== "object") return { added: [], removed: [] };
+  const candidate = value as { added?: unknown; removed?: unknown };
+  const removed = normalizeTags(
+    Array.isArray(candidate.removed)
+      ? candidate.removed.filter(
+          (tag): tag is string => typeof tag === "string",
+        )
+      : [],
+  );
+  const removedSet = new Set(removed);
+  const added = normalizeTags(
+    Array.isArray(candidate.added)
+      ? candidate.added.filter((tag): tag is string => typeof tag === "string")
+      : [],
+  ).filter((tag) => !removedSet.has(tag));
+  return { added, removed };
+}
+
+/** Load local tag edits, recovering from malformed state like skill-state.ts. */
+export async function loadSkillTagState(
+  path?: string,
+): Promise<SkillTagStateFile> {
+  const statePath = path ?? getSkillTagsPath();
+  let raw: string;
+  try {
+    raw = await readFile(statePath, "utf-8");
+  } catch (error: any) {
+    if (error?.code === "ENOENT") return emptySkillTagState();
+    throw error;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as { version?: unknown; skills?: unknown };
+    if (
+      !parsed ||
+      parsed.version !== 1 ||
+      !parsed.skills ||
+      typeof parsed.skills !== "object" ||
+      Array.isArray(parsed.skills)
+    ) {
+      throw new Error("invalid schema");
+    }
+
+    const state = emptySkillTagState();
+    for (const [key, value] of Object.entries(parsed.skills)) {
+      const entry = normalizeEntry(value);
+      if (entry.added.length > 0 || entry.removed.length > 0) {
+        state.skills[key] = entry;
+      }
+    }
+    return state;
+  } catch {
+    const backupPath = `${statePath}.bak`;
+    debug(`skill-tags: parse error, backing up to ${backupPath}`);
+    try {
+      await copyFile(statePath, backupPath);
+    } catch {
+      // Best-effort backup; an unreadable state file must not break listing.
+    }
+    return emptySkillTagState();
+  }
+}
+
+export async function saveSkillTagState(
+  state: SkillTagStateFile,
+  path?: string,
+): Promise<void> {
+  const statePath = path ?? getSkillTagsPath();
+  await mkdir(dirname(statePath), { recursive: true });
+  await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
+}
+
+export function skillTagKey(skill: Pick<SkillInfo, "realPath">): string {
+  return skill.realPath;
+}
+
+export function effectiveSkillTags(
+  frontmatterTags: string[] | undefined,
+  entry?: { added: string[]; removed: string[] },
+): string[] {
+  const removed = new Set(normalizeTags(entry?.removed || []));
+  return normalizeTags([
+    ...normalizeTags(frontmatterTags || []).filter((tag) => !removed.has(tag)),
+    ...normalizeTags(entry?.added || []).filter((tag) => !removed.has(tag)),
+  ]);
+}
+
+export function applySkillTagState(
+  skills: SkillInfo[],
+  state: SkillTagStateFile,
+): void {
+  for (const skill of skills) {
+    skill.tags = effectiveSkillTags(
+      skill.tags,
+      state.skills[skillTagKey(skill)],
+    );
+  }
+}
+
+function pruneEntry(state: SkillTagStateFile, key: string): void {
+  const entry = state.skills[key];
+  if (entry && entry.added.length === 0 && entry.removed.length === 0) {
+    delete state.skills[key];
+  }
+}
+
+/** Add normalized tags, clearing frontmatter-removal tombstones when needed. */
+export function addSkillTags(
+  state: SkillTagStateFile,
+  key: string,
+  frontmatterTags: string[] | undefined,
+  tags: string[],
+): string[] {
+  const base = new Set(normalizeTags(frontmatterTags || []));
+  const entry = (state.skills[key] ??= { added: [], removed: [] });
+  const added = new Set(normalizeTags(entry.added));
+  const removed = new Set(normalizeTags(entry.removed));
+
+  for (const tag of normalizeTags(tags)) {
+    removed.delete(tag);
+    if (!base.has(tag)) added.add(tag);
+  }
+
+  entry.added = [...added];
+  entry.removed = [...removed];
+  pruneEntry(state, key);
+  return effectiveSkillTags(frontmatterTags, state.skills[key]);
+}
+
+/** Remove local additions or tombstone authoritative frontmatter tags. */
+export function removeSkillTags(
+  state: SkillTagStateFile,
+  key: string,
+  frontmatterTags: string[] | undefined,
+  tags: string[],
+): string[] {
+  const base = new Set(normalizeTags(frontmatterTags || []));
+  const entry = (state.skills[key] ??= { added: [], removed: [] });
+  const added = new Set(normalizeTags(entry.added));
+  const removed = new Set(normalizeTags(entry.removed));
+
+  for (const tag of normalizeTags(tags)) {
+    added.delete(tag);
+    if (base.has(tag)) removed.add(tag);
+  }
+
+  entry.added = [...added];
+  entry.removed = [...removed];
+  pruneEntry(state, key);
+  return effectiveSkillTags(frontmatterTags, state.skills[key]);
+}

--- a/src/utils/frontmatter.test.ts
+++ b/src/utils/frontmatter.test.ts
@@ -3,11 +3,44 @@ import {
   parseFrontmatter,
   resolveVersion,
   resolveAllowedTools,
+  resolveTags,
+  normalizeTag,
+  normalizeTags,
   resolveModelInvocable,
   resolveUserInvocable,
   formatInvocability,
   matchesInvocabilityFilters,
 } from "./frontmatter";
+
+describe("tag normalization", () => {
+  it("parses comma-separated, whitespace-separated, and inline-array tags", () => {
+    expect(resolveTags({ tags: "CLI, Testing cli" })).toEqual([
+      "cli",
+      "testing",
+    ]);
+    expect(resolveTags({ tags: "['frontend', \"accessibility\"]" })).toEqual([
+      "frontend",
+      "accessibility",
+    ]);
+  });
+
+  it("normalizes valid tags and rejects invalid values", () => {
+    expect(normalizeTag(" TypeScript ")).toBe("typescript");
+    expect(normalizeTag("c")).toBe("c");
+    expect(normalizeTag("bad tag")).toBeNull();
+    expect(normalizeTag("!bad")).toBeNull();
+    expect(normalizeTag("x".repeat(33))).toBeNull();
+    expect(normalizeTags(["CLI", "cli", "test_tools", ""])).toEqual([
+      "cli",
+      "test_tools",
+    ]);
+  });
+
+  it("returns an empty list when tags are missing or invalid", () => {
+    expect(resolveTags({})).toEqual([]);
+    expect(resolveTags({ tags: "[!, @]" })).toEqual([]);
+  });
+});
 
 describe("parseFrontmatter", () => {
   it("parses simple key-value pairs", () => {

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -124,6 +124,42 @@ export function resolveAllowedTools(fm: Record<string, string>): string[] {
     .filter(Boolean);
 }
 
+export function resolveTags(fm: Record<string, string>): string[] {
+  const raw = (fm.tags || "").trim();
+  if (!raw) return [];
+
+  // Support both `tags: cli, testing` and the common inline YAML array form
+  // `tags: [cli, testing]`. The frontmatter reader intentionally returns
+  // strings, so normalize the lightweight array syntax here.
+  const value =
+    raw.startsWith("[") && raw.endsWith("]") ? raw.slice(1, -1) : raw;
+  return normalizeTags(
+    value.split(/[\s,]+/).map((tag) => tag.replace(/^['"]|['"]$/g, "")),
+  );
+}
+
+const TAG_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+export function normalizeTag(tag: string): string | null {
+  const normalized = tag.trim().toLowerCase();
+  if (!normalized || normalized.length > 32) return null;
+  if (!TAG_RE.test(normalized)) return null;
+  return normalized;
+}
+
+export function normalizeTags(tags: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of tags) {
+    const n = normalizeTag(raw);
+    if (n && !seen.has(n)) {
+      seen.add(n);
+      out.push(n);
+    }
+  }
+  return out;
+}
+
 function normalizeFmBool(value: string | undefined): string {
   return (value || "").trim().toLowerCase();
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -13,6 +13,8 @@ export interface SkillInfo {
   license: string;
   compatibility: string;
   allowedTools: string[];
+  /** Free-form tags assigned to the skill. */
+  tags?: string[];
   /** Agent Skills model invocation. Default true when omitted. */
   modelInvocable?: boolean;
   /** Agent Skills user/slash invocation. Default true when omitted. */
@@ -600,6 +602,7 @@ export interface DiscoveredSkill {
   creator: string;
   compatibility: string;
   allowedTools: string[];
+  tags?: string[];
   modelInvocable?: boolean;
   userInvocable?: boolean;
   /**
@@ -635,6 +638,7 @@ export interface IndexedSkill {
   creator: string;
   compatibility: string;
   allowedTools: string[];
+  tags?: string[];
   modelInvocable?: boolean;
   userInvocable?: boolean;
   installUrl: string;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -86,6 +86,20 @@ export interface SkillStateFile {
   >;
 }
 
+/** Local tag edits keyed by the skill's canonical on-disk directory. */
+export interface SkillTagStateFile {
+  version: 1;
+  skills: Record<
+    string,
+    {
+      /** Tags added locally beyond authoritative SKILL.md frontmatter. */
+      added: string[];
+      /** Frontmatter tags hidden locally without mutating SKILL.md. */
+      removed: string[];
+    }
+  >;
+}
+
 /**
  * Slim, JSON-friendly snapshot of an `asm eval` report for the
  * "before-install" decision surfaces (website cards/modal, TUI detail,

--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -57,6 +57,7 @@ const catalog = {
       license: "MIT",
       version: "1.0.0",
       verified: true,
+      tags: ["cli", "testing"],
       hasTools: false,
       tokenCount: 300,
     },
@@ -72,6 +73,7 @@ const catalog = {
       license: "MIT",
       version: "0.1.0",
       verified: false,
+      tags: ["docs"],
       hasTools: false,
       tokenCount: 500,
     },
@@ -108,6 +110,7 @@ const SKILL_DETAIL = {
   version: "1.0.0",
   verified: true,
   allowedTools: [],
+  tags: ["cli", "testing"],
   tokenCount: 300,
   skillUrl: "https://github.com/owner/repo/blob/main/SKILL.md",
 };
@@ -187,6 +190,31 @@ describe("App smoke", () => {
     expect(screen.getByText(/Select a skill/i)).toBeTruthy();
   });
 
+  it("filters by multiple tags with URL-persisted AND semantics", async () => {
+    window.history.replaceState(null, "", "/#/skills");
+    render(
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </HashRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("hello-world")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "cli" }));
+    expect(screen.getByText("hello-world")).toBeTruthy();
+    expect(screen.queryByText("readme-generator")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "testing" }));
+    await waitFor(() => {
+      const query = window.location.hash.split("?")[1] || "";
+      expect(new URLSearchParams(query).get("tag")).toBe("cli,testing");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "docs" }));
+    expect(screen.getByText("No skills match your filters")).toBeTruthy();
+  });
+
   it("parses the search index once and preserves search results", async () => {
     window.history.replaceState(null, "", "/#/skills");
     const indexText = buildIndexJson();
@@ -255,9 +283,7 @@ describe("App smoke", () => {
     await waitFor(() => {
       expect(screen.getByText("Catalog failed to load")).toBeTruthy();
       expect(
-        screen.getByText(
-          /Catalog and search index are from different builds/i,
-        ),
+        screen.getByText(/Catalog and search index are from different builds/i),
       ).toBeTruthy();
     });
   });

--- a/website-src/src/__tests__/filter-sort.test.js
+++ b/website-src/src/__tests__/filter-sort.test.js
@@ -5,7 +5,7 @@ import {
   buildNameCollisionKeys,
   defaultSort,
 } from "../lib/filter-sort.js";
-import { emptyFacetState } from "../lib/facets.js";
+import { computeFacetCounts, emptyFacetState } from "../lib/facets.js";
 
 const mk = (p) => ({
   id: p.id,
@@ -21,6 +21,7 @@ const mk = (p) => ({
   evalSummary: p.evalSummary,
   featured: !!p.featured,
   allowedTools: p.allowedTools,
+  tags: p.tags,
 });
 
 const base = () => ({
@@ -111,6 +112,27 @@ describe("applyFilters", () => {
     expect(applyFilters(skills, state).map((s) => s.id)).toEqual(["y"]);
   });
 
+  it("filters by one or more tags with AND semantics", () => {
+    const skills = [
+      mk({ id: "both", tags: ["cli", "testing"] }),
+      mk({ id: "cli", tags: ["cli"] }),
+      mk({ id: "legacy" }),
+    ];
+    const oneTag = base();
+    oneTag.activeFacets.tags.add("cli");
+    expect(applyFilters(skills, oneTag).map((skill) => skill.id)).toEqual([
+      "both",
+      "cli",
+    ]);
+
+    const twoTags = base();
+    twoTags.activeFacets.tags.add("CLI");
+    twoTags.activeFacets.tags.add("testing");
+    expect(applyFilters(skills, twoTags).map((skill) => skill.id)).toEqual([
+      "both",
+    ]);
+  });
+
   it("sort: grade — best grade first, tiebreak by score desc then name", () => {
     const skills = [
       mk({ id: "b", name: "b", evalSummary: { grade: "B", overallScore: 81 } }),
@@ -147,6 +169,17 @@ describe("applyFilters", () => {
     ]);
     const out = applyFilters(skills, state, { scoreById });
     expect(out.map((s) => s.id)).toEqual(["gamma", "beta"]);
+  });
+});
+
+describe("computeFacetCounts", () => {
+  it("counts normalized tags once per skill and tolerates missing tags", () => {
+    const counts = computeFacetCounts([
+      mk({ id: "one", tags: ["CLI", "cli", "testing"] }),
+      mk({ id: "two", tags: ["cli"] }),
+      mk({ id: "legacy" }),
+    ]);
+    expect(counts.tags).toEqual({ cli: 2, testing: 1 });
   });
 });
 

--- a/website-src/src/components/TagFilter.jsx
+++ b/website-src/src/components/TagFilter.jsx
@@ -1,0 +1,91 @@
+import { useMemo, useState } from "react";
+
+const MAX_VISIBLE_TAGS = 20;
+
+/** Searchable, keyboard-accessible AND-filter for catalog skill tags. */
+export default function TagFilter({ counts, activeTags, onChange }) {
+  const [query, setQuery] = useState("");
+
+  const tags = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    const ordered = Object.entries(counts || {})
+      .filter(([, count]) => count > 0)
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+    const matching = normalizedQuery
+      ? ordered.filter(([tag]) => tag.includes(normalizedQuery))
+      : ordered;
+    const active = ordered.filter(([tag]) => activeTags.has(tag));
+    const inactive = matching.filter(([tag]) => !activeTags.has(tag));
+    return [...active, ...inactive].slice(0, MAX_VISIBLE_TAGS);
+  }, [activeTags, counts, query]);
+
+  if (Object.keys(counts || {}).length === 0) return null;
+
+  return (
+    <div
+      className="flex flex-col gap-1.5 border border-[var(--border)] rounded-md px-2 py-1.5"
+      role="group"
+      aria-label="Filter by tags"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <label
+          htmlFor="catalog-tag-filter"
+          className="text-xs font-medium text-[var(--fg-dim)]"
+        >
+          Tags
+          {activeTags.size > 0 && (
+            <span className="ml-1.5 text-[10px] text-[var(--brand)]">
+              {activeTags.size} selected
+            </span>
+          )}
+        </label>
+        <input
+          id="catalog-tag-filter"
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Find tags…"
+          className="w-28 px-2 py-1 rounded border border-[var(--border)] bg-[var(--bg-input)] text-[var(--fg)] text-[11px]"
+        />
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {tags.map(([tag, count]) => {
+          const selected = activeTags.has(tag);
+          return (
+            <button
+              key={tag}
+              type="button"
+              aria-pressed={selected}
+              onClick={() => {
+                const next = new Set(activeTags);
+                if (selected) next.delete(tag);
+                else next.add(tag);
+                onChange(next);
+              }}
+              className={
+                "inline-flex items-center gap-1 px-2 py-0.5 text-[11px] rounded border transition-colors " +
+                (selected
+                  ? "border-[var(--brand)] text-[var(--brand)] bg-[color-mix(in_srgb,var(--brand)_12%,transparent)]"
+                  : "border-[var(--border)] text-[var(--fg-dim)] hover:text-[var(--fg)] hover:border-[var(--brand)]")
+              }
+            >
+              {tag}
+              <span
+                aria-hidden="true"
+                className="text-[10px] text-[var(--fg-muted)]"
+              >
+                {count}
+              </span>
+            </button>
+          );
+        })}
+        {tags.length === 0 && (
+          <span className="text-[11px] text-[var(--fg-muted)]">
+            No matching tags
+          </span>
+        )}
+      </div>
+      <span className="sr-only">Selected tags use AND matching.</span>
+    </div>
+  );
+}

--- a/website-src/src/hooks/useCatalogState.js
+++ b/website-src/src/hooks/useCatalogState.js
@@ -4,7 +4,14 @@ import { csvToSet, setToCsv } from "../lib/utils.js";
 import { emptyFacetState } from "../lib/facets.js";
 import { defaultSort } from "../lib/filter-sort.js";
 
-const FACET_KEYS = ["license", "grade", "source", "usesTools", "author"];
+const FACET_KEYS = [
+  "license",
+  "grade",
+  "source",
+  "usesTools",
+  "author",
+  "tags",
+];
 
 /**
  * React Router's `useSearchParams` keeps the URL query string in sync with
@@ -33,6 +40,9 @@ export function useCatalogState() {
     facets.source = csvToSet(params.get("source"));
     facets.usesTools = csvToSet(params.get("tools"));
     facets.author = csvToSet(params.get("author"));
+    facets.tags = new Set(
+      [...csvToSet(params.get("tag"))].map((tag) => tag.toLowerCase()),
+    );
     // Backwards-compat: migrate old `?verified=1` into source facet.
     if (params.get("verified") === "1") facets.source.add("verified");
     return {
@@ -99,7 +109,8 @@ export function useCatalogState() {
   const setFacet = useCallback(
     (key, values) => {
       if (!FACET_KEYS.includes(key)) return;
-      const paramKey = key === "usesTools" ? "tools" : key;
+      const paramKey =
+        key === "usesTools" ? "tools" : key === "tags" ? "tag" : key;
       update((next) => {
         if (values.size > 0) next.set(paramKey, setToCsv(values));
         else next.delete(paramKey);

--- a/website-src/src/lib/facets.js
+++ b/website-src/src/lib/facets.js
@@ -46,6 +46,7 @@ export function emptyFacetState() {
     source: new Set(),
     usesTools: new Set(),
     author: new Set(),
+    tags: new Set(),
   };
 }
 
@@ -56,6 +57,7 @@ export function computeFacetCounts(skills) {
     source: {},
     usesTools: { yes: 0, no: 0 },
     author: {},
+    tags: {},
   };
   for (const s of skills) {
     const lb = licenseBucket(s.license);
@@ -72,6 +74,15 @@ export function computeFacetCounts(skills) {
     // Author facet — bucket by owner
     if (s.owner) {
       out.author[s.owner] = (out.author[s.owner] || 0) + 1;
+    }
+    const skillTags = new Set(
+      (Array.isArray(s.tags) ? s.tags : [])
+        .filter((tag) => typeof tag === "string")
+        .map((tag) => tag.trim().toLowerCase())
+        .filter(Boolean),
+    );
+    for (const tag of skillTags) {
+      out.tags[tag] = (out.tags[tag] || 0) + 1;
     }
   }
   return out;

--- a/website-src/src/lib/filter-sort.js
+++ b/website-src/src/lib/filter-sort.js
@@ -63,6 +63,18 @@ export function applyFilters(skills, state, options = {}) {
       (s) => s.owner && state.activeFacets.author.has(s.owner),
     );
   }
+  if (state.activeFacets.tags?.size > 0) {
+    results = results.filter((s) => {
+      const skillTags = new Set(
+        (Array.isArray(s.tags) ? s.tags : []).map((tag) =>
+          String(tag).toLowerCase(),
+        ),
+      );
+      return [...state.activeFacets.tags].every((tag) =>
+        skillTags.has(String(tag).toLowerCase()),
+      );
+    });
+  }
 
   // Featured skills pin to the top of every sort mode (including search
   // relevance). Returns -1/1 when featured differs, 0 otherwise so callers
@@ -164,9 +176,8 @@ export function anyFilterActive(state) {
   }
   // Check sort state — when sort differs from the search-aware default,
   // the "Clear all" button should appear (issue #526).
-  const expectedDefault = state.searchQuery && state.searchQuery.trim()
-    ? "relevance"
-    : "name";
+  const expectedDefault =
+    state.searchQuery && state.searchQuery.trim() ? "relevance" : "name";
   if (state.sort && state.sort !== expectedDefault) return true;
   return false;
 }

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -15,6 +15,7 @@ import { decodeSkillId } from "../lib/utils.js";
 import SearchBox from "../components/SearchBox.jsx";
 import CategoryTabs from "../components/CategoryTabs.jsx";
 import FacetRow from "../components/FacetRow.jsx";
+import TagFilter from "../components/TagFilter.jsx";
 import SkillListItem from "../components/SkillListItem.jsx";
 import SkillDetail from "../components/SkillDetail.jsx";
 import SidebarDrawer from "../components/SidebarDrawer.jsx";
@@ -97,7 +98,11 @@ export default function CatalogPage() {
       const tag = (e.target && e.target.tagName) || "";
       // Ignore if focused in an input/textarea/contenteditable
       if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
-      if ((e.key === "/" || (e.key === "k" && (e.metaKey || e.ctrlKey))) && !e.altKey && !e.shiftKey) {
+      if (
+        (e.key === "/" || (e.key === "k" && (e.metaKey || e.ctrlKey))) &&
+        !e.altKey &&
+        !e.shiftKey
+      ) {
         e.preventDefault();
         searchBoxRef.current?.focus();
       }
@@ -259,11 +264,18 @@ export default function CatalogPage() {
         onChange={setActiveCategories}
       />
       {facetCounts && (
-        <FacetRow
-          counts={facetCounts}
-          activeFacets={state.activeFacets}
-          onToggle={setFacet}
-        />
+        <>
+          <FacetRow
+            counts={facetCounts}
+            activeFacets={state.activeFacets}
+            onToggle={setFacet}
+          />
+          <TagFilter
+            counts={facetCounts.tags}
+            activeTags={state.activeFacets.tags}
+            onChange={(tags) => setFacet("tags", tags)}
+          />
+        </>
       )}
       <div className="flex flex-wrap items-center gap-2">
         <select


### PR DESCRIPTION
Closes #584

## Summary

Skills can now carry tags, users can edit them locally, and both the CLI and the catalog website can filter by them. Frontmatter `tags:` stays the authoritative catalog metadata; a local overlay at `~/.config/agent-skill-manager/skill-tags.json` records per-install add/remove edits so no installed or shared `SKILL.md` is ever mutated.

## Approach

Option 2 — balanced hybrid. Frontmatter tags are parsed once in `src/utils/frontmatter.ts` and propagated through scanner/ingester/installer-core into `IndexedSkill`/`DiscoveredSkill`. A `src/skill-tags.ts` overlay (modelled on the existing `src/skill-state.ts` load/save/backup pattern) stores user edits as `{added, removed}` per skill path, merged at read time for CLI views and filtering. `scripts/build-catalog.ts` carries the frontmatter tags into the static website data, where a new `tags` facet filters with AND semantics.

## Decision Record

- **Root cause:** the index carried tag-like data only inside prose; there was no first-class tag field, no way to assign tags, and no filter surface on either the CLI or the website.
- **Options considered:** Option 1 — frontmatter-only (edits write into installed `SKILL.md`); Option 2 — frontmatter authoritative + local overlay for edits; Option 3 — Option 2 plus a TUI tag editor, migration tooling, and tag analytics.
- **Options rejected:** Option 1 — writing user tag edits directly into installed `SKILL.md` conflicts with the established `skill-state.ts` persistence pattern and breaks for shared/symlinked installs; Option 3 — exceeds the stated acceptance criteria and the issue's L effort estimate with TUI editing, migration, and analytics that were not requested.
- **Selected option:** Option 2 — Balanced approach, frontmatter-authoritative tags plus local overlay for edits.
- **Residual risk:** two tag sources are reconciled at read time (`effectiveSkillTags`), covered by dedicated unit tests in `src/skill-tags.test.ts`. The website filters catalog (frontmatter) tags only — the static build has no per-user overlay, which is expected rather than a gap.
- **Design-confirm:** confirmed Option 2 at design-confirm checkpoint (complexity: L, risk: Medium).

Analyzed at: `feat/584-add-tag-assignment-for-skills-and @ 66e1d5c` (2026-08-28)

## Changes

| File | Change |
|------|--------|
| `src/utils/frontmatter.ts` | `resolveTags` / `normalizeTag` / `normalizeTags` — parse, validate, lowercase, dedupe |
| `src/utils/types.ts` | optional `tags` on `SkillInfo`/`DiscoveredSkill`/`IndexedSkill`; `SkillTagStateFile` |
| `src/scanner.ts`, `src/ingester.ts`, `src/installer-core.ts` | carry frontmatter tags into discovered/ingested skills |
| `src/skill-index.ts` | backfill `tags` on index load; `SearchFilters.tags` AND-matching |
| `src/skill-tags.ts` | new local overlay: load/save with corrupt-file backup, add/remove, merge, `parseTagInputs`, `matchesAllTags` |
| `src/config.ts` | `getSkillTagsPath()` |
| `src/commands/tag.ts` | new `asm tag add\|remove <skill> <tag...>` |
| `src/commands/list.ts`, `src/commands/search.ts` | `--tag` filtering (repeatable and comma-separated), merged overlay tags, tags in `--json`/`--machine` output |
| `src/cli.ts` | `--tag` flag parsing, `tag` command routing, help text |
| `src/formatter-core.ts`, `src/formatter.ts` | `formatTagUpdates` — all tag output routed through the formatter |
| `scripts/build-catalog.ts` | `tags` on `CatalogSkill`, slim rows and skill detail; tags added to the MiniSearch text |
| `website-src/src/lib/facets.js` | `tags` facet state + per-tag counts |
| `website-src/src/lib/filter-sort.js` | AND-semantics tag predicate |
| `website-src/src/hooks/useCatalogState.js` | `tags` facet with URL persistence as `?tag=` |
| `website-src/src/components/TagFilter.jsx` | new searchable, keyboard-accessible tag filter |
| `website-src/src/pages/CatalogPage.jsx` | renders `TagFilter` alongside the existing facet row |

## Test Results

- Unit tests: 2573 passed (78 files, `CI=true npm test`)
- Integration tests: covered within the unit suite (`src/cli.test.ts` end-to-end CLI cases)
- E2e tests: skipped — `tests/e2e/` is not part of `npm test`
- Build: `npm run typecheck` and `npm run lint` both clean
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| A user can assign one or more tags to a skill, and the assignment persists across sessions / is part of the committed catalog metadata | pass | `asm tag add` writes `skill-tags.json` via `saveSkillTagState` (`src/skill-tags.ts`); frontmatter `tags:` is the committed catalog half. Tests: `src/skill-tags.test.ts`, `src/cli.test.ts` |
| Tags are editable: a user can add and remove tags from a skill after assignment | pass | `addSkillTags` / `removeSkillTags` (`src/skill-tags.ts`), surfaced as `asm tag add\|remove`; removal of a frontmatter tag is recorded as a tombstone. Tests: `src/skill-tags.test.ts` |
| The catalog website exposes a tag filter (single and/or multi-select) that narrows the visible skill list | pass | `TagFilter.jsx` + `tags` facet in `useCatalogState.js`, AND filtering in `filter-sort.js`, persisted as `?tag=`. Tests: `website-src/src/__tests__/filter-sort.test.js`, `app-smoke.test.jsx` (multi-tag AND + URL persistence) |
| The CLI `list` / `search` surface supports filtering by one or more tags | pass | `--tag` (repeatable, comma-separated) on `asm list` and `asm search`, covering installed skills and the index via `SearchFilters.tags`. Tests: `src/cli.test.ts`, `src/skill-index.test.ts` |

<!-- gitissue:qa v1 head=7d7bb660dfc6f7124a0530bb53e1a10fe1efd11f profile=full cycles=1 review=clean tests=2573@7d7bb660dfc6f7124a0530bb53e1a10fe1efd11f ui=code:clean@7d7bb660dfc6f7124a0530bb53e1a10fe1efd11f -->
