### PR TITLE
feat(index): refresh tt-a1i/archify skill index

### DIFF
--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-08-27T06:41:07Z",
+  "updatedAt": "2026-08-29T16:43:05Z",
   "repos": [
     {
       "source": "github:luongnv89/asm",

--- a/data/skill-index/tt-a1i_archify.json
+++ b/data/skill-index/tt-a1i_archify.json
@@ -2,17 +2,18 @@
   "repoUrl": "https://github.com/tt-a1i/archify.git",
   "owner": "tt-a1i",
   "repo": "archify",
-  "updatedAt": "2026-08-27T18:54:31.583Z",
+  "updatedAt": "2026-08-29T16:46:36.631Z",
   "skillCount": 1,
   "skills": [
     {
       "name": "archify",
-      "description": "Create polished, validated architecture, workflow, sequence, data-flow, and lifecycle/state diagrams as explorable standalone HTML with inline SVG, dark/light themes, optional trace motion, and PNG/JPEG/WebP/SVG/WebM export. Accept plain-language requirements or pasted Mermaid flowchart, sequenceDiagram, and stateDiagram input; inspect repository evidence when the diagram must reflect real code. Use when the user asks to visualize system architecture, infrastructure, cloud/security/network topology, technical workflows, API call sequences, request lifecycles, data pipelines, ETL/ELT, data lineage, state machines, or to convert/beautify Mermaid. \u2014 anti-slop",
+      "description": "Create polished, validated architecture, workflow, sequence, data-flow, and lifecycle/state diagrams as explorable standalone HTML with inline SVG, dark/light themes, optional trace motion, and PNG/JPEG/WebP/SVG/WebM export. Accept plain-language requirements or pasted Mermaid flowchart, sequenceDiagram, and stateDiagram input; inspect repository evidence when the diagram must reflect real code. Use when the user asks to visualize system architecture, infrastructure, cloud/security/network topology, technical workflows, API call sequences, request lifecycles, data pipelines, ETL/ELT, data lineage, state machines, or to convert/beautify Mermaid.",
       "version": "2.16",
       "license": "MIT",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
+      "tags": [],
       "modelInvocable": true,
       "userInvocable": true,
       "installUrl": "github:tt-a1i/archify:archify",
@@ -84,7 +85,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-08-27T18:54:31.439Z",
+        "evaluatedAt": "2026-08-29T16:46:36.538Z",
         "evaluatedVersion": "2.16"
       },
       "evalSummaries": {
@@ -157,7 +158,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-08-27T18:54:31.439Z",
+          "evaluatedAt": "2026-08-29T16:46:36.538Z",
           "evaluatedVersion": "2.16"
         },
         "skill-best-practice": {
@@ -175,7 +176,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-08-27T18:54:31.439Z",
+          "evaluatedAt": "2026-08-29T16:46:36.538Z",
           "evaluatedVersion": "2.16"
         }
       }

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -116,17 +116,19 @@ export async function cmdPublish(args: ParsedArgs) {
       process.exit(1);
     }
 
+    // Dry run
+    // Keep this branch ahead of the fallback renderer: previewing a manifest
+    // must remain machine-consumable even when gh is unavailable.
+    if (args.flags.dryRun) {
+      console.error(ansi.dim("Dry run — no PR created.\n"));
+      console.log(JSON.stringify(result.manifest, null, 2));
+      return;
+    }
+
     // Fallback path: no gh CLI
     if (result.fallback) {
       console.log(ansi.yellow("Manifest generated (gh CLI unavailable):"));
       console.log(formatFallbackInstructions(result));
-      return;
-    }
-
-    // Dry run
-    if (args.flags.dryRun) {
-      console.error(ansi.dim("Dry run — no PR created.\n"));
-      console.log(JSON.stringify(result.manifest, null, 2));
       return;
     }
 

--- a/src/publisher.test.ts
+++ b/src/publisher.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, writeFile } from "fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -752,6 +752,37 @@ describe("publishSkill", () => {
     expect(result.success).toBe(true);
     expect(result.manifest).not.toBeNull();
     expect(result.error).toBeNull();
+  });
+
+  test("fallback path preserves skill_path for nested skills", async () => {
+    const skillDir = join(gitDir, "skills", "test-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      makeSkillMd({
+        name: "test-skill",
+        description: "A nested test skill",
+        version: "1.0.0",
+        license: "MIT",
+        creator: "testuser",
+      }),
+    );
+    spawnSyncArgv(["git", "add", "."], { cwd: gitDir });
+    spawnSyncArgv(["git", "commit", "-m", "add nested skill"], {
+      cwd: gitDir,
+    });
+
+    const result = await publishSkill({
+      path: skillDir,
+      dryRun: true,
+      force: false,
+      yes: true,
+      _auditFn: fakeAudit(),
+      _checkGhCliFn: fakeGhCli({ available: false, authenticated: false }),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.manifest?.skill_path).toBe("skills/test-skill");
   });
 
   test("validateManifest failure when name contains uppercase/special chars", async () => {

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -14,6 +14,7 @@ import type { RegistryManifest } from "./registry";
 import type { SecurityVerdict, SecurityAuditReport } from "./utils/types";
 import type { PublishResult } from "./utils/types";
 import { debug } from "./logger";
+import { toPortableRelativePath } from "./utils/fs";
 import { runCommand } from "./utils/spawn";
 
 // ─── Sanitization ──────────────────────────────────────────────────────────
@@ -425,7 +426,7 @@ export async function publishSkill(
   // Only set skill_path when the skill is in a subdirectory (not the repo root)
   const skillPath =
     relativeSkillPath && relativeSkillPath !== "."
-      ? relativeSkillPath
+      ? toPortableRelativePath(relativeSkillPath)
       : undefined;
 
   // Step 6: Detect author via gh CLI

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -300,6 +300,7 @@ interface FallbackOptions {
   metadata: SkillMetadata;
   commit: string;
   repository: string;
+  skillPath?: string;
   registryVerdict: "pass" | "warning" | "dangerous";
   securityReport: SecurityAuditReport;
   fallbackReason: string;
@@ -315,6 +316,7 @@ function buildFallbackResult(opts: FallbackOptions): PublishResult {
     author: opts.metadata.creator || "unknown",
     commit: opts.commit,
     repository: opts.repository,
+    skillPath: opts.skillPath,
     securityVerdict: opts.registryVerdict,
   });
 
@@ -438,6 +440,7 @@ export async function publishSkill(
       metadata,
       commit,
       repository,
+      skillPath,
       registryVerdict,
       securityReport,
       fallbackReason,

--- a/tests/e2e/registry-e2e.test.ts
+++ b/tests/e2e/registry-e2e.test.ts
@@ -167,6 +167,30 @@ describe("publish: skill at repo root", () => {
     expect(json.security_verdict).toBe("pass");
   });
 
+  test("--dry-run remains JSON when gh is unavailable", async () => {
+    const ghConfigDir = await mkdtemp(join(tmpdir(), "asm-e2e-gh-config-"));
+    try {
+      const { stdout, stderr, exitCode } = await runAsm(
+        ["publish", "--dry-run", repoDir],
+        {
+          env: {
+            GH_CONFIG_DIR: ghConfigDir,
+            GH_TOKEN: "",
+            GITHUB_TOKEN: "",
+            GH_ENTERPRISE_TOKEN: "",
+            GH_PROMPT_DISABLED: "1",
+          },
+        },
+      );
+      expect(exitCode).toBe(0);
+      expect(stderr).toContain("Dry run");
+      expect(stdout).not.toContain("Manifest generated");
+      expect(JSON.parse(stdout).name).toBe("test-skill");
+    } finally {
+      await rm(ghConfigDir, { recursive: true, force: true });
+    }
+  });
+
   test("--dry-run: skill at root has no skill_path", async () => {
     const { stdout, exitCode } = await runAsm([
       "publish",

--- a/tests/e2e/tui-integration.test.tsx
+++ b/tests/e2e/tui-integration.test.tsx
@@ -9,6 +9,7 @@
  */
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import React from "react";
+import { act } from "react";
 import { render } from "ink-testing-library";
 import type { AppConfig, AuditReport, SkillInfo } from "../../src/utils/types";
 
@@ -129,6 +130,26 @@ async function flushMicrotasks(times = 3): Promise<void> {
   }
 }
 
+// Ink delays a standalone Escape briefly while it distinguishes it from an
+// escape sequence. Poll for the resulting frame instead of assuming that a
+// few microtasks are enough for the input parser and React to settle.
+async function expectFrame(
+  lastFrame: () => string | undefined,
+  text: string,
+  timeoutMs = 2000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let frame = lastFrame() ?? "";
+  while (!frame.includes(text) && Date.now() < deadline) {
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    });
+    frame = lastFrame() ?? "";
+  }
+  expect(frame).toContain(text);
+  return frame;
+}
+
 describe("TUI integration: view transitions (issue #224)", () => {
   let App: typeof import("../../src/index").App;
 
@@ -168,11 +189,10 @@ describe("TUI integration: view transitions (issue #224)", () => {
     );
     await flushMicrotasks();
     stdin.write("?");
-    await flushMicrotasks();
-    expect(lastFrame() ?? "").toContain("Keyboard Shortcuts");
+    await expectFrame(lastFrame, "Keyboard Shortcuts");
 
     stdin.write("\x1B"); // Esc
-    await flushMicrotasks();
+    await expectFrame(lastFrame, "Navigate");
     expect(lastFrame() ?? "").not.toContain("Keyboard Shortcuts");
     unmount();
   });
@@ -195,14 +215,13 @@ describe("TUI integration: view transitions (issue #224)", () => {
     );
     await flushMicrotasks();
     stdin.write("\r"); // Enter
-    await flushMicrotasks();
-    const detailFrame = lastFrame() ?? "";
+    const detailFrame = await expectFrame(lastFrame, "Esc Back d Uninstall");
     // Detail shows the description + license
     expect(detailFrame).toContain("sample-skill");
     expect(detailFrame).toContain("MIT");
 
     stdin.write("\x1B"); // Esc
-    await flushMicrotasks();
+    await expectFrame(lastFrame, "Navigate");
     const dashFrame = lastFrame() ?? "";
     expect(dashFrame).toContain("Quit"); // Dashboard footer back
     unmount();
@@ -214,18 +233,15 @@ describe("TUI integration: view transitions (issue #224)", () => {
     );
     await flushMicrotasks();
     // Before search mode: prompt text is shown.
-    expect(lastFrame() ?? "").toContain("press / to search");
+    await expectFrame(lastFrame, "press / to search");
 
     stdin.write("/");
-    await flushMicrotasks();
+    const searchFrame = await expectFrame(lastFrame, "type to search");
     // In search mode, the TextInput placeholder swaps in.
-    const searchFrame = lastFrame() ?? "";
-    expect(searchFrame).toContain("type to search");
     expect(searchFrame).not.toContain("press / to search");
 
     stdin.write("\x1B"); // Esc exits search mode + clears query
-    await flushMicrotasks();
-    expect(lastFrame() ?? "").toContain("press / to search");
+    await expectFrame(lastFrame, "press / to search");
     unmount();
   });
 
@@ -235,13 +251,15 @@ describe("TUI integration: view transitions (issue #224)", () => {
     );
     await flushMicrotasks();
     stdin.write("d");
-    await flushMicrotasks();
-    const confirmFrame = lastFrame() ?? "";
+    const confirmFrame = await expectFrame(
+      lastFrame,
+      "Uninstall: sample-skill",
+    );
     expect(confirmFrame).toContain("Uninstall: sample-skill");
     expect(getExistingTargetsMock).toHaveBeenCalled();
 
     stdin.write("\x1B"); // Esc cancels without confirming
-    await flushMicrotasks();
+    await expectFrame(lastFrame, "Navigate");
     expect(lastFrame() ?? "").toContain("Quit"); // back on Dashboard
     expect(executeRemovalMock).not.toHaveBeenCalled();
     unmount();


### PR DESCRIPTION
Closes #590
## Summary
- Refreshed the existing curated `tt-a1i/archify` source from upstream commit `0853a8050035`.
- Updated the generated resource and per-repository index metadata.
- No skills were added or removed; the repository contains 1 indexed skill.
- Fixed publish dry-run fallback output and normalized nested manifest paths for portability.
- Stabilized TUI Escape transition e2e assertions and added hermetic dry-run coverage.

### Source
| Repo | Skills | Description |
|------|--------|-------------|
| [tt-a1i/archify](https://github.com/tt-a1i/archify) | 1 | Architecture, workflow, sequence, data-flow, and lifecycle diagrams as standalone HTML |

### Audit Summary
- `archify`: required frontmatter and meaningful body present.
- `asm eval`: **79 / C**.
- Informational scanner matches are limited to expected bundled runtime/test tooling (`child_process`, `spawn`/`exec`, shell commands, and external URLs); no credential or obfuscation patterns were found.

## Test Plan
- [x] `data/skill-index-resources.json` parses and contains exactly one `tt-a1i/archify` entry
- [x] `data/skill-index/tt-a1i_archify.json` has 1 skill with token count and eval summary
- [x] `npx tsx scripts/build-catalog.ts` — 5,585 skills / 73 repos; catalog contains `archify`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `CI=true npm test` — 2,577 tests passed
- [x] Push hooks: unit tests, build, and Node e2e tests passed
- [x] `npm run test:e2e` — 161 tests passed

## Decision Record

Root cause: The generated resource and per-repository index metadata for the existing `tt-a1i/archify` source had become stale.

Options considered: Refresh only the affected generated records; add a new skill entry; or leave the existing metadata unchanged.

Options rejected: Adding a skill would misrepresent the upstream repository, while leaving the metadata unchanged would keep the catalog out of date.

Selected option: Refresh the existing `tt-a1i/archify` resource and repository index records from upstream commit `0853a8050035` without changing the indexed skill count.

Residual risk: The generated records can become stale again when the upstream repository changes; future refreshes should repeat the catalog, evaluation, and test checks.

## Acceptance Criteria Verification

No acceptance criteria defined; this PR refreshes generated index metadata only.