### PR TITLE
feat(website): sort catalog by popularity and lead cards with score + stars

### DIFF
--- a/website-src/src/__tests__/filter-sort.test.js
+++ b/website-src/src/__tests__/filter-sort.test.js
@@ -18,6 +18,7 @@ const mk = (p) => ({
   verified: !!p.verified,
   hasTools: !!p.hasTools,
   tokenCount: p.tokenCount,
+  stars: p.stars,
   evalSummary: p.evalSummary,
   featured: !!p.featured,
   allowedTools: p.allowedTools,
@@ -33,12 +34,48 @@ const base = () => ({
 });
 
 describe("applyFilters", () => {
-  it("returns all when no filters active and sorts by name", () => {
+  it("returns all when no filters active and sorts by stars (most popular)", () => {
     const skills = [
-      mk({ id: "b", name: "beta" }),
-      mk({ id: "a", name: "alpha" }),
+      mk({ id: "b", name: "beta", stars: 10 }),
+      mk({ id: "a", name: "alpha", stars: 5 }),
+      mk({ id: "c", name: "charlie", stars: 500 }),
     ];
     const out = applyFilters(skills, base());
+    expect(out.map((s) => s.id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("sort: stars — ties break by score desc, then name; missing stars sink", () => {
+    const skills = [
+      mk({ id: "nostars", name: "aaa" }),
+      mk({
+        id: "low",
+        name: "zzz",
+        stars: 100,
+        evalSummary: { overallScore: 60, grade: "C" },
+      }),
+      mk({
+        id: "high",
+        name: "yyy",
+        stars: 100,
+        evalSummary: { overallScore: 95, grade: "A" },
+      }),
+      mk({
+        id: "same",
+        name: "bbb",
+        stars: 100,
+        evalSummary: { overallScore: 95, grade: "A" },
+      }),
+    ];
+    const out = applyFilters(skills, { ...base(), sort: "stars" });
+    expect(out.map((s) => s.id)).toEqual(["same", "high", "low", "nostars"]);
+  });
+
+  it("sort: name — alphabetical regardless of stars", () => {
+    const skills = [
+      mk({ id: "b", name: "beta", stars: 500 }),
+      mk({ id: "a", name: "alpha", stars: 5 }),
+    ];
+    const out = applyFilters(skills, { ...base(), sort: "name" });
     expect(out.map((s) => s.id)).toEqual(["a", "b"]);
   });
 
@@ -256,8 +293,11 @@ describe("anyFilterActive", () => {
   it("returns true when sort='grade' with no search (non-default)", () => {
     expect(anyFilterActive({ ...base(), sort: "grade" })).toBe(true);
   });
-  it("returns false when sort='name' with no search (matches default)", () => {
-    expect(anyFilterActive({ ...base(), sort: "name" })).toBe(false);
+  it("returns false when sort='stars' with no search (matches default)", () => {
+    expect(anyFilterActive({ ...base(), sort: "stars" })).toBe(false);
+  });
+  it("returns true when sort='name' with no search (non-default)", () => {
+    expect(anyFilterActive({ ...base(), sort: "name" })).toBe(true);
   });
   it("returns true when sort='relevance' with no search (non-default)", () => {
     expect(anyFilterActive({ ...base(), sort: "relevance" })).toBe(true);
@@ -270,8 +310,8 @@ describe("anyFilterActive", () => {
 });
 
 describe("defaultSort", () => {
-  it("is relevance when search active, name otherwise", () => {
-    expect(defaultSort("")).toBe("name");
+  it("is relevance when search active, stars otherwise", () => {
+    expect(defaultSort("")).toBe("stars");
     expect(defaultSort("foo")).toBe("relevance");
   });
 });

--- a/website-src/src/__tests__/skill-card.test.jsx
+++ b/website-src/src/__tests__/skill-card.test.jsx
@@ -105,6 +105,15 @@ describe("SkillCard — storefront anatomy", () => {
     ).toBeTruthy();
   });
 
+  it("does not render a name initial in the tile (score + stars lead instead)", () => {
+    const { container } = renderCard({ ...baseSkill, stars: 42 });
+    expect(container.querySelector(".shop-initial")).toBeNull();
+    const stats = container.querySelector(".shop-tile .shop-tile-stats");
+    expect(stats).toBeTruthy();
+    expect(stats.querySelector(".shop-sticker")).toBeTruthy();
+    expect(stats.querySelector(".shop-stars")).toBeTruthy();
+  });
+
   it("shows the eval score as the price sticker when present", () => {
     const { container } = renderCard({
       ...baseSkill,
@@ -123,11 +132,11 @@ describe("SkillCard — storefront anatomy", () => {
   });
 });
 
-describe("SkillCard — GitHub star badge (repo trust signal)", () => {
+describe("SkillCard — GitHub star stat in the tile (repo trust signal)", () => {
   afterEach(() => cleanup());
 
   /**
-   * Helper to find the star badge by its title attribute, which is unique
+   * Helper to find the star stat by its title attribute, which is unique
    * per skill and never collides with skill name / owner / repo text.
    */
   function getStarBadge(container) {

--- a/website-src/src/components/SkillCard.jsx
+++ b/website-src/src/components/SkillCard.jsx
@@ -14,8 +14,11 @@ import {
 /**
  * Product card for a skill in the storefront grid.
  *
- * The tile on top stands in for a product photo: a hatched panel with
- * the skill's initial and a score "sticker". The title is a stretched
+ * The tile on top stands in for a product photo: a hatched panel that
+ * leads with the two numbers a shopper compares first — the asm eval
+ * score (the "price tag") and the source repo's GitHub stars (social
+ * proof). Featured/official flags sit in the tile's top corner. The
+ * title is a stretched
  * link (see `.shop-link::after` in shop.css) so the whole card opens
  * the product page while the cart button stays independently
  * clickable. `locationSearch` is preserved on the link so active
@@ -46,8 +49,7 @@ function SkillCard({
   // (plugin-bundle variants — issue #241) surface the distinguishing
   // relPath so the card is no longer visually identical to its siblings.
   const collisionPath = hasNameCollision ? skillRelPath(skill.installUrl) : "";
-  const initial =
-    (skill.name || "?").replace(/^[^a-z0-9]+/i, "").charAt(0) || "?";
+  const stars = formatStars(skill.stars);
   const tone = hashTone(skill.id || skill.name);
 
   return (
@@ -57,25 +59,39 @@ function SkillCard({
       data-skill-id={skill.id}
     >
       <div className="shop-tile" data-tone={tone}>
-        <span className="shop-initial" aria-hidden="true">
-          {initial}
-        </span>
-        {score ? (
-          <span
-            className="shop-sticker"
-            data-grade={score.grade}
-            title={`asm eval score: ${score.overallScore}/100 (grade ${score.grade})`}
-          >
-            {score.overallScore}
-            <small>/100 · {score.grade}</small>
-          </span>
-        ) : (
-          <span className="shop-sticker" title="No asm eval score yet">
-            <small>not scored</small>
-          </span>
+        {(isFeatured || isOfficial) && (
+          <div className="shop-tile-flags">
+            {isFeatured && <Badge tone="featured">★ featured</Badge>}
+            {isOfficial && <Badge tone="official">official</Badge>}
+          </div>
         )}
-        {isFeatured && <Badge tone="featured">★ featured</Badge>}
-        {isOfficial && <Badge tone="official">official</Badge>}
+        <div className="shop-tile-stats">
+          {score ? (
+            <span
+              className="shop-sticker"
+              data-grade={score.grade}
+              title={`asm eval score: ${score.overallScore}/100 (grade ${score.grade})`}
+            >
+              <b>{score.overallScore}</b>
+              <small>/100 · {score.grade}</small>
+            </span>
+          ) : (
+            <span className="shop-sticker" title="No asm eval score yet">
+              <b aria-hidden="true">–</b>
+              <small>not scored</small>
+            </span>
+          )}
+          {stars && (
+            <span
+              className="shop-stars"
+              title={`${skill.owner}/${skill.repo} GitHub stars`}
+            >
+              <Star aria-hidden="true" />
+              <b>{stars}</b>
+              <small>stars</small>
+            </span>
+          )}
+        </div>
       </div>
 
       <div className="flex flex-1 flex-col gap-1.5 px-3.5 pt-3 pb-3">
@@ -116,18 +132,6 @@ function SkillCard({
           {typeof skill.tokenCount === "number" && (
             <Badge tone="tokens" title="Estimated tokens in SKILL.md">
               {formatTokens(skill.tokenCount)}
-            </Badge>
-          )}
-          {typeof skill.stars === "number" && skill.stars > 0 && (
-            <Badge
-              tone="tokens"
-              title={`${skill.owner}/${skill.repo} GitHub stars`}
-            >
-              <Star
-                className="h-3 w-3 fill-[var(--fg-dim)]"
-                aria-hidden="true"
-              />
-              {formatStars(skill.stars)}
             </Badge>
           )}
           {usesTools && (

--- a/website-src/src/lib/filter-sort.js
+++ b/website-src/src/lib/filter-sort.js
@@ -11,7 +11,7 @@ import { licenseBucket, skillSource } from "./utils.js";
  * @param {Set<string>} state.activeCategories
  * @param {string} state.activeRepo "all" or "owner/repo".
  * @param {Record<string, Set<string>>} state.activeFacets
- * @param {string} state.sort "relevance" | "name" | "grade" | "tokens-asc" | "tokens-desc".
+ * @param {string} state.sort "stars" | "relevance" | "name" | "grade" | "tokens-asc" | "tokens-desc".
  * @param {object | null} options Optional MiniSearch results.
  * @param {Map<string, number> | null} options.scoreById Score per skill id.
  */
@@ -98,13 +98,27 @@ export function applyFilters(skills, state, options = {}) {
     results = scored.map((r) => r.skill);
   }
 
-  const hasSearch = state.searchQuery && state.searchQuery.trim();
-  const sortMode = state.sort || (hasSearch ? "relevance" : "name");
+  const sortMode = state.sort || defaultSort(state.searchQuery);
 
-  if (sortMode === "name" || (sortMode === "relevance" && !scored)) {
+  if (sortMode === "name") {
     results = results.slice().sort((a, b) => {
       const f = featuredFirst(a, b);
       if (f !== 0) return f;
+      return a.name.localeCompare(b.name);
+    });
+  } else if (sortMode === "stars" || (sortMode === "relevance" && !scored)) {
+    // "Most popular": the source repo's GitHub stars, best eval score as
+    // the tiebreak so skills from the same repo still rank meaningfully,
+    // then name. Missing/zero stars sink to the bottom.
+    results = results.slice().sort((a, b) => {
+      const f = featuredFirst(a, b);
+      if (f !== 0) return f;
+      const ast = typeof a.stars === "number" ? a.stars : 0;
+      const bst = typeof b.stars === "number" ? b.stars : 0;
+      if (ast !== bst) return bst - ast;
+      const as = a.evalSummary ? a.evalSummary.overallScore : -1;
+      const bs = b.evalSummary ? b.evalSummary.overallScore : -1;
+      if (as !== bs) return bs - as;
       return a.name.localeCompare(b.name);
     });
   } else if (sortMode === "grade") {
@@ -176,16 +190,14 @@ export function anyFilterActive(state) {
   }
   // Check sort state — when sort differs from the search-aware default,
   // the "Clear all" button should appear (issue #526).
-  const expectedDefault =
-    state.searchQuery && state.searchQuery.trim() ? "relevance" : "name";
-  if (state.sort && state.sort !== expectedDefault) return true;
+  if (state.sort && state.sort !== defaultSort(state.searchQuery)) return true;
   return false;
 }
 
 /**
- * Default sort depends on whether search is active. Preserves legacy UX:
- * no search → alphabetical; search active → relevance scoring.
+ * Default sort depends on whether search is active: no search → most
+ * popular (source-repo GitHub stars); search active → relevance scoring.
  */
 export function defaultSort(searchQuery) {
-  return searchQuery && searchQuery.trim() ? "relevance" : "name";
+  return searchQuery && searchQuery.trim() ? "relevance" : "stars";
 }

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -376,9 +376,10 @@ export default function CatalogPage() {
                 aria-label="Sort skills"
                 className="rounded-md border border-[var(--border)] bg-[var(--bg-input)] px-2 py-1.5 text-xs text-[var(--fg)]"
               >
+                <option value="stars">Most popular</option>
                 <option value="relevance">Relevance</option>
-                <option value="name">Name A–Z</option>
                 <option value="grade">Best score</option>
+                <option value="name">Name A–Z</option>
                 <option value="tokens-asc">Smallest first</option>
                 <option value="tokens-desc">Largest first</option>
               </select>

--- a/website-src/src/shop.css
+++ b/website-src/src/shop.css
@@ -117,16 +117,16 @@
   z-index: 1;
 }
 
-/* The "product photo": a hatched tile with a large serif initial. The
- * hatch direction rotates per card (data-tone 0–3) so a grid of tiles
- * reads as a set rather than a repeat. */
+/* The "product photo": a hatched tile that leads with the two numbers a
+ * shopper compares first — eval score (the price tag) and repo stars
+ * (social proof). The hatch direction rotates per card (data-tone 0–3)
+ * so a grid of tiles reads as a set rather than a repeat. */
 .shop-tile {
   position: relative;
   height: 96px;
   display: flex;
   align-items: flex-end;
-  gap: 6px;
-  padding: 10px 12px;
+  padding: 10px 14px 12px;
   background: color-mix(in srgb, var(--brand) 7%, var(--bg-input));
   border-bottom: 1px solid var(--border);
   overflow: hidden;
@@ -152,48 +152,88 @@
 .shop-tile[data-tone="3"] {
   --shop-hatch: 0deg;
 }
-.shop-initial {
+.shop-tile-flags {
   position: absolute;
-  right: 14px;
-  top: -14px;
-  font-family: "Instrument Serif", var(--shop-serif);
-  font-style: italic;
-  font-size: 92px;
-  line-height: 1;
-  color: color-mix(in srgb, var(--brand) 55%, var(--fg-muted));
-  opacity: 0.45;
-  user-select: none;
-  transition:
-    opacity 240ms ease,
-    transform 320ms var(--shop-ease);
+  top: 10px;
+  left: 14px;
+  display: flex;
+  gap: 4px;
 }
-.shop-card:hover .shop-initial {
-  opacity: 0.8;
+.shop-tile-stats {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  min-width: 0;
+}
+/* Score — the "price tag". Big serif numeral, mono denominator. */
+.shop-sticker {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  min-width: 0;
+  font-family: var(--shop-mono);
+  color: var(--fg);
+  transition: transform 320ms var(--shop-ease);
+}
+.shop-sticker b {
+  font-family: var(--shop-serif);
+  font-weight: 500;
+  font-size: 40px;
+  line-height: 0.85;
+  letter-spacing: -0.04em;
+  font-variation-settings: "opsz" 144;
+}
+.shop-sticker small {
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+.shop-sticker[data-grade="A"] b {
+  color: var(--brand);
+}
+.shop-sticker[data-grade="B"] b {
+  color: color-mix(in srgb, var(--brand) 55%, var(--fg));
+}
+.shop-sticker:not([data-grade]) b {
+  color: var(--fg-muted);
+  font-weight: 400;
+}
+.shop-card:hover .shop-sticker {
   transform: translateY(-2px);
 }
-/* Score sticker — the "price tag" */
-.shop-sticker {
-  position: relative;
+/* Stars — social proof, right-aligned against the score. */
+.shop-stars {
   display: inline-flex;
   align-items: baseline;
   gap: 4px;
-  padding: 3px 8px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-  background: var(--bg-card);
+  flex-shrink: 0;
   font-family: var(--shop-mono);
-  font-size: 11px;
-  font-weight: 600;
   color: var(--fg);
 }
-.shop-sticker small {
+.shop-stars svg {
+  width: 13px;
+  height: 13px;
+  align-self: center;
+  color: color-mix(in srgb, var(--brand) 70%, var(--fg));
+  fill: currentColor;
+}
+.shop-stars b {
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.shop-stars small {
   font-size: 9.5px;
   font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
   color: var(--fg-muted);
-}
-.shop-sticker[data-grade="A"] {
-  border-color: color-mix(in srgb, var(--brand) 60%, var(--border));
-  color: var(--brand);
 }
 
 .shop-name {

--- a/website-src/src/shop.css
+++ b/website-src/src/shop.css
@@ -529,11 +529,13 @@
     animation: none;
   }
   .shop-card,
-  .shop-initial {
+  .shop-initial,
+  .shop-sticker {
     transition: none;
   }
   .shop-card:hover,
-  .shop-card:focus-within {
+  .shop-card:focus-within,
+  .shop-card:hover .shop-sticker {
     transform: none;
   }
 }


### PR DESCRIPTION
Closes #600

## What

Catalog (listing) page updates:

- **Default sort is "Most popular"** — source-repo GitHub stars desc, eval score desc, then name. Search still defaults to relevance. The option is first in the Sort menu and \`anyFilterActive\` treats it as the clean state.
- **Score is the hero number** — the pill sticker became a large serif numeral (40px, brand green for grade A) with a small mono "/100 · B" beside it.
- **Tile header shows score + stars** instead of the skill's first letter. Featured/official flags move to the tile's top-left corner; the duplicate star badge leaves the meta row. Unscored skills show "– not scored".

## Screenshots

Verified in headless Chrome at 1280 / 768 / 375, light and dark, no horizontal overflow.

## Tests

- \`filter-sort.test.js\`: new default, stars sort (ties → score → name, missing stars sink), name sort still alphabetical, \`anyFilterActive\` / \`defaultSort\` updated.
- \`skill-card.test.jsx\`: tile renders score + stars stats and no initial; star tests retained.
- \`CI=true npm test\`: 2606 passed. \`lint:site\`: 0 errors (2 pre-existing warnings in untouched files).

## Related

#598 — 16 of 73 repos are published with 0 stars (unauthenticated star fetch is rate-limited). Those repos sink to the bottom under the new default until that is fixed.

https://claude.ai/code/session_01VdxoLMUNjJY466u4AkNSdL