### PR TITLE
fix(ci): skip retired npm audit endpoint in unit-tests (#604)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         # Node 18/20 are EOL; floor is >=22 (see package.json engines / #444).
         node-version: [22, 24]
@@ -58,7 +59,7 @@ jobs:
         run: node scripts/patch-ts6.cjs
 
       - name: Audit production dependencies
-        run: npm audit --audit-level=high --omit=dev
+        run: npx tsx scripts/ci-npm-audit.ts --omit=dev
 
       - name: Audit all dependencies
         run: npx tsx scripts/ci-npm-audit.ts

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -62,9 +62,10 @@ GitHub Actions runs on every push to `main` and on all PRs:
 1. Checkout code
 2. Setup Node.js (matrix: 22, 24)
 3. Install dependencies (`npm ci`)
-4. Audit dependencies (`npm audit --audit-level=high --omit=dev`)
-5. Run unit tests (`npx vitest run src/`)
-6. Build (`npm run build`) and verify the `dist/` entry point
-7. Run Node.js E2E and npm-install E2E suites against the packed tarball
+4. Audit production dependencies (`npx tsx scripts/ci-npm-audit.ts --omit=dev`) — hard-fails on high/critical advisories; skips (exit 0, not a lockfile rebuild) when the npm audit endpoint returns HTTP 400 or is retired
+5. Audit all dependencies (`npx tsx scripts/ci-npm-audit.ts`) — same skip/fail policy, including `devDependencies`
+6. Run unit tests (`npx vitest run src/`)
+7. Build (`npm run build`) and verify the `dist/` entry point
+8. Run Node.js E2E and npm-install E2E suites against the packed tarball
 
 See `.github/workflows/ci.yml` for the full pipeline.

--- a/scripts/ci-npm-audit.ts
+++ b/scripts/ci-npm-audit.ts
@@ -1,11 +1,14 @@
 #!/usr/bin/env npx tsx
 /**
- * Fail the CI job on high/critical npm advisories, including devDependencies.
+ * Fail the CI job on high/critical npm advisories.
  *
- * Invokes `npm audit --audit-level=high --json` (no --omit=dev). An optional
- * time-boxed allowlist (ASM_AUDIT_ALLOWLIST + ASM_AUDIT_ALLOWLIST_EXPIRES)
- * may suppress specific GHSA ids. After the expiry date (UTC, inclusive)
- * the allowlist is ignored. An allowlist without an expiry is never honoured.
+ * Invokes `npm audit --audit-level=high --json`. Pass `--omit=dev` to audit
+ * production dependencies only. Registry HTTP 400 / retired `audits/quick`
+ * responses are skipped (exit 0), not treated as lockfile or advisory
+ * failures. An optional time-boxed allowlist (ASM_AUDIT_ALLOWLIST +
+ * ASM_AUDIT_ALLOWLIST_EXPIRES) may suppress specific GHSA ids. After the
+ * expiry date (UTC, inclusive) the allowlist is ignored. An allowlist
+ * without an expiry is never honoured.
  */
 
 import { spawnSync } from "node:child_process";
@@ -13,6 +16,70 @@ import { pathToFileURL } from "node:url";
 
 const GHSA_RE = /GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/i;
 const HIGH_SEVS = new Set(["high", "critical"]);
+
+/** Tight markers for a retired / HTTP-400 npm audit registry — not every npm exit 1. */
+const AUDIT_UNAVAILABLE_MARKERS = [
+  "400 Bad Request",
+  "audits/quick",
+  "audit endpoint returned an error",
+  "This endpoint is being retired",
+] as const;
+
+export type NpmAuditSpawnInput = {
+  error?: Error | null;
+  status: number | null;
+  stdout?: string | null;
+  stderr?: string | null;
+};
+
+export type NpmAuditSpawnDecision =
+  | { kind: "unavailable" }
+  | { kind: "report"; report: unknown }
+  | { kind: "spawn-error"; message: string }
+  | { kind: "unreadable" };
+
+export function isNpmAuditUnavailable(
+  stdout: string,
+  stderr: string,
+  status: number | null,
+): boolean {
+  // npm exits 1 on real high/critical advisories — status alone is never a skip.
+  if (status === 0) return false;
+  const haystack = `${stdout}\n${stderr}`;
+  return AUDIT_UNAVAILABLE_MARKERS.some((marker) => haystack.includes(marker));
+}
+
+export function parseNpmAuditOutput(stdout: string): unknown | null {
+  try {
+    return JSON.parse(stdout) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveNpmAuditSpawn(
+  result: NpmAuditSpawnInput,
+): NpmAuditSpawnDecision {
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  if (result.error) {
+    return { kind: "spawn-error", message: result.error.message };
+  }
+  if (isNpmAuditUnavailable(stdout, stderr, result.status)) {
+    return { kind: "unavailable" };
+  }
+  const report = parseNpmAuditOutput(stdout);
+  if (report === null) {
+    return { kind: "unreadable" };
+  }
+  return { kind: "report", report };
+}
+
+export function npmAuditCliArgs(argv: string[]): string[] {
+  const args = ["audit", "--audit-level=high", "--json"];
+  if (argv.includes("--omit=dev")) args.push("--omit=dev");
+  return args;
+}
 
 export type Advisory = {
   id: string;
@@ -98,21 +165,26 @@ export function evaluateReport(
 }
 
 function runNpmAudit(): unknown {
-  const result = spawnSync("npm", ["audit", "--audit-level=high", "--json"], {
+  const result = spawnSync("npm", npmAuditCliArgs(process.argv.slice(2)), {
     encoding: "utf8",
     maxBuffer: 20 * 1024 * 1024,
   });
-  if (result.error) {
-    console.error(`npm audit failed to start: ${result.error.message}`);
-    process.exit(2);
-  }
-  const stdout = result.stdout || "";
-  try {
-    return JSON.parse(stdout);
-  } catch {
-    console.error("npm audit --json produced unreadable output");
-    if (result.stderr) console.error(result.stderr);
-    process.exit(2);
+  const decision = resolveNpmAuditSpawn(result);
+  switch (decision.kind) {
+    case "spawn-error":
+      console.error(`npm audit failed to start: ${decision.message}`);
+      process.exit(2);
+    case "unavailable":
+      console.log(
+        "npm audit skipped: registry audit endpoint unavailable (HTTP 400 / retired)",
+      );
+      process.exit(0);
+    case "unreadable":
+      console.error("npm audit --json produced unreadable output");
+      if (result.stderr) console.error(result.stderr);
+      process.exit(2);
+    case "report":
+      return decision.report;
   }
 }
 

--- a/src/ci-npm-audit.test.ts
+++ b/src/ci-npm-audit.test.ts
@@ -3,8 +3,11 @@ import {
   collectHighCriticalAdvisories,
   evaluateReport,
   isAllowlistExpired,
+  isNpmAuditUnavailable,
   parseAllowlist,
+  parseNpmAuditOutput,
   remainingAdvisories,
+  resolveNpmAuditSpawn,
 } from "../scripts/ci-npm-audit.ts";
 
 const VITEST_GHSA = "GHSA-5xrq-8626-4rwp";
@@ -115,5 +118,92 @@ describe("ci-npm-audit allowlist gate", () => {
     expect(parseAllowlist(" GHSA-5xrq-8626-4rwp , ")).toEqual([
       VITEST_GHSA.toUpperCase(),
     ]);
+  });
+});
+
+const RETIRED_STDERR = [
+  "npm error audit endpoint returned an error",
+  "npm error 400 Bad Request - POST https://registry.npmjs.org/-/npm/v1/security/audits/quick",
+  "npm error This endpoint is being retired",
+].join("\n");
+
+describe("ci-npm-audit registry-unavailable skip", () => {
+  it("classifies HTTP 400 Bad Request as unavailable", () => {
+    expect(
+      isNpmAuditUnavailable(
+        "",
+        "400 Bad Request - POST https://registry.npmjs.org/-/npm/v1/security/audits/quick",
+        1,
+      ),
+    ).toBe(true);
+    expect(
+      resolveNpmAuditSpawn({
+        error: null,
+        status: 1,
+        stdout: "",
+        stderr: "400 Bad Request",
+      }),
+    ).toEqual({ kind: "unavailable" });
+  });
+
+  it("classifies the retired audits/quick endpoint as unavailable", () => {
+    expect(isNpmAuditUnavailable("", RETIRED_STDERR, 1)).toBe(true);
+  });
+
+  it("skips non-JSON output when retirement markers are present", () => {
+    expect(parseNpmAuditOutput("not json")).toBeNull();
+    expect(
+      resolveNpmAuditSpawn({
+        error: null,
+        status: 1,
+        stdout: "Invalid package tree",
+        stderr: RETIRED_STDERR,
+      }),
+    ).toEqual({ kind: "unavailable" });
+  });
+
+  it("does not classify a remaining-GHSA JSON report as unavailable", () => {
+    const stdout = JSON.stringify(
+      reportWith([{ id: VITEST_GHSA, severity: "critical", name: "vitest" }]),
+    );
+    expect(isNpmAuditUnavailable(stdout, "", 1)).toBe(false);
+    const decision = resolveNpmAuditSpawn({
+      error: null,
+      status: 1,
+      stdout,
+      stderr: "",
+    });
+    expect(decision.kind).toBe("report");
+    if (decision.kind !== "report") return;
+    expect(evaluateReport(decision.report).remaining.map((a) => a.id)).toEqual([
+      VITEST_GHSA.toUpperCase(),
+    ]);
+  });
+
+  it("keeps local spawn failures as spawn-error (exit 2)", () => {
+    expect(
+      resolveNpmAuditSpawn({
+        error: new Error("spawn npm ENOENT"),
+        status: null,
+        stdout: "",
+        stderr: "",
+      }),
+    ).toEqual({ kind: "spawn-error", message: "spawn npm ENOENT" });
+  });
+
+  it("treats generic unreadable JSON without retirement markers as unreadable", () => {
+    expect(
+      resolveNpmAuditSpawn({
+        error: null,
+        status: 1,
+        stdout: "not json at all",
+        stderr: "something went wrong",
+      }),
+    ).toEqual({ kind: "unreadable" });
+  });
+
+  it("does not skip on npm exit 1 without registry-unavailable markers", () => {
+    expect(isNpmAuditUnavailable("{}", "", 1)).toBe(false);
+    expect(isNpmAuditUnavailable("{}", "", 0)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #604

## Summary

The `unit-tests` matrix was failing because `npm audit` POSTs to the retired `/-/npm/v1/security/audits/quick` endpoint, which returns HTTP 400 even when the lockfile is unchanged. Both CI audit steps now go through `scripts/ci-npm-audit.ts`, which skips (exit 0) on that registry failure while still hard-failing parseable high/critical GHSAs, and `fail-fast: false` keeps a sibling Node version from being cancelled.

## Approach

Option 2 — Balanced approach: treat registry HTTP 400 / retired `audits/quick` / unreadable audit JSON with those markers as a skip in both audit gates; keep valid high/critical advisories as hard failures; disable fail-fast; cover the skip path in tests. Do not rebuild the lockfile.

## Decision Record

- **Root cause:** `.github/workflows/ci.yml` treated a hard `npm audit --audit-level=high --omit=dev` as a required step. Bundled npm POSTs the lockfile to the retired `/-/npm/v1/security/audits/quick` endpoint, which returns HTTP 400; the job exits 1 and default fail-fast cancels the sibling Node 22/24 leg. The second gate `scripts/ci-npm-audit.ts` used the same CLI with no HTTP-400 handling and was unreached. Lockfile version skew is a red herring (`main` passed on the same tree; observed on no-dep-change PR #603).
- **Options considered:** Option 1 — Minimal fix; Option 2 — Balanced approach; Option 3 — Comprehensive refactor
- **Options rejected:** Option 1 — continue-on-error greens the matrix only by dropping the high/critical gate when npm audit works, and leaving the second gate blocking still reds the job on the same HTTP 400; Option 3 — overscoped for a registry-400: relocating audit out of unit-tests changes the PR gate and still needs skip/fail-soft unless the bulk endpoint is proven, which the findings do not show
- **Selected option:** Option 2 — Balanced approach
- **Residual risk:** Skip-detection must stay tight so a real advisory JSON failure is not classified as 400 — mitigated by tests that keep remaining GHSAs as a hard fail. Live registry skip is covered at the classifier seam, not by hanging `npm audit` locally.
- **Reproduction:** `npx vitest run src/ci-npm-audit.test.ts` confirmed red (`expected { kind: 'unreadable' } to deeply equal { kind: 'unavailable' }` at `src/ci-npm-audit.test.ts:154`) → regression test `src/ci-npm-audit.test.ts` (skips non-JSON output when retirement markers are present)

Analyzed at: `main` @ `01b1e05` (2026-09-04)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | `fail-fast: false` on `unit-tests`; both audit steps run `scripts/ci-npm-audit.ts` (production via `--omit=dev`) |
| `scripts/ci-npm-audit.ts` | Skip exit 0 on HTTP 400 / retired `audits/quick`; keep exit 1 for remaining GHSAs; exit 2 for local spawn/unreadable-without-markers |
| `src/ci-npm-audit.test.ts` | Registry-unavailable skip vs remaining-GHSA fail vs spawn-error vs generic unreadable |
| `docs/DEPLOYMENT.md` | Document both audit gates and the graceful-skip policy |

## Test Results

- Unit tests: 2633 passed
- Integration tests: skipped
- E2e tests: skipped
- Build: passed (not required for this CI-helper change; unit suite green)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| The `unit-tests` CI matrix is green on a PR that does not change dependency files, without manual reruns | pass | Production and all-deps audit steps skip on retired-endpoint markers (`scripts/ci-npm-audit.ts` `resolveNpmAuditSpawn` → exit 0). Live confirmation is this PR's `unit-tests` matrix. |
| When the lockfile is unchanged and valid, dependency audit either passes or is skipped without failing the job | pass | Verified red: `npx vitest run src/ci-npm-audit.test.ts` → fixed → `src/ci-npm-audit.test.ts` (`skips non-JSON output when retirement markers are present`) |
| A retired or HTTP-400 npm audit endpoint does not red the entire `unit-tests` matrix via fail-fast | pass | `.github/workflows/ci.yml` `strategy.fail-fast: false` on `unit-tests` |

<!-- gitissue:qa v1 head=bf34ae857eb4c26fa2f45fc7d1cc4c2351623072 profile=full cycles=1 review=clean ui=none -->
