### PR TITLE
feat(skills): add skill-shortener for progressive-disclosure shrinking

### DIFF
--- a/skills/skill-shortener/SKILL.md
+++ b/skills/skill-shortener/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: skill-shortener
+description: "Refactor a too-long SKILL.md by progressive disclosure: measure token cost, classify every section KEEP/CUT/MOVE, shorten the body into references/ and scripts/, verify nothing was lost. Don't use for authoring new skills, eval retrofits, or prose."
+license: MIT
+compatibility: "Claude Code; Python 3; skill-creator's quick_validate.py"
+allowed-tools: Bash Read Write Edit Grep Glob
+effort: high
+metadata:
+  version: 1.0.0
+  author: luongnv89
+---
+
+# Skill Shortener
+
+Shrink an over-long `SKILL.md` by **progressive disclosure**: what the agent needs on _every_ activation stays in the body, everything else moves behind a pointer that says when to load it — or is cut outright.
+
+Three load layers decide where a piece of content belongs:
+
+| Layer             | Holds                                | Costs            |
+| ----------------- | ------------------------------------ | ---------------- |
+| **always-loaded** | frontmatter `name` + `description`   | every turn       |
+| **on-trigger**    | the `SKILL.md` body                  | every activation |
+| **on-demand**     | `references/`, `scripts/`, `assets/` | only when read   |
+
+The bar is **behavior-preserving**: the shortened skill drives the same process as the long one. Line count is the score, not the goal — a run that reaches 400 lines by deleting a loop's stop condition has failed, however good the number looks.
+
+## Two modes
+
+Pick one before Phase 0; they diverge at Phase 2.
+
+- **Mode 1 — shorten (default).** Phases 0–4: measure, classify, plan, apply on approval, verify. Every "shorten this", "this SKILL.md is too long", "cut its token cost", "apply progressive disclosure" request is Mode 1.
+- **Mode 2 — audit only.** Phases 0–2, then stop and hand over the plan. Nothing outside the workdir is written, so the repo sync and snapshot in Phase 0 are skipped. Use when the user wants to know what _would_ move, or will apply the split themselves.
+
+## Run variables
+
+Every snippet below uses these four. **Bash tool calls do not share shell state**, so re-declare them at the top of each call that needs them — an empty `$SKILL_PATH` turns `cp -R "$SKILL_PATH/."` into a copy of the filesystem root. Capture `RUN_EPOCH` once and reuse the _number_; never re-stamp it.
+
+```bash
+SS="$HOME/.claude/skills/skill-shortener"                            # this skill
+SKILL_PATH="$HOME/.claude/skills/<target>"                           # the target: the dir holding SKILL.md
+QV="$HOME/.claude/skills/skill-creator/scripts/quick_validate.py"    # the Phase 4 gate
+# RUN_EPOCH: reuse the number the preflight printed, e.g. RUN_EPOCH=1787948450
+```
+
+## Dependency Preflight (mandatory)
+
+This skill invokes `skill-creator`: it runs that skill's `quick_validate.py` as the Phase 4 frontmatter gate. Resolve it **before the snapshot below**, the first step that changes anything:
+
+```bash
+RUN_EPOCH="$(date +%s)"; echo "run_started_epoch=$RUN_EPOCH" >&2   # anchors Run stats
+QV="$HOME/.claude/skills/skill-creator/scripts/quick_validate.py"
+test -f "$QV" || {
+  echo "Missing required skill: skill-creator" >&2
+  echo "Install it:      asm install skill-creator -p claude --yes" >&2
+  echo "No asm yet:      npm install -g agent-skill-manager" >&2
+  echo "Verify:          asm list -p claude --json | grep 'skill-creator'" >&2
+  exit 1
+}
+```
+
+`-p claude` is not decoration: `asm install` refuses to guess a provider non-interactively and `--yes` does not cover that choice, so an install command without it errors instead of installing. On a miss, stop before the first mutation and print those three commands — never continue with a partial run.
+
+## Snapshot and Repo Sync Before Edits (mandatory)
+
+**Always snapshot first.** The most common target — `~/.claude/skills/<name>/` — is _not_ a git repository, so git is not a guaranteed undo path, and this skill rewrites a whole directory rather than one file:
+
+```bash
+: "${SKILL_PATH:?set SKILL_PATH to the target skill directory}"
+: "${RUN_EPOCH:?reuse the epoch captured in the preflight}"
+case "$PWD/" in "$SKILL_PATH"/*) echo "cwd is inside $SKILL_PATH — run from outside it, or the workdir is copied into itself" >&2; exit 1;; esac
+SNAP=".skill-shortener/snapshot-$RUN_EPOCH"
+mkdir -p "$SNAP" && cp -R "$SKILL_PATH/." "$SNAP/"
+```
+
+Then sync **only if** the target is in a git repo:
+
+```bash
+if git -C "$SKILL_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+  branch="$(git -C "$SKILL_PATH" rev-parse --abbrev-ref HEAD)"
+  git -C "$SKILL_PATH" fetch origin && git -C "$SKILL_PATH" pull --rebase origin "$branch"
+else
+  echo "note: $SKILL_PATH is not in a git repo — $SNAP is the only undo path"
+fi
+```
+
+If the tree is dirty, `git stash`, sync, `git stash pop`. If `origin` is missing or the pull conflicts, **stop and ask the user** — never skip or force the sync. In a git repo, suggest adding `.skill-shortener/` to `.gitignore`.
+
+## The three dispositions
+
+Every section of the body gets exactly one, and each has one reference behind it. Read the reference for the disposition you are about to assign — not all three up front.
+
+| Disposition | Means                                                                | Read before assigning it                                       |
+| ----------- | -------------------------------------------------------------------- | -------------------------------------------------------------- |
+| **KEEP**    | needed on every activation; stays in the body                        | read `references/behavior-preservation.md` before assigning it |
+| **CUT**     | deleted; the model already knows it or it changes no behavior        | read `references/cut-list.md` before assigning it              |
+| **MOVE**    | relocated to `references/`, `scripts/`, or `assets/`, with a pointer | read `references/split-patterns.md` before assigning it        |
+
+## Workflow
+
+### Phase 0 — Baseline
+
+Run the preflight, take the snapshot, sync if applicable, then measure:
+
+```bash
+python3 "$SS/scripts/measure_skill.py" "$SKILL_PATH" --json --out .skill-shortener/baseline.json
+python3 "$SS/scripts/measure_skill.py" "$SKILL_PATH"   # the human-readable section table
+```
+
+The section table, largest first, is where the fat is — read it before reading the body.
+
+**Early exit.** If the verdict is `WITHIN_CAP`, stop: print the current footprint and say no shortening is warranted — splitting a body that already fits costs a pointer hop for no saving. The one exception is an existing `references/` tree that is chained or orphaned; see _Edge cases_. The user can override.
+
+**Done when:** `.skill-shortener/baseline.json` exists with a non-empty `sections` array, and the verdict is recorded.
+
+### Phase 1 — Classify every section (the manifest)
+
+Read the body, then assign every heading from `baseline.json` exactly one disposition. Write `.skill-shortener/manifest.json`:
+
+```json
+{
+  "target": "<skill-path>",
+  "sections": [
+    { "heading": "Overview", "disposition": "KEEP" },
+    {
+      "heading": "API error codes",
+      "disposition": "MOVE",
+      "destination": "references/<topic>.md",
+      "load_condition": "when the API returns a non-200"
+    },
+    {
+      "heading": "History",
+      "disposition": "CUT",
+      "reason": "changelog and attribution; changes no behavior"
+    }
+  ]
+}
+```
+
+`destination` may be a string or a list. `load_condition` is the clause that goes into the pointer, so write it as the agent will read it: "when X", "before Y", "if Z".
+
+The manifest **is** the loss-prevention record. Nothing is verified as preserved except through it, so an unclassified section is an unaudited deletion waiting to happen.
+
+**Done when:** every heading in `baseline.json` appears in the manifest exactly once; every `CUT` carries a `reason`; every `MOVE` carries a `destination` and a `load_condition`. `scripts/verify_shorten.py` checks all four in Phase 4 — do not defer them.
+
+### Phase 2 — Plan and approve
+
+Present the plan as a table — heading, disposition, destination, lines saved — plus the projected body size against both caps and the always-loaded/on-demand split. Name the biggest three savings first.
+
+**Expected output** — the plan, before any file is touched:
+
+```
+Plan for skill-x — 812 lines / 5,140 words → projected 190 lines / 1,480 words
+
+  heading                  disposition  destination                   lines
+  -----------------------  -----------  ----------------------------  -----
+  Azure deployment         MOVE         references/<branch>.md         -180
+  Error code reference     MOVE         references/<codes>.txt         -140
+  Release history          CUT          changelog; changes no behavior  -46
+  Workflow                 KEEP         -                                 0
+
+  always-loaded 64 tokens (unchanged) · on-trigger 12,900 → 3,700 · on-demand +9,100
+```
+
+**Mode 2 ends here.** In Mode 1, stop and wait for an explicit go-ahead. A split is a judgment call and the user is the one who has to live with the result.
+
+**Done when:** the user has approved the plan, or asked for changes that are folded back into the manifest.
+
+### Phase 3 — Apply
+
+1. Write each `MOVE` destination. The moved material must be **self-contained** — a reader arriving with only the pointer's context can act on it. Add a one-line contents map at the top of any reference over 300 lines.
+2. Rewrite the body: delete `CUT` sections, replace each `MOVE` section with a pointer carrying its `load_condition` ("Read `references/<topic>.md` when the API returns a non-200"). A bare "see `references/<topic>.md`" is relocation, not disclosure, and Phase 4 fails it.
+3. Keep references **one level deep**. A reference that points to another reference is a chain — inline it or promote it to a sibling.
+4. Bump `metadata.version`: **minor** for pure relocation, **major** if any `CUT` removed an instruction or the step sequence changed.
+
+When the plan extracts three or more reference files and the Agent tool is available, hand each one to its own worker: the worker's `Input` is `references/split-patterns.md` plus that section's text, and it returns the finished file. The body rewrite stays with the main agent, which is the only step that needs the whole picture.
+
+**Done when:** every `MOVE` destination exists and is non-empty, the body contains a conditional pointer to each, and the version is bumped.
+
+### Phase 4 — Verify
+
+```bash
+python3 "$SS/scripts/verify_shorten.py" "$SKILL_PATH" \
+  --manifest .skill-shortener/manifest.json \
+  --baseline .skill-shortener/baseline.json
+python3 "$QV" "$SKILL_PATH"
+```
+
+Then do the **read-back**, which no script can do for you: open every file the plan created and confirm the material arrived complete and reads as instructions rather than as an excerpt. The script proves the manifest is exhaustive and the wiring is sound; only the read-back proves the content survived the move.
+
+On a failure, fix and re-run — up to 3 rounds, then report what still fails instead of looping. If the result is worse than the original, restore — guarding both variables, because an empty `$SNAP` leaves a deleted skill and nothing to put back:
+
+```bash
+: "${SKILL_PATH:?}"; : "${SNAP:?}"; test -d "$SNAP" || { echo "no snapshot at $SNAP" >&2; exit 1; }
+rm -rf "$SKILL_PATH" && cp -R "$SNAP" "$SKILL_PATH"
+```
+
+**Done when:** `verify_shorten.py` exits 0, `quick_validate.py` exits 0, and every created file has been read back.
+
+## Edge cases
+
+Only the ones where judgment reliably goes wrong — everything else, handle on the merits.
+
+- **Already within both caps** → take the Phase 0 early exit. Splitting a body that fits adds a pointer hop and saves nothing.
+- **The target already has `references/`** → measure it too. A chained or orphaned existing tree is in scope even when the body fits, and it is the one case where a `WITHIN_CAP` verdict still warrants work.
+- **The path is a collection** (no `SKILL.md` at the root, children have one) → ask which skill. Never span two skills in one manifest.
+- **The user asks to cut a never-cut block** → say in one sentence why it stays, then pursue the size target through the other dispositions. Do not silently comply, and do not refuse the whole task.
+- **A section too big for one destination** → `destination` takes a list. Split it by sub-topic, never by line range: half a procedure is not self-contained.
+- **Under one cap, over the other** → both gate. 480 lines at 4,200 words has not been shortened enough.
+
+## Step Completion Reports
+
+After each phase, print:
+
+```
+◆ [Phase Name] (phase N of 4 — [context])
+··································································
+  [Check 1]:          √ pass
+  [Check 2]:          × fail — [reason]
+  [Criteria]:         √ N/M met
+  ____________________________
+  Result:             PASS | FAIL | PARTIAL
+```
+
+Per-phase checks: Phase 0 `Preflight`, `Snapshot`, `Baseline measured`, `Cap verdict`. Phase 1 `Every section classified`, `Reasons given`, `Load conditions written`. Phase 2 `Plan presented`, `Approval received`. Phase 3 `Destinations written`, `Pointers conditional`, `Version bumped`. Phase 4 `verify_shorten`, `quick_validate`, `Read-back`.
+
+## Run stats (mandatory)
+
+Close every run — including an early exit, a refused gate, or a failed phase — with this block as the last thing printed:
+
+```
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Run stats   elapsed 4m 12s · tokens 96,300 · cost $0.31
+              agents 0 · skills 1 · tool calls 22
+```
+
+Fields are fixed and in this order: `elapsed`, `tokens`, `cost`, `agents`, `skills`, `tool calls`. `tokens` and `cost` are omitted entirely when the host reported no figure — never estimated. The other four always print; an undeterminable value prints `n/a`, and `0` is a determined value. `elapsed` comes from `RUN_EPOCH`, captured once in the preflight.
+
+## Reference files
+
+| File                                  | Read it when                                                                             |
+| ------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `references/behavior-preservation.md` | you are assigning `KEEP` — it names the blocks that may never be cut, whatever they cost |
+| `references/cut-list.md`              | you are assigning `CUT` — what is safe to delete and how to word the reason              |
+| `references/split-patterns.md`        | you are assigning `MOVE` — choosing the destination, writing the pointer, flattening     |

--- a/skills/skill-shortener/SKILL.md
+++ b/skills/skill-shortener/SKILL.md
@@ -72,14 +72,15 @@ SNAP=".skill-shortener/snapshot-$RUN_EPOCH"
 mkdir -p "$SNAP" && cp -R "$SKILL_PATH/." "$SNAP/"
 ```
 
-Then sync **only if** the target is in a git repo:
+Then sync **only if** the target directory itself is a git work tree root — `rev-parse --git-dir` succeeds for any nested path inside a larger repo, and must not trigger fetch/pull of that tree:
 
 ```bash
-if git -C "$SKILL_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+toplevel="$(git -C "$SKILL_PATH" rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$toplevel" ] && [ "$(cd "$SKILL_PATH" && pwd -P)" = "$toplevel" ]; then
   branch="$(git -C "$SKILL_PATH" rev-parse --abbrev-ref HEAD)"
   git -C "$SKILL_PATH" fetch origin && git -C "$SKILL_PATH" pull --rebase origin "$branch"
 else
-  echo "note: $SKILL_PATH is not in a git repo — $SNAP is the only undo path"
+  echo "note: $SKILL_PATH is not a git work tree root — $SNAP is the only undo path; skip fetch/pull"
 fi
 ```
 
@@ -99,7 +100,9 @@ Every section of the body gets exactly one, and each has one reference behind it
 
 ### Phase 0 — Baseline
 
-Run the preflight, take the snapshot, sync if applicable, then measure:
+**Mode 2 — skip snapshot and git sync.** Audit-only must not reach `fetch` / `pull --rebase`. Run the preflight and the two `measure_skill.py` commands below, then continue to Phase 1. Do not create `$SNAP` and do not run the repo-sync block.
+
+**Mode 1.** Run the preflight, take the snapshot, sync only when `$SKILL_PATH` is itself the git work tree root (see above), then measure:
 
 ```bash
 python3 "$SS/scripts/measure_skill.py" "$SKILL_PATH" --json --out .skill-shortener/baseline.json

--- a/skills/skill-shortener/docs/README.md
+++ b/skills/skill-shortener/docs/README.md
@@ -1,0 +1,57 @@
+<!--
+  DO NOT READ THIS FILE — This README.md is for human catalog browsing only.
+  It ships inside the .skill package but is NEVER auto-loaded into agent context.
+  The runtime loader only reads SKILL.md + references/ + scripts/ + agents/ when the skill triggers.
+  If you're an AI agent, read the SKILL.md file instead for skill instructions.
+-->
+
+# Skill Shortener
+
+> Shrink an over-long SKILL.md by progressive disclosure — and prove nothing was lost.
+
+## Highlights
+
+- **Measures before it cuts** — per-section line and word counts, plus the always-loaded / on-trigger / on-demand token split
+- **Classifies every section** into KEEP, CUT, or MOVE, recorded in a manifest that becomes the loss-prevention record
+- **Plans before it applies** — you approve the exact split before a single file is rewritten
+- **Verifies mechanically** — 12 checks covering manifest exhaustiveness, dangling and orphaned pointers, reference chains, both size caps, and the version bump
+- **Snapshots first**, because `~/.claude/skills/` is usually not a git repo
+
+## When to Use
+
+| Say this...                            | Skill will...                                                         |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| "this SKILL.md is way too long"        | Measure it, propose a split, apply it on your go-ahead                |
+| "shorten skill-x"                      | Run the full measure → classify → plan → apply → verify pass          |
+| "what would you cut from this skill?"  | Audit-only mode: produce the plan and touch nothing                   |
+| "apply progressive disclosure to this" | Move non-universal material into `references/` behind load conditions |
+
+## How It Works
+
+```mermaid
+graph TD
+    A["Phase 0: baseline + snapshot"] --> B["Phase 1: classify every section"]
+    B --> C["Phase 2: plan + approve"]
+    C --> D["Phase 3: apply the split"]
+    D --> E["Phase 4: verify + read-back"]
+    style A fill:#4CAF50,color:#fff
+    style E fill:#2196F3,color:#fff
+```
+
+## Usage
+
+```
+/skill-shortener
+```
+
+## Resources
+
+| Path                        | Description                                                           |
+| --------------------------- | --------------------------------------------------------------------- |
+| `references/`               | One file per disposition: what to keep, what to cut, where to move it |
+| `scripts/measure_skill.py`  | Footprint and per-section size report, human-readable or JSON         |
+| `scripts/verify_shorten.py` | The 12 post-split invariants, with a fix hint on every failure        |
+
+## Output
+
+A rewritten `SKILL.md` under the 500-line and 3000-word caps, new files under `references/` and `scripts/`, a bumped `metadata.version`, and a `.skill-shortener/` workdir holding the baseline, the manifest, and a timestamped snapshot of the original.

--- a/skills/skill-shortener/evals/evals.json
+++ b/skills/skill-shortener/evals/evals.json
@@ -1,0 +1,98 @@
+{
+  "skill_name": "skill-shortener",
+  "evals": [
+    {
+      "id": 1,
+      "kind": "happy-path",
+      "prompt": "~/.claude/skills/game-forge/SKILL.md is 900 lines and it's eating my context on every run. Shorten it.",
+      "expected_output": "A plan is presented and approved before anything is written; the body ends under 500 lines and 3000 words with the extracted material in references/ behind conditional pointers.",
+      "files": [],
+      "expectations": [
+        "Ran scripts/measure_skill.py and wrote .skill-shortener/baseline.json before reading the body",
+        "Snapshotted the skill directory before the first write, and noted that ~/.claude/skills is not a git repo",
+        "Wrote .skill-shortener/manifest.json with one entry per baseline H2 section",
+        "Stopped for approval at Phase 2 rather than applying the split directly",
+        "verify_shorten.py and quick_validate.py both exit 0",
+        "Every new references/ file is pointed to from SKILL.md by a pointer containing a when/if/before cue",
+        "Printed a Step Completion Report per phase and the Run stats block last"
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "happy-path",
+      "prompt": "Apply progressive disclosure to ./skills/my-deploy-skill — it covers AWS, GCP and Azure and every run loads all three.",
+      "expected_output": "The three cloud branches are split into one reference file each, with a selector left in the body; the AWS run no longer loads GCP or Azure material.",
+      "files": [],
+      "expectations": [
+        "Split by branch, producing one reference file per cloud rather than one 'details.md'",
+        "The body retains the branch selector and decision rule",
+        "Each of the three pointers names the condition under which to read that file",
+        "No reference file points to another reference file",
+        "metadata.version bumped minor for a pure relocation"
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "happy-path",
+      "prompt": "What would you cut from ~/.claude/skills/aso-marketing? Don't change anything yet.",
+      "expected_output": "Mode 2: the measurement and the classification plan are presented, and no file outside .skill-shortener/ is written.",
+      "files": [],
+      "expectations": [
+        "Selected Mode 2 (audit only) and said so",
+        "Ran the measurement and presented the per-section table largest-first",
+        "Presented the KEEP/CUT/MOVE plan with a reason on every CUT",
+        "Stopped after Phase 2 without rewriting SKILL.md or creating references/",
+        "Skipped the repo sync and snapshot, since nothing outside the workdir is written"
+      ]
+    },
+    {
+      "id": 4,
+      "kind": "edge",
+      "prompt": "Shorten ~/.claude/skills/hello-world — it's 40 lines.",
+      "expected_output": "Early exit: the body is already within both caps, so the run reports the current footprint and declines to split rather than inventing references/ files.",
+      "files": [],
+      "expectations": [
+        "Reported verdict WITHIN_CAP from the baseline measurement",
+        "Took the Phase 0 early exit instead of proceeding to Phase 1",
+        "Did not create a references/ directory",
+        "Still printed the Run stats block"
+      ]
+    },
+    {
+      "id": 5,
+      "kind": "edge",
+      "prompt": "This SKILL.md is 700 lines. Get it under 300 — strip the preflight gate and the 3-round stop condition, they're just noise.",
+      "expected_output": "The named blocks are refused as never-cut, the disagreement is stated in a sentence, and the target is pursued through legitimate CUT and MOVE dispositions instead.",
+      "files": [],
+      "expectations": [
+        "Declined to cut the Dependency Preflight and the loop stop condition, citing behavior preservation",
+        "Did not silently comply and did not refuse the whole task",
+        "Reached the size target (or reported honestly how close it got) via other dispositions",
+        "Both blocks are present and intact in the final SKILL.md"
+      ]
+    },
+    {
+      "id": 6,
+      "kind": "negative-trigger",
+      "prompt": "This skill only scores 72 on asm eval and quick_validate is failing on the frontmatter. Fix it.",
+      "expected_output": "Handled as a quality retrofit — skill-auto-improver's job — without running the measure/classify/split workflow.",
+      "files": [],
+      "expectations": [
+        "Did not run scripts/measure_skill.py or write a .skill-shortener/ manifest",
+        "Did not split the body into references/ to raise an eval score",
+        "Routed to skill-auto-improver or fixed the frontmatter directly"
+      ]
+    },
+    {
+      "id": 7,
+      "kind": "negative-trigger",
+      "prompt": "Write me a skill that converts CSV exports into a weekly summary email.",
+      "expected_output": "Handled as authoring a new skill — skill-creator's job — with no shortening workflow applied.",
+      "files": [],
+      "expectations": [
+        "Did not apply the KEEP/CUT/MOVE dispositions to a skill that does not exist yet",
+        "Routed to skill-creator or authored the skill directly"
+      ]
+    }
+  ]
+}

--- a/skills/skill-shortener/references/behavior-preservation.md
+++ b/skills/skill-shortener/references/behavior-preservation.md
@@ -1,0 +1,41 @@
+# Behavior preservation — the KEEP disposition
+
+Read this while assigning `KEEP`. It answers one question: what must stay in the body no matter what it costs?
+
+## Never cut, never move
+
+These blocks look like overhead to a line-count optimizer and are exactly what it should not touch. Each one changes what the agent _does_; removing it silently changes the skill's behavior while every mechanical check still passes.
+
+| Block                             | Why it stays                                                                       |
+| --------------------------------- | ---------------------------------------------------------------------------------- |
+| **Dependency Preflight**          | Without the gate, a missing dependency surfaces mid-run, after edits have landed   |
+| **Repo sync / snapshot gates**    | The undo path. Cutting it makes the skill unrecoverable on failure                 |
+| **Stop-and-ask gates**            | Approval points are the user's control over the run                                |
+| **Per-step completion criteria**  | The bar that stops the agent declaring success early                               |
+| **Loop stop conditions**          | "…or 3 rounds, then report" is what prevents an infinite loop                      |
+| **Step Completion Report format** | The report is the skill's observable contract                                      |
+| **Run stats block**               | Same — a terminal output other tooling and the user rely on                        |
+| **Negative-trigger clause**       | In the description. Cutting it produces false-positive triggering across the fleet |
+| **Safety and refusal rules**      | Never a size optimization                                                          |
+
+A block on this list may be **tightened** — three sentences to one, prose to a table — but its instruction must survive the edit intact.
+
+## What else earns KEEP
+
+- **The routing spine**: mode selector, ordered step headings, and the pointer lines themselves. A run must be able to reach every branch without loading anything.
+- **Anything every run needs**: if a piece is read on 100% of activations, moving it to `references/` adds a hop and saves nothing. Schemas the workflow writes on every run belong in the body for this reason.
+- **Decision rules**: the criteria that pick between branches. Move the elaboration, keep the rule.
+- **Project-specific conventions and non-obvious gotchas**: the reason the skill exists.
+
+## Tightening without changing behavior
+
+Order of preference, cheapest first:
+
+1. Prose → table, when the content is parallel (three options with the same fields).
+2. Repeated explanation → a **leading word** used consistently ("behavior-preserving", "disposition", "load condition").
+3. Multi-sentence rationale → one clause. Keep _why_ only where the agent would otherwise do the wrong thing.
+4. Several near-identical examples → the single best one.
+
+## When the read-back fails
+
+Phase 4's read-back is where a moved section is found to have lost something — a caveat that only made sense next to the step it qualified, a reference to "the table above" that no longer resolves. Fix it in the destination file, not by reverting the move: make the file self-contained by restating the context in a sentence. If it cannot be made self-contained, the section was mis-classified — change its disposition to `KEEP` and re-run the phase.

--- a/skills/skill-shortener/references/cut-list.md
+++ b/skills/skill-shortener/references/cut-list.md
@@ -1,0 +1,42 @@
+# The cut list — the CUT disposition
+
+Read this while assigning `CUT`. A cut is a deletion with no forwarding address, so each one needs a `reason` in the manifest that survives review.
+
+## The test
+
+Delete a sentence and ask: **would the agent behave differently without it?** If not, it is content the skill is paying for on every activation and getting nothing back. Cut it.
+
+## Safe to cut
+
+| Category                        | Examples                                                                           |
+| ------------------------------- | ---------------------------------------------------------------------------------- |
+| **Common knowledge**            | What JSON/REST/Python/PDF/git _is_; how a well-known library works; syntax primers |
+| **When-to-use prose**           | Already the job of the `description`; a body section restating it is dead weight   |
+| **Setup and install notes**     | Unless the skill's own run depends on them — then they belong in a preflight       |
+| **History and attribution**     | Changelogs, "v2 added…", author notes, credits                                     |
+| **Template placeholders**       | `[TODO: …]` scaffolding left over from `init_skill.py`                             |
+| **No-op instructions**          | "Be careful", "use good judgment", "make it high quality", "think step by step"    |
+| **`--help`-level completeness** | Exhaustive flag lists. Keep the common 80% and say to run `--help` for the rest    |
+| **Duplication**                 | The same rule stated in two sections. Keep one home and link to it                 |
+| **Stale sediment**              | Guidance for a flow that no longer exists; pointers to deleted files               |
+| **Every-edge-case enumeration** | Cases a capable agent handles by judgment. Keep the ones where judgment goes wrong |
+
+## Cut with care
+
+- **File paths, line numbers, magic constants** — cut unless the skill is a code-navigation runbook, where they are the payload.
+- **Rationale ("why")** — keep exactly where the agent would otherwise do the wrong thing, cut where it is reassurance for a human reader.
+- **Examples** — one worked example teaches more than five variants. Cut the variants, keep the best one.
+
+## Never cut
+
+The blocked list lives with the KEEP disposition. Before cutting anything that reads like process overhead — a gate, a stop condition, a report format, a completion criterion — check it there first.
+
+## Writing the reason
+
+The `reason` field is read by whoever reviews the plan, so make it a claim they can check:
+
+- Good: `"restates the description's when-to-use; changes no behavior"`
+- Good: `"exhaustive flag list; body now says to run --help"`
+- Weak: `"not needed"`, `"redundant"`, `"cleanup"`
+
+If the reason cannot be written in one checkable clause, the section is probably a `MOVE`, not a `CUT`.

--- a/skills/skill-shortener/references/split-patterns.md
+++ b/skills/skill-shortener/references/split-patterns.md
@@ -1,0 +1,48 @@
+# Split patterns — the MOVE disposition
+
+Read this while assigning `MOVE`. It decides the destination, the pointer, and the shape of the file that lands there.
+
+## Choosing the destination
+
+| Content                                                                 | Destination                      |
+| ----------------------------------------------------------------------- | -------------------------------- |
+| Schemas, API docs, long examples, edge-case catalogs, per-branch detail | `references/*.md`                |
+| Flat lists — commands, error codes, field names                         | `references/*.txt`               |
+| A fragile multi-step procedure the agent repeats                        | `scripts/*` (rewrite it as code) |
+| Templates, boilerplate, files that appear in the output                 | `assets/*`                       |
+| A complete prompt for a delegated worker                                | `agents/*.md`                    |
+
+**Scripts are the biggest win.** A twenty-step procedure moved to `references/` still costs full tokens when read. Rewritten as a CLI, only its _output_ enters context. Any section that reads "do these N fragile steps" and could be deterministic is a script, not a reference. Give it descriptive stderr errors saying what went wrong, which input caused it, and how to fix it — an agent that hits a bare `exit 1` is stuck.
+
+## Splitting by branch or by sequence
+
+- **By branch** — a skill covering AWS _and_ GCP, or create _and_ edit, gets one file per branch and a selector in the body. This is the highest-value split: a run loads its own branch and never sees the other.
+- **By sequence** — a long phase 5 moves to its own file, read when the run reaches it. This also keeps the agent from seeing the finish line early and rushing the step in front of it.
+
+Name files after the branch or phase, not the content type: `aws.md`, `phase-5-publish.md` — not `details.md` or `advanced.md`.
+
+## Writing the pointer
+
+A pointer without a load condition is relocation, not disclosure — the agent either reads everything anyway or skips something it needed. Verification fails a pointer with no `when` / `if` / `before` / `after` cue.
+
+- Good: ``Read `references/api-errors.md` when the API returns a non-200.``
+- Good: ``Run `scripts/validate.py` before committing.``
+- Good: ``For the full command list, read `references/commands.txt` if the common four are not enough.``
+- Bad: ``See `references/api-errors.md`.``
+- Bad: ``More detail in `references/advanced.md`.``
+
+Write **illustrative** paths as placeholders — `references/<topic>.md`, not `references/api-errors.md`. Verification reads every concrete `references/…` path in the body as a real pointer and fails the ones that do not resolve; a placeholder is unmistakably an example.
+
+State the condition the way the agent will meet it — a state it can observe, not a topic it might be interested in.
+
+## Rules for the destination file
+
+1. **One level deep.** A reference must not point to another reference. If two belong together, merge them; if one is genuinely shared, promote it to a sibling the body points at directly. Chains defeat disclosure — the agent pays for both files to reach the second.
+2. **Self-contained.** The reader arrives with the pointer's sentence and nothing else. Restate the context in one line rather than writing "as described above".
+3. **Contents map over 300 lines.** A one-line list of headings at the top so the agent can skim to its section.
+4. **Flatten dense material.** Markdown headings, fences, and blank lines cost real tokens on a list of commands. A flat `.txt` of `command — what it does` lines is often an order of magnitude cheaper than the same content as formatted Markdown, and just as readable to the agent.
+5. **No orphans.** Every file under `references/` and `scripts/` must be pointed at from the body. An unpointed file is either dead or a pointer you forgot to write.
+
+## Delegating the write
+
+With three or more destinations and the Agent tool available, give each file its own worker. The worker receives this file plus the section's original text as its `Input`, and returns the finished destination file. Keep the body rewrite with the main agent — it is the one step that needs every pointer in view at once.

--- a/skills/skill-shortener/scripts/measure_skill.py
+++ b/skills/skill-shortener/scripts/measure_skill.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Measure a skill's context footprint and per-section size.
+
+Usage:
+    measure_skill.py <skill-path> [--json] [--out FILE]
+
+Reports for <skill-path>/SKILL.md:
+  * always-loaded footprint  - frontmatter name + description (every turn)
+  * on-trigger footprint     - the SKILL.md body (every activation)
+  * on-demand footprint      - references/, scripts/, agents/, assets/
+  * every H2 section with its line and word count, largest first
+  * a verdict against the 500-line AND 3000-word body caps
+
+Exit codes:
+    0  measurement completed (over-cap is reported, not an error)
+    2  the target could not be measured (missing/unparsable SKILL.md)
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+LINE_CAP = 500
+WORD_CAP = 3000
+ON_DEMAND_DIRS = ("references", "scripts", "agents", "assets")
+CHARS_PER_TOKEN = 4  # rough estimate, labelled as such in the report
+
+
+def die(msg, fix):
+    print(f"Error: {msg}", file=sys.stderr)
+    print(f"Fix:   {fix}", file=sys.stderr)
+    sys.exit(2)
+
+
+def split_frontmatter(text, skill_md):
+    """Return (frontmatter_text, body_text, body_start_line) - 1-indexed."""
+    if not text.startswith("---"):
+        die(
+            f"{skill_md} has no YAML frontmatter (file does not start with '---').",
+            "Add a frontmatter block with at least 'name:' and 'description:'.",
+        )
+    m = re.match(r"^---\n(.*?)\n---\n?", text, re.DOTALL)
+    if not m:
+        die(
+            f"{skill_md} has an unterminated YAML frontmatter block.",
+            "Close the frontmatter with a line containing exactly '---'.",
+        )
+    fm = m.group(1)
+    body = text[m.end():]
+    body_start = text[: m.end()].count("\n") + 1
+    return fm, body, body_start
+
+
+def frontmatter_field(fm_text, field, indented=False):
+    """Read one scalar field without requiring PyYAML."""
+    prefix = r"\s+" if indented else ""
+    m = re.search(rf"^{prefix}{field}:\s*(.*)$", fm_text, re.MULTILINE)
+    if not m:
+        return None
+    val = m.group(1).strip()
+    if len(val) >= 2 and val[0] == val[-1] and val[0] in "\"'":
+        val = val[1:-1]
+    return val
+
+
+def measure_text(text):
+    lines = text.splitlines()
+    chars = len(text)
+    return {
+        "lines": len(lines),
+        "words": len(text.split()),
+        "chars": chars,
+        "est_tokens": round(chars / CHARS_PER_TOKEN),
+    }
+
+
+def find_sections(body, body_start):
+    """H2 sections of the body, ignoring '##' inside fenced code blocks.
+
+    Content before the first H2 becomes a '(preamble)' pseudo-section so that
+    every line of the body belongs to exactly one section.
+    """
+    lines = body.splitlines()
+    fence = None
+    heads = []
+    for i, line in enumerate(lines):
+        fm = re.match(r"^\s*(`{3,}|~{3,})", line)
+        if fm:
+            tok = fm.group(1)[0]
+            if fence is None:
+                fence = tok
+            elif fence == tok:
+                fence = None
+            continue
+        if fence is None and re.match(r"^##\s+\S", line):
+            heads.append((i, line.strip().lstrip("#").strip()))
+
+    bounds = []
+    if not heads or heads[0][0] > 0:
+        bounds.append((0, heads[0][0] if heads else len(lines), "(preamble)"))
+    for n, (idx, title) in enumerate(heads):
+        end = heads[n + 1][0] if n + 1 < len(heads) else len(lines)
+        bounds.append((idx, end, title))
+
+    sections = []
+    for start, end, title in bounds:
+        chunk = "\n".join(lines[start:end])
+        if not chunk.strip() and title == "(preamble)":
+            continue
+        sections.append(
+            {
+                "heading": title,
+                "start_line": body_start + start,
+                "end_line": body_start + end - 1,
+                "lines": end - start,
+                "words": len(chunk.split()),
+            }
+        )
+    return sections
+
+
+def measure_dir(path):
+    if not path.is_dir():
+        return {"files": 0, "lines": 0, "words": 0, "est_tokens": 0}
+    files = [p for p in sorted(path.rglob("*")) if p.is_file() and not p.name.startswith(".")]
+    lines = words = chars = 0
+    for p in files:
+        try:
+            t = p.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        lines += len(t.splitlines())
+        words += len(t.split())
+        chars += len(t)
+    return {
+        "files": len(files),
+        "lines": lines,
+        "words": words,
+        "est_tokens": round(chars / CHARS_PER_TOKEN),
+    }
+
+
+def build_report(skill_path):
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.is_file():
+        die(
+            f"no SKILL.md found at {skill_md}.",
+            "Pass the skill's directory, e.g. measure_skill.py ~/.claude/skills/my-skill",
+        )
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except OSError as exc:
+        die(f"could not read {skill_md}: {exc}", "Check file permissions and encoding (UTF-8 expected).")
+
+    fm, body, body_start = split_frontmatter(text, skill_md)
+    name = frontmatter_field(fm, "name") or skill_path.name
+    desc = frontmatter_field(fm, "description") or ""
+    version = frontmatter_field(fm, "version", indented=True)
+
+    body_stats = measure_text(body)
+    report = {
+        "skill": name,
+        "path": str(skill_path),
+        "version": version,
+        "always_loaded": {
+            "description_chars": len(desc),
+            "frontmatter_lines": len(fm.splitlines()),
+            "est_tokens": round((len(name) + len(desc)) / CHARS_PER_TOKEN),
+        },
+        "on_trigger": dict(body_stats, start_line=body_start),
+        "on_demand": {d: measure_dir(skill_path / d) for d in ON_DEMAND_DIRS},
+        "sections": sorted(find_sections(body, body_start), key=lambda s: -s["lines"]),
+        "caps": {
+            "lines": {"value": body_stats["lines"], "cap": LINE_CAP, "over": body_stats["lines"] > LINE_CAP},
+            "words": {"value": body_stats["words"], "cap": WORD_CAP, "over": body_stats["words"] > WORD_CAP},
+        },
+    }
+    report["verdict"] = "OVER_CAP" if (report["caps"]["lines"]["over"] or report["caps"]["words"]["over"]) else "WITHIN_CAP"
+    return report
+
+
+def print_human(r):
+    print(f"Skill: {r['skill']}  ({r['path']})")
+    print()
+    print("Footprint")
+    a, t = r["always_loaded"], r["on_trigger"]
+    print(f"  always-loaded (every turn)  description {a['description_chars']} chars, ~{a['est_tokens']} tokens")
+    print(f"  on-trigger    (every run)   {t['lines']} lines, {t['words']} words, ~{t['est_tokens']} tokens")
+    od = r["on_demand"]
+    total = sum(v["est_tokens"] for v in od.values())
+    detail = ", ".join(f"{d} {od[d]['files']}f/{od[d]['lines']}L" for d in ON_DEMAND_DIRS if od[d]["files"])
+    print(f"  on-demand     (when read)   ~{total} tokens" + (f"  [{detail}]" if detail else "  [none]"))
+    print()
+    c = r["caps"]
+    for key in ("lines", "words"):
+        mark = "OVER" if c[key]["over"] else "ok"
+        print(f"  body {key:<6} {c[key]['value']:>6} / {c[key]['cap']}  {mark}")
+    print(f"  verdict: {r['verdict']}")
+    print()
+    print("Sections, largest first")
+    print(f"  {'lines':>6} {'words':>7}  {'at':>5}  heading")
+    for s in r["sections"]:
+        print(f"  {s['lines']:>6} {s['words']:>7}  {s['start_line']:>5}  {s['heading']}")
+    if r["verdict"] == "WITHIN_CAP":
+        print()
+        print("Body is within both caps. Shortening is optional - see the early exit in SKILL.md Phase 0.")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Measure a skill's context footprint and per-section size.")
+    ap.add_argument("skill_path", help="path to the skill directory (the one containing SKILL.md)")
+    ap.add_argument("--json", action="store_true", help="print the report as JSON")
+    ap.add_argument("--out", help="also write the JSON report to this file")
+    args = ap.parse_args()
+
+    report = build_report(Path(args.skill_path).expanduser())
+
+    if args.out:
+        out = Path(args.out).expanduser()
+        try:
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        except OSError as exc:
+            die(f"could not write report to {out}: {exc}", "Choose a writable path, e.g. --out .skill-shortener/baseline.json")
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print_human(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/skill-shortener/scripts/test_condition_cues.py
+++ b/skills/skill-shortener/scripts/test_condition_cues.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Regression: load-condition cues are whole words and ignore the destination path."""
+
+from verify_shorten import has_load_condition_cue
+
+DEST = "scripts/verify_shorten.py"
+assert not has_load_condition_cue(f"See `{DEST}`", DEST), "path substring 'if'/'verify' must not count"
+assert not has_load_condition_cue("See `references/verification.md`", "references/verification.md")
+assert not has_load_condition_cue("See `scripts/when-to-run.py`", "scripts/when-to-run.py"), "filename 'when' must not count"
+assert has_load_condition_cue(f"See `{DEST}` when the body is over cap", DEST)
+assert has_load_condition_cue("Read it if the API returns non-200", "references/api.md")
+print("ok")

--- a/skills/skill-shortener/scripts/verify_shorten.py
+++ b/skills/skill-shortener/scripts/verify_shorten.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Verify a shortened skill against the behavior-preserving invariants.
+
+Usage:
+    verify_shorten.py <skill-path> --manifest FILE [--baseline FILE]
+
+Manifest schema (written in Phase 1, one entry per baseline H2 section):
+
+    {
+      "target": "<skill-path>",
+      "sections": [
+        {"heading": "Overview", "disposition": "KEEP"},
+        {"heading": "API errors", "disposition": "MOVE",
+         "destination": "references/api-errors.md",
+         "load_condition": "when the API returns a non-200"},
+        {"heading": "History", "disposition": "CUT",
+         "reason": "changelog and attribution; changes no behavior"}
+      ]
+    }
+
+"destination" may be a string or a list of strings. Checks that need the
+pre-shorten state (exhaustiveness, shrinkage, version bump) are skipped with a
+warning when --baseline is omitted.
+
+Exit codes:
+    0  every applicable check passed
+    1  at least one check failed (each failure prints what and how to fix it)
+    2  the run could not start (missing skill, manifest, or malformed JSON)
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+LINE_CAP = 500
+WORD_CAP = 3000
+DESC_TARGET = 250
+POINTER_DIRS = ("references", "scripts", "assets", "agents")
+ORPHAN_DIRS = ("references", "scripts")  # docs/, evals/, assets/, agents/ are not pointed to line-by-line
+CONDITION_CUES = ("when", "if", "before", "after", "unless", "for ", "on a ", "whenever", "each time")
+VALID = {"KEEP", "CUT", "MOVE"}
+
+
+def die(msg, fix):
+    print(f"Error: {msg}", file=sys.stderr)
+    print(f"Fix:   {fix}", file=sys.stderr)
+    sys.exit(2)
+
+
+def load_json(path, what, fix):
+    p = Path(path).expanduser()
+    if not p.is_file():
+        die(f"{what} not found at {p}.", fix)
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        die(f"{what} at {p} is not readable JSON: {exc}", "Rewrite it as valid JSON - see the schema in this script's docstring.")
+
+
+def read_body(skill_md):
+    text = skill_md.read_text(encoding="utf-8")
+    m = re.match(r"^---\n(.*?)\n---\n?", text, re.DOTALL)
+    if not m:
+        die(f"{skill_md} has no parsable YAML frontmatter.", "Restore the '---' delimited frontmatter block at the top of the file.")
+    return m.group(1), text[m.end():]
+
+
+def field(fm, name, indented=False):
+    prefix = r"\s+" if indented else ""
+    m = re.search(rf"^{prefix}{name}:\s*(.*)$", fm, re.MULTILINE)
+    if not m:
+        return None
+    v = m.group(1).strip()
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in "\"'":
+        v = v[1:-1]
+    return v
+
+
+def destinations(entry):
+    d = entry.get("destination")
+    if d is None:
+        return []
+    return [d] if isinstance(d, str) else list(d)
+
+
+def mentioned_paths(text):
+    """Every references//scripts//assets//agents/ path the text mentions."""
+    # (?<![\w./-]) keeps a path that is part of a longer path - another skill's
+    # ~/.claude/skills/other/scripts/x.py, or ~/.agents/skills/ - from being read
+    # as a local pointer.
+    pat = rf"(?<![\w./-])(?:{'|'.join(POINTER_DIRS)})/[A-Za-z0-9._\-/]+"
+    return {m.rstrip(".,;:)`'\"") for m in re.findall(pat, text)}
+
+
+def lines_mentioning(text, needle):
+    """Lines mentioning `needle`, each paired with its table header when the
+    mention sits in a Markdown table - a 'Read it when' column header is a real
+    load condition for every row under it."""
+    lines = text.splitlines()
+    out = []
+    for i, ln in enumerate(lines):
+        if needle not in ln:
+            continue
+        ctx = [ln]
+        if ln.lstrip().startswith("|"):
+            j = i
+            while j > 0 and lines[j - 1].lstrip().startswith("|"):
+                j -= 1
+            ctx.append(lines[j])
+        out.append(" ".join(ctx))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Verify a shortened skill's behavior-preserving invariants.")
+    ap.add_argument("skill_path")
+    ap.add_argument("--manifest", required=True, help="Phase 1 manifest JSON")
+    ap.add_argument("--baseline", help="Phase 0 baseline JSON from measure_skill.py")
+    args = ap.parse_args()
+
+    skill = Path(args.skill_path).expanduser()
+    skill_md = skill / "SKILL.md"
+    if not skill_md.is_file():
+        die(f"no SKILL.md at {skill_md}.", "Pass the skill directory, e.g. verify_shorten.py ~/.claude/skills/my-skill --manifest ...")
+
+    manifest = load_json(args.manifest, "manifest", "Write it in Phase 1 - schema is in this script's docstring.")
+    baseline = load_json(args.baseline, "baseline", "Produce it with: measure_skill.py <skill> --json --out .skill-shortener/baseline.json") if args.baseline else None
+
+    fm, body = read_body(skill_md)
+    entries = manifest.get("sections")
+    if not isinstance(entries, list) or not entries:
+        die("manifest has no 'sections' array.", "Add one entry per baseline H2 section - schema is in this script's docstring.")
+
+    results = []   # (name, ok, detail)
+    skipped = []
+    warnings = []
+
+    def check(name, ok, detail=""):
+        results.append((name, ok, detail))
+
+    # 1. every disposition is valid and carries its required fields
+    bad = []
+    for e in entries:
+        h, d = e.get("heading", "?"), e.get("disposition")
+        if d not in VALID:
+            bad.append(f"{h!r}: disposition {d!r} is not one of KEEP/CUT/MOVE")
+        elif d == "CUT" and not str(e.get("reason", "")).strip():
+            bad.append(f"{h!r}: CUT with no 'reason'")
+        elif d == "MOVE":
+            if not destinations(e):
+                bad.append(f"{h!r}: MOVE with no 'destination'")
+            if not str(e.get("load_condition", "")).strip():
+                bad.append(f"{h!r}: MOVE with no 'load_condition'")
+    check("dispositions valid", not bad, "; ".join(bad[:4]))
+
+    # 2. manifest accounts for every baseline section, exactly once
+    if baseline:
+        base = [s["heading"] for s in baseline.get("sections", [])]
+        got = [e.get("heading", "") for e in entries]
+        missing = [h for h in base if h not in got]
+        dupes = sorted({h for h in got if got.count(h) > 1})
+        extra = [h for h in got if h not in base]
+        ok = not (missing or dupes)
+        detail = "; ".join(
+            filter(None, [
+                f"unclassified: {missing[:4]}" if missing else "",
+                f"classified twice: {dupes[:4]}" if dupes else "",
+                f"(not in baseline, ignored: {extra[:3]})" if extra else "",
+            ])
+        )
+        check(f"manifest exhaustive ({len(base)} sections)", ok, detail)
+    else:
+        skipped.append("manifest exhaustive (needs --baseline)")
+
+    # 3. every MOVE destination exists and is non-empty
+    missing_dest = []
+    all_dest = []
+    for e in entries:
+        if e.get("disposition") != "MOVE":
+            continue
+        for d in destinations(e):
+            all_dest.append(d)
+            p = skill / d
+            if not p.is_file():
+                missing_dest.append(f"{d} (missing)")
+            elif not p.read_text(encoding="utf-8").strip():
+                missing_dest.append(f"{d} (empty)")
+    check(f"destinations written ({len(set(all_dest))})", not missing_dest, "; ".join(missing_dest[:4]))
+
+    # 4. every destination is pointed to from SKILL.md
+    unpointed = sorted({d for d in all_dest if d not in body})
+    check("destinations pointed to", not unpointed, "; ".join(unpointed[:4]))
+
+    # 5. every pointer carries a load condition (disclosure, not relocation)
+    bare = []
+    for d in sorted(set(all_dest)):
+        pointer_lines = lines_mentioning(body, d)
+        if pointer_lines and not any(c in ln.lower() for ln in pointer_lines for c in CONDITION_CUES):
+            bare.append(d)
+    check("pointers state load conditions", not bare, "; ".join(f"{d}: no when/if/before cue" for d in bare[:3]))
+
+    # 6. no dangling pointer
+    dangling = sorted(p for p in mentioned_paths(body) if not (skill / p).exists())
+    check("pointers resolve", not dangling,
+          "; ".join(dangling[:4]) + " - create the file; write another skill's path in full (~/.claude/skills/<skill>/...); "
+          "write an illustrative path as a placeholder (references/<name>.md) so it is not read as a pointer")
+
+    # 7. no orphan file under references/ (hard) or scripts/ (advisory).
+    #    A helper module a sibling script imports is reached through that script,
+    #    not through SKILL.md, so it is not an orphan.
+    def collect(d):
+        root = skill / d
+        return [p for p in sorted(root.rglob("*")) if p.is_file() and not p.name.startswith(".") and p.suffix != ".pyc"] if root.is_dir() else []
+
+    script_files = collect("scripts")
+    internal = set()
+    for p in script_files:
+        try:
+            src = p.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for q in script_files:
+            if q != p and (re.search(rf"\b(?:import|from)\s+\.?{re.escape(q.stem)}\b", src) or q.name in src):
+                internal.add(q)
+
+    ref_orphans = [p.relative_to(skill).as_posix() for p in collect("references") if p.relative_to(skill).as_posix() not in body]
+    check("no orphan references", not ref_orphans, "; ".join(ref_orphans[:4]) + " - point at it from SKILL.md, or delete it")
+
+    script_orphans = [
+        p.relative_to(skill).as_posix() for p in script_files
+        if p not in internal and p.name != "__init__.py" and p.relative_to(skill).as_posix() not in body
+    ]
+    if script_orphans:
+        warnings.append(f"scripts not named in SKILL.md (fine if a sibling script calls them): {'; '.join(script_orphans[:4])}")
+
+    # 8. references stay one level deep - no reference-to-reference chain
+    chains = []
+    refs = skill / "references"
+    if refs.is_dir():
+        for p in sorted(refs.rglob("*.md")):
+            # A chain needs a real local target: an illustrative path in prose
+            # ("Read references/api-errors.md when ...") is an example, not a hop.
+            hits = {
+                h for h in mentioned_paths(p.read_text(encoding="utf-8"))
+                if h.startswith("references/")
+                and h != p.relative_to(skill).as_posix()
+                and (skill / h).is_file()
+            }
+            if hits:
+                chains.append(f"{p.relative_to(skill).as_posix()} -> {sorted(hits)[:2]}")
+    check("references one level deep", not chains, "; ".join(chains[:3]))
+
+    # 9. body within BOTH caps
+    n_lines, n_words = len(body.splitlines()), len(body.split())
+    check(f"body within caps ({n_lines}L / {n_words}W)", n_lines <= LINE_CAP and n_words <= WORD_CAP,
+          f"caps are {LINE_CAP} lines and {WORD_CAP} words")
+
+    # 10. body actually got smaller
+    if baseline:
+        was = baseline.get("on_trigger", {})
+        shrank = n_lines < was.get("lines", 0) or n_words < was.get("words", 0)
+        check("body shrank", shrank, f"was {was.get('lines')}L / {was.get('words')}W, now {n_lines}L / {n_words}W")
+    else:
+        skipped.append("body shrank (needs --baseline)")
+
+    # 11. description still valid and within the runtime target
+    desc = field(fm, "description") or ""
+    ok_desc = 0 < len(desc) <= DESC_TARGET and "\n" not in desc and "<" not in desc and ">" not in desc
+    check(f"description intact ({len(desc)} chars)", ok_desc, f"must be non-empty, single line, no angle brackets, <= {DESC_TARGET} chars")
+
+    # 12. version bumped
+    if baseline:
+        old, new = baseline.get("version"), field(fm, "version", indented=True)
+        check("metadata.version bumped", bool(new) and new != old, f"was {old}, now {new} - minor for pure relocation, major if a CUT removed an instruction")
+    else:
+        skipped.append("metadata.version bumped (needs --baseline)")
+
+    width = max(len(n) for n, _, _ in results)
+    print(f"Verify: {skill}")
+    print("." * (width + 22))
+    for name, ok, detail in results:
+        mark = "PASS" if ok else "FAIL"
+        print(f"  {name:<{width}}  {mark}" + (f" - {detail}" if detail and not ok else ""))
+    for s in skipped:
+        print(f"  {s:<{width}}  SKIP")
+    for w in warnings:
+        print(f"  {'(warning)':<{width}}  {w}")
+    failed = [n for n, ok, _ in results if not ok]
+    print("-" * (width + 22))
+    print(f"  Result: {'PASS' if not failed else 'FAIL'}  ({len(results) - len(failed)}/{len(results)} checks)")
+    if failed:
+        print(f"\nFix each FAIL above, then re-run this command. Failing checks: {', '.join(failed)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/skill-shortener/scripts/verify_shorten.py
+++ b/skills/skill-shortener/scripts/verify_shorten.py
@@ -39,7 +39,14 @@ WORD_CAP = 3000
 DESC_TARGET = 250
 POINTER_DIRS = ("references", "scripts", "assets", "agents")
 ORPHAN_DIRS = ("references", "scripts")  # docs/, evals/, assets/, agents/ are not pointed to line-by-line
-CONDITION_CUES = ("when", "if", "before", "after", "unless", "for ", "on a ", "whenever", "each time")
+# Whole-word cues on the pointer line/header. Trailing spaces used to fake
+# boundaries for "for"/"on a"; \b does that, and the destination path is
+# stripped first so scripts/verify_*.py cannot pass via the "if" in "verify".
+CONDITION_CUES = ("when", "if", "before", "after", "unless", "for", "on a", "whenever", "each time")
+CONDITION_CUE_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(c) for c in CONDITION_CUES) + r")\b",
+    re.IGNORECASE,
+)
 VALID = {"KEEP", "CUT", "MOVE"}
 
 
@@ -92,6 +99,18 @@ def mentioned_paths(text):
     # as a local pointer.
     pat = rf"(?<![\w./-])(?:{'|'.join(POINTER_DIRS)})/[A-Za-z0-9._\-/]+"
     return {m.rstrip(".,;:)`'\"") for m in re.findall(pat, text)}
+
+
+def text_without_destination(text, destination):
+    """Pointer context with the destination path removed so the path is not cue text."""
+    if not destination:
+        return text
+    return text.replace(destination, "")
+
+
+def has_load_condition_cue(text, destination=""):
+    """True when a CONDITION_CUE appears as a whole word outside `destination`."""
+    return bool(CONDITION_CUE_RE.search(text_without_destination(text, destination)))
 
 
 def lines_mentioning(text, needle):
@@ -197,7 +216,7 @@ def main():
     bare = []
     for d in sorted(set(all_dest)):
         pointer_lines = lines_mentioning(body, d)
-        if pointer_lines and not any(c in ln.lower() for ln in pointer_lines for c in CONDITION_CUES):
+        if pointer_lines and not any(has_load_condition_cue(ln, d) for ln in pointer_lines):
             bare.append(d)
     check("pointers state load conditions", not bare, "; ".join(f"{d}: no when/if/before cue" for d in bare[:3]))
 

--- a/skills/skill-shortener/scripts/verify_shorten.py
+++ b/skills/skill-shortener/scripts/verify_shorten.py
@@ -92,6 +92,27 @@ def destinations(entry):
     return [d] if isinstance(d, str) else list(d)
 
 
+def confined_under(skill, rel):
+    """Return the resolved path of `rel` if it stays inside `skill`, else None.
+
+    POSIX `Path / rel` discards the skill root when `rel` is absolute, and
+    `..` segments walk out of it. Both must fail the wiring checks rather
+    than be treated as files under the skill.
+    """
+    if not isinstance(rel, str) or not rel.strip():
+        return None
+    candidate = Path(rel).expanduser()
+    if candidate.is_absolute():
+        return None
+    root = skill.resolve()
+    try:
+        resolved = (skill / candidate).resolve()
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    return resolved
+
+
 def mentioned_paths(text):
     """Every references//scripts//assets//agents/ path the text mentions."""
     # (?<![\w./-]) keeps a path that is part of a longer path - another skill's
@@ -200,8 +221,11 @@ def main():
         if e.get("disposition") != "MOVE":
             continue
         for d in destinations(e):
+            p = confined_under(skill, d)
+            if p is None:
+                missing_dest.append(f"{d} (outside skill)")
+                continue
             all_dest.append(d)
-            p = skill / d
             if not p.is_file():
                 missing_dest.append(f"{d} (missing)")
             elif not p.read_text(encoding="utf-8").strip():
@@ -221,7 +245,10 @@ def main():
     check("pointers state load conditions", not bare, "; ".join(f"{d}: no when/if/before cue" for d in bare[:3]))
 
     # 6. no dangling pointer
-    dangling = sorted(p for p in mentioned_paths(body) if not (skill / p).exists())
+    dangling = sorted(
+        p for p in mentioned_paths(body)
+        if (loc := confined_under(skill, p)) is None or not loc.exists()
+    )
     check("pointers resolve", not dangling,
           "; ".join(dangling[:4]) + " - create the file; write another skill's path in full (~/.claude/skills/<skill>/...); "
           "write an illustrative path as a placeholder (references/<name>.md) so it is not read as a pointer")
@@ -265,7 +292,8 @@ def main():
                 h for h in mentioned_paths(p.read_text(encoding="utf-8"))
                 if h.startswith("references/")
                 and h != p.relative_to(skill).as_posix()
-                and (skill / h).is_file()
+                and (loc := confined_under(skill, h)) is not None
+                and loc.is_file()
             }
             if hits:
                 chains.append(f"{p.relative_to(skill).as_posix()} -> {sorted(hits)[:2]}")


### PR DESCRIPTION
Closes #588
Closes #587

## What

Adds `skills/skill-shortener` — a skill that shrinks an over-long `SKILL.md` by progressive disclosure: what the agent needs on every activation stays in the body, everything else moves behind a pointer with a load condition, or is cut.

Workflow is measure → classify → plan → approve → apply → verify, with two modes (shorten, audit-only).

## Why the verification works the way it does

The obvious "nothing was lost" check — matching baseline lines against the new body plus the extracted files — does not work. Moved sections get new headings and reflowed prose, so line matching reports false losses, and an agent quickly learns to ignore the one check that guarantees safety.

Instead the **manifest is the loss-prevention record**: Phase 1 assigns every H2 section exactly one disposition (KEEP / CUT / MOVE), and `verify_shorten.py` checks 12 facts a script can actually decide:

- manifest exhaustiveness — every baseline section classified exactly once
- every MOVE destination exists, is non-empty, and is pointed to from `SKILL.md`
- every pointer carries a load condition (a bare `see references/x.md` is relocation, not disclosure)
- no dangling pointers, no orphan reference files, no reference-to-reference chains
- both size caps (500 lines **and** 3000 words — passing one is not passing)
- `metadata.version` bumped

The semantic claim then rests on manifest exhaustiveness plus a read-back the agent performs, not on a script pretending to adjudicate prose.

## Notable design points

- **Always snapshots before the first write.** `~/.claude/skills` is not a git repo, so the standard repo-sync gate alone would hard-fail on the most common target and leave no undo path.
- **`references/behavior-preservation.md`** names the blocks a line-count optimizer deletes first: dependency preflights, loop stop conditions, per-step completion criteria, stop-and-ask gates, negative-trigger clauses.
- **`measure_skill.py`** separates always-loaded / on-trigger / on-demand footprint, so a split that saves nothing is visible.
- Orphan detection is a hard failure for `references/` but advisory for `scripts/`, since a helper module imported by a sibling script is reached through that script, not through `SKILL.md`.

## Verification

- `quick_validate.py` — clean
- `asm eval` — **96/100 (A)**, min category 8, clearing both skill-auto-improver gates
- Self-verified: the skill's own `verify_shorten.py` passes 10/10 applicable checks against itself (2 checks are baseline-relative and cannot pass on a skill that was never shortened)
- All 7 `bash` blocks pass `bash -n`
- `CI=true npm test` — 2576 passed / 79 files; pre-push hook also ran build + e2e
- Body is 233 lines / 2005 words, within both caps it enforces

Run end-to-end, the installed skill identifies 10 over-cap skills in a typical `~/.claude/skills` fleet, largest section named for each.

## Not included

`evals/evals.json` ships 7 drafted cases (3 happy-path, 2 edge, 2 negative-trigger) but the eval runs were not executed.

https://claude.ai/code/session_01T2w6YuAYMwsYtqaQ2kKwSJ