### PR TITLE
fix(cli): resolve provider before bundle install confirm (#602)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -7,6 +7,7 @@ import {
   beforeEach,
   afterEach,
   beforeAll,
+  vi,
 } from "vitest";
 import {
   parseArgs,
@@ -14,6 +15,9 @@ import {
   printImportConflictDiffs,
   promptForImportConflict,
 } from "./cli";
+import { cmdBundle } from "./commands/bundle";
+import * as shared from "./commands/shared";
+import * as checkboxPickerMod from "./utils/checkbox-picker";
 import type { ImportConflict, ImportResult } from "./utils/types";
 import { compareSemver } from "./scanner";
 import { join, dirname } from "path";
@@ -5347,6 +5351,191 @@ describe("CLI integration: bundle", () => {
 
       // Clean up: uninstall the skill
       await runCLI("uninstall", "installable-skill", "--yes");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("bundle install TTY confirm without --tool does not abort as non-interactive", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "cli-bundle-tty-"));
+    const origIsTTY = process.stdin.isTTY;
+    const readLineSpy = vi.spyOn(shared, "readLine").mockResolvedValue("y");
+    const pickerSpy = vi
+      .spyOn(checkboxPickerMod, "checkboxPicker")
+      .mockResolvedValue([0]);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit);
+    const logs: string[] = [];
+    const logSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation((msg?: unknown) => {
+        logs.push(String(msg ?? ""));
+      });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+    try {
+      const skillDir = join(tmpDir, "tty-bundle-skill");
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, "SKILL.md"),
+        `---\nname: tty-bundle-skill\nversion: 1.0.0\n---\n# TTY Bundle Skill\nA test skill for TTY bundle install.\n`,
+      );
+      const bundlePath = join(tmpDir, "tty-bundle.json");
+      await writeFile(
+        bundlePath,
+        JSON.stringify({
+          version: 1,
+          name: "tty-bundle",
+          description: "TTY bundle install",
+          author: "tester",
+          createdAt: new Date().toISOString(),
+          skills: [
+            {
+              name: "tty-bundle-skill",
+              installUrl: skillDir,
+              description: "TTY Bundle Skill",
+              version: "1.0.0",
+            },
+          ],
+        }),
+      );
+
+      const args = parseArgs([
+        "node",
+        "script.ts",
+        "bundle",
+        "install",
+        bundlePath,
+        "--json",
+        "--force",
+      ]);
+      await cmdBundle(args);
+
+      const jsonOut =
+        logs.find((l) => l.includes("bundleName")) ?? logs.join("");
+      const parsed = JSON.parse(jsonOut);
+      expect(parsed.bundleName).toBe("tty-bundle");
+      expect(parsed.installed).toBe(1);
+      expect(parsed.failed).toBe(0);
+      expect(parsed.results[0].status).toBe("installed");
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(pickerSpy).toHaveBeenCalled();
+      expect(readLineSpy).toHaveBeenCalled();
+      expect(pickerSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        readLineSpy.mock.invocationCallOrder[0],
+      );
+
+      await runCLI("uninstall", "tty-bundle-skill", "--yes");
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: origIsTTY,
+        configurable: true,
+      });
+      readLineSpy.mockRestore();
+      pickerSpy.mockRestore();
+      exitSpy.mockRestore();
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("bundle install without --tool in non-TTY requires provider before confirm", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "cli-bundle-nontty-"));
+    try {
+      const skillDir = join(tmpDir, "nontty-skill");
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, "SKILL.md"),
+        `---\nname: nontty-skill\nversion: 1.0.0\n---\n# Non-TTY Skill\n`,
+      );
+      const bundlePath = join(tmpDir, "nontty-bundle.json");
+      await writeFile(
+        bundlePath,
+        JSON.stringify({
+          version: 1,
+          name: "nontty-bundle",
+          description: "Non-TTY",
+          author: "tester",
+          createdAt: new Date().toISOString(),
+          skills: [
+            {
+              name: "nontty-skill",
+              installUrl: skillDir,
+              description: "Non-TTY Skill",
+              version: "1.0.0",
+            },
+          ],
+        }),
+      );
+
+      const { stderr, exitCode } = await runCLI(
+        "bundle",
+        "install",
+        bundlePath,
+        "--json",
+        "--force",
+      );
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("--tool (or --provider) is required");
+      expect(stderr).not.toContain("Install all skills from this bundle?");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("bundle install accepts --tool all", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "cli-bundle-all-"));
+    try {
+      const skillDir = join(tmpDir, "all-tool-skill");
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, "SKILL.md"),
+        `---\nname: all-tool-skill\nversion: 1.0.0\n---\n# All Tool Skill\n`,
+      );
+      const bundlePath = join(tmpDir, "all-tool-bundle.json");
+      await writeFile(
+        bundlePath,
+        JSON.stringify({
+          version: 1,
+          name: "all-tool-bundle",
+          description: "All-tool bundle",
+          author: "tester",
+          createdAt: new Date().toISOString(),
+          skills: [
+            {
+              name: "all-tool-skill",
+              installUrl: skillDir,
+              description: "All Tool Skill",
+              version: "1.0.0",
+            },
+          ],
+        }),
+      );
+
+      const { stdout, exitCode } = await runCLI(
+        "bundle",
+        "install",
+        bundlePath,
+        "--json",
+        "--force",
+        "--tool",
+        "all",
+      );
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.bundleName).toBe("all-tool-bundle");
+      expect(parsed.installed).toBe(1);
+      expect(parsed.failed).toBe(0);
+      expect(parsed.results[0].status).toBe("installed");
+
+      await runCLI("uninstall", "all-tool-skill", "--yes");
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -10,6 +10,7 @@ import {
   cloneToTemp,
   validateSkill,
   executeInstall,
+  executeInstallAllProviders,
   cleanupTemp,
   resolveProvider,
   buildInstallPlan,
@@ -230,6 +231,13 @@ export async function cmdBundle(args: ParsedArgs) {
         );
       }
 
+      const config = await loadConfig();
+      const { provider, allProviders } = await resolveProvider(
+        config,
+        args.flags.provider,
+        !!process.stdin.isTTY,
+      );
+
       // Confirm
       if (!args.flags.yes && process.stdin.isTTY) {
         process.stderr.write(
@@ -248,13 +256,6 @@ export async function cmdBundle(args: ParsedArgs) {
         status: "installed" | "skipped" | "failed";
         reason?: string;
       }> = [];
-
-      const config = await loadConfig();
-      const { provider } = await resolveProvider(
-        config,
-        args.flags.provider,
-        false, // non-interactive for batch
-      );
 
       const installScope: "global" | "project" =
         args.flags.scope === "global" || args.flags.scope === "project"
@@ -333,7 +334,11 @@ export async function cmdBundle(args: ParsedArgs) {
               throw conflictErr;
             }
 
-            await executeInstall(plan);
+            if (allProviders) {
+              await executeInstallAllProviders(plan, allProviders);
+            } else {
+              await executeInstall(plan);
+            }
             results.push({ name: skill.name, status: "installed" });
             console.error(`    ${ansi.green("+++")} ${skill.name} installed`);
           } finally {


### PR DESCRIPTION
Closes #602

## Summary

`asm bundle install` was resolving the target tool with `isTTY` hardcoded to `false` *after* the user confirmed `Install all skills from this bundle?`. On a TTY with several providers enabled and no `--tool` flag, that threw `--tool (or --provider) is required in non-interactive mode` and installed nothing. Provider selection now runs first (real TTY, matching `asm install`), then the confirm prompt; `--tool all` installs via `executeInstallAllProviders`.

## Approach

Resolve provider before bundle confirm — call `resolveProvider(config, flags.provider, !!process.stdin.isTTY)` before the y-confirm, keep `allProviders`, and use `executeInstallAllProviders` when it is set.

## Decision Record

- **Root cause:** `cmdBundle` install confirmed on a TTY, then called `resolveProvider(..., false)`. With multiple enabled providers and no `--tool`/`--provider`, `resolveProvider` threw the non-interactive error before the per-skill install loop, so failures were not recorded per skill.
- **Options considered:** Option 1 — Resolve provider before bundle confirm
- **Options rejected:** n/a — trivial change, direct plan (light profile)
- **Selected option:** Option 1 — Resolve provider before bundle confirm
- **Residual risk:** The TTY regression mocks `checkboxPicker` and `readLine`; a live multi-provider picker session is not e2e-tested. Non-TTY without `--tool` still errors, which is required.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle
- **Reproduction:** `npx vitest run src/cli.test.ts -t "bundle install TTY confirm without --tool"` confirmed red (`Error: --tool (or --provider) is required in non-interactive mode` after the confirm prompt) → regression test `src/cli.test.ts` (`bundle install TTY confirm without --tool does not abort as non-interactive`)

Analyzed at: `fix/602-bundle-install-requiring-tool-in-non` @ 92d842f (2026-09-04)

## Changes

| File | Change |
|------|--------|
| `src/commands/bundle.ts` | Resolve provider with real TTY before confirm; honor `allProviders` |
| `src/cli.test.ts` | TTY confirm-without-`--tool` regression; non-TTY still requires `--tool` before confirm; `--tool all` still installs |

## Test Results

- Unit tests: 2626 passed
- Integration tests: skipped — no separate integration framework
- E2e tests: passed (pre-push hook)
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| After answering `y` to `Install all skills from this bundle?`, `asm bundle install` of a local `.bundle.json` does not abort with `--tool (or --provider) is required in non-interactive mode` | pass | Verified red: `npx vitest run src/cli.test.ts -t "bundle install TTY confirm without --tool"` → fixed → `src/cli.test.ts` (`bundle install TTY confirm without --tool does not abort as non-interactive`) |
| The skills listed in the reporter's bundle either install successfully or each reports its own install result | pass | Per-skill try/catch around `executeInstall` / `executeInstallAllProviders` unchanged; TTY regression installs 1/1; resolveProvider throw no longer happens after confirm |
| When `--tool` / `--provider` is required, that requirement is stated or collected before the install-confirmation prompt | pass | Picker invocation order asserted before `readLine`; non-TTY test expects the `--tool` error and that `Install all skills from this bundle?` is absent |
| The same command still accepts `--tool`, `--provider`, and `all` when those flags are passed | pass | Existing `--tool claude` bundle install tests kept; new `bundle install accepts --tool all` (`flags.provider` is shared with `--provider`) |

<!-- gitissue:qa v1 head=097422bebd574fb3e42fb1bd8f1bf31e5f1b6831 profile=light cycles=1 review=clean ui=none -->

Made with [Cursor](https://cursor.com)