### PR TITLE
feat(bundle): interactive tool and scope pickers for install (#612)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -5822,6 +5822,74 @@ describe("CLI integration: bundle", () => {
     }
   });
 
+  test("bundle install TTY scope dismissal aborts gracefully", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "cli-bundle-scope-abort-"));
+    const origIsTTY = process.stdin.isTTY;
+    const pickerSpy = vi
+      .spyOn(checkboxPickerMod, "checkboxPicker")
+      .mockResolvedValue([]);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+    try {
+      const skillDir = join(tmpDir, "scope-abort-skill");
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, "SKILL.md"),
+        `---\nname: scope-abort-skill\nversion: 1.0.0\n---\n# Scope Abort Skill\n`,
+      );
+      const bundlePath = join(tmpDir, "scope-abort-bundle.json");
+      await writeFile(
+        bundlePath,
+        JSON.stringify({
+          version: 1,
+          name: "scope-abort-bundle",
+          description: "Scope dismissal",
+          author: "tester",
+          createdAt: new Date().toISOString(),
+          skills: [
+            {
+              name: "scope-abort-skill",
+              installUrl: skillDir,
+            },
+          ],
+        }),
+      );
+
+      const args = parseArgs([
+        "node",
+        "script.ts",
+        "bundle",
+        "install",
+        bundlePath,
+        "--json",
+        "--force",
+        "--tool",
+        "claude",
+      ]);
+      await expect(cmdBundle(args)).rejects.toThrow("process.exit(1)");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: origIsTTY,
+        configurable: true,
+      });
+      pickerSpy.mockRestore();
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+      logSpy.mockRestore();
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   test("main --help includes bundle in command list", async () => {
     const { stdout, exitCode } = await runCLI("--help");
     expect(exitCode).toBe(0);

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -35,6 +35,7 @@ import {
 } from "fs/promises";
 import { tmpdir, homedir } from "os";
 import { spawnCollect, runInlineTs } from "./utils/test-spawn";
+import { loadConfig, resolveProviderPath } from "./config";
 
 // Helper: path to the CLI entry point
 const CLI_BIN = join(
@@ -5620,6 +5621,203 @@ describe("CLI integration: bundle", () => {
       // Clean up: uninstall the skill
       await runCLI("uninstall", "skip-test-skill", "--yes");
     } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("bundle install TTY selects subset of skills and installs only chosen", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "cli-bundle-select-"));
+    const origIsTTY = process.stdin.isTTY;
+    const readLineSpy = vi.spyOn(shared, "readLine").mockResolvedValue("y");
+    const pickerSpy = vi
+      .spyOn(checkboxPickerMod, "checkboxPicker")
+      .mockImplementation(async (opts) => {
+        const labels = opts.items.map((i) => i.label);
+        // Scope picker offers "Global (...)" — keep global; the skill
+        // picker offers skill names — take the second skill only.
+        if (labels.some((l) => l.startsWith("Global ("))) return [0];
+        return [1];
+      });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit);
+    const logs: string[] = [];
+    const logSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation((msg?: unknown) => {
+        logs.push(String(msg ?? ""));
+      });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+    try {
+      for (const name of ["tty-skill-a", "tty-skill-b"]) {
+        const skillDir = join(tmpDir, name);
+        await mkdir(skillDir, { recursive: true });
+        await writeFile(
+          join(skillDir, "SKILL.md"),
+          `---\nname: ${name}\nversion: 1.0.0\n---\n# ${name}\n`,
+        );
+      }
+      const bundlePath = join(tmpDir, "select-bundle.json");
+      await writeFile(
+        bundlePath,
+        JSON.stringify({
+          version: 1,
+          name: "select-bundle",
+          description: "Subset selection",
+          author: "tester",
+          createdAt: new Date().toISOString(),
+          skills: ["tty-skill-a", "tty-skill-b"].map((n) => ({
+            name: n,
+            installUrl: join(tmpDir, n),
+          })),
+        }),
+      );
+
+      const args = parseArgs([
+        "node",
+        "script.ts",
+        "bundle",
+        "install",
+        bundlePath,
+        "--json",
+        "--force",
+        "--tool",
+        "claude",
+      ]);
+      await cmdBundle(args);
+      const jsonOut =
+        logs.find((l) => l.includes("bundleName")) ?? logs.join("");
+      const parsed = JSON.parse(jsonOut);
+      expect(parsed.bundleName).toBe("select-bundle");
+      expect(parsed.total).toBe(1);
+      expect(parsed.installed).toBe(1);
+      expect(parsed.failed).toBe(0);
+      expect(parsed.results).toHaveLength(1);
+      expect(parsed.results[0].name).toBe("tty-skill-b");
+      expect(parsed.results[0].status).toBe("installed");
+      expect(exitSpy).not.toHaveBeenCalled();
+
+      await runCLI("uninstall", "tty-skill-b", "--yes");
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: origIsTTY,
+        configurable: true,
+      });
+      readLineSpy.mockRestore();
+      pickerSpy.mockRestore();
+      exitSpy.mockRestore();
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("bundle install TTY scope selection installs into project scope", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "cli-bundle-scope-"));
+    const origCwd = process.cwd();
+    const origIsTTY = process.stdin.isTTY;
+    const readLineSpy = vi.spyOn(shared, "readLine").mockResolvedValue("y");
+    const pickerSpy = vi
+      .spyOn(checkboxPickerMod, "checkboxPicker")
+      .mockImplementation(async (opts) => {
+        const labels = opts.items.map((i) => i.label);
+        // Only the scope picker appears (single skill, explicit --tool):
+        // choose the second entry (project).
+        if (labels.some((l) => l.startsWith("Global ("))) return [1];
+        return [0];
+      });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit);
+    const logs: string[] = [];
+    const logSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation((msg?: unknown) => {
+        logs.push(String(msg ?? ""));
+      });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+    // Project scope resolves relative paths from cwd — run inside tmpDir so
+    // the install lands under tmpDir and never touches the repo checkout.
+    process.chdir(tmpDir);
+    try {
+      const skillDir = join(tmpDir, "scope-proj-skill");
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, "SKILL.md"),
+        `---\nname: scope-proj-skill\nversion: 1.0.0\n---\n# Scope Project Skill\n`,
+      );
+      const bundlePath = join(tmpDir, "scope-bundle.json");
+      await writeFile(
+        bundlePath,
+        JSON.stringify({
+          version: 1,
+          name: "scope-bundle",
+          description: "Scope selection",
+          author: "tester",
+          createdAt: new Date().toISOString(),
+          skills: [
+            {
+              name: "scope-proj-skill",
+              installUrl: skillDir,
+            },
+          ],
+        }),
+      );
+
+      const args = parseArgs([
+        "node",
+        "script.ts",
+        "bundle",
+        "install",
+        bundlePath,
+        "--json",
+        "--force",
+        "--tool",
+        "claude",
+      ]);
+      await cmdBundle(args);
+      const jsonOut =
+        logs.find((l) => l.includes("bundleName")) ?? logs.join("");
+      const parsed = JSON.parse(jsonOut);
+      expect(parsed.bundleName).toBe("scope-bundle");
+      expect(parsed.installed).toBe(1);
+      expect(parsed.failed).toBe(0);
+      expect(parsed.scope).toBe("project");
+      expect(exitSpy).not.toHaveBeenCalled();
+
+      const config = await loadConfig();
+      const claude = config.providers.find((p) => p.name === "claude");
+      expect(claude).toBeDefined();
+      const installedMd = join(
+        resolveProviderPath(claude!.project),
+        "scope-proj-skill",
+        "SKILL.md",
+      );
+      const content = await readFile(installedMd, "utf-8");
+      expect(content).toContain("scope-proj-skill");
+    } finally {
+      process.chdir(origCwd);
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: origIsTTY,
+        configurable: true,
+      });
+      readLineSpy.mockRestore();
+      pickerSpy.mockRestore();
+      exitSpy.mockRestore();
+      logSpy.mockRestore();
+      errSpy.mockRestore();
       await rm(tmpDir, { recursive: true, force: true });
     }
   });

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -241,27 +241,33 @@ export async function cmdBundle(args: ParsedArgs) {
 
       // Interactive skill selection (issue #612): mirror `asm install` —
       // TTY runs pick which bundle entries to install, --yes installs all.
+      // Both pickers dismiss into a friendly abort (not an unhandled throw).
       let skillsToInstall = bundle.skills;
-      if (process.stdin.isTTY && !args.flags.yes && bundle.skills.length > 1) {
-        try {
+      let installScope!: "global" | "project";
+      try {
+        if (
+          process.stdin.isTTY &&
+          !args.flags.yes &&
+          bundle.skills.length > 1
+        ) {
           skillsToInstall = await selectBundleSkills(bundle.skills, {
             isTTY: true,
             yes: false,
           });
-        } catch (err: any) {
-          error(err.message);
-          process.exit(1);
         }
-      }
 
-      // Interactive scope selection (issue #612): explicit --scope wins,
-      // otherwise TTY runs are offered global/project, rest default global.
-      const installScope = await promptInstallScope({
-        scopeFlag: args.flags.scope,
-        provider,
-        isTTY: !!process.stdin.isTTY,
-        yes: !!args.flags.yes,
-      });
+        // Interactive scope selection (issue #612): explicit --scope wins,
+        // otherwise TTY runs are offered global/project, rest default global.
+        installScope = await promptInstallScope({
+          scopeFlag: args.flags.scope,
+          provider,
+          isTTY: !!process.stdin.isTTY,
+          yes: !!args.flags.yes,
+        });
+      } catch (err: any) {
+        error(err.message);
+        process.exit(1);
+      }
 
       // Confirm
       if (!args.flags.yes && process.stdin.isTTY) {

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -30,6 +30,7 @@ import type { BundleSkillRef } from "../utils/types";
 import { join as joinPath } from "path";
 
 import { error, readLine } from "./shared";
+import { promptInstallScope, selectBundleSkills } from "./install-prompts";
 import type { ParsedArgs } from "../cli";
 
 function printBundleHelp() {
@@ -238,11 +239,37 @@ export async function cmdBundle(args: ParsedArgs) {
         !!process.stdin.isTTY,
       );
 
+      // Interactive skill selection (issue #612): mirror `asm install` —
+      // TTY runs pick which bundle entries to install, --yes installs all.
+      let skillsToInstall = bundle.skills;
+      if (process.stdin.isTTY && !args.flags.yes && bundle.skills.length > 1) {
+        try {
+          skillsToInstall = await selectBundleSkills(bundle.skills, {
+            isTTY: true,
+            yes: false,
+          });
+        } catch (err: any) {
+          error(err.message);
+          process.exit(1);
+        }
+      }
+
+      // Interactive scope selection (issue #612): explicit --scope wins,
+      // otherwise TTY runs are offered global/project, rest default global.
+      const installScope = await promptInstallScope({
+        scopeFlag: args.flags.scope,
+        provider,
+        isTTY: !!process.stdin.isTTY,
+        yes: !!args.flags.yes,
+      });
+
       // Confirm
       if (!args.flags.yes && process.stdin.isTTY) {
-        process.stderr.write(
-          `\n${ansi.bold("Install all skills from this bundle?")} [y/N] `,
-        );
+        const countLabel =
+          skillsToInstall.length === bundle.skills.length
+            ? "all skills from this bundle"
+            : `${skillsToInstall.length} selected skill(s) from this bundle`;
+        process.stderr.write(`\n${ansi.bold(`Install ${countLabel}?`)} [y/N] `);
         const answer = await readLine();
         if (answer.toLowerCase() !== "y" && answer.toLowerCase() !== "yes") {
           console.error("Aborted.");
@@ -250,19 +277,14 @@ export async function cmdBundle(args: ParsedArgs) {
         }
       }
 
-      // Install each skill
+      // Install each selected skill
       const results: Array<{
         name: string;
         status: "installed" | "skipped" | "failed";
         reason?: string;
       }> = [];
 
-      const installScope: "global" | "project" =
-        args.flags.scope === "global" || args.flags.scope === "project"
-          ? args.flags.scope
-          : "global";
-
-      for (const skill of bundle.skills) {
+      for (const skill of skillsToInstall) {
         console.error(`\n  Installing ${ansi.bold(skill.name)}...`);
         try {
           // Check if git is available for remote installs
@@ -370,6 +392,7 @@ export async function cmdBundle(args: ParsedArgs) {
               installed,
               skipped,
               failed,
+              scope: installScope,
               results,
             },
             null,

--- a/src/commands/install-prompts.test.ts
+++ b/src/commands/install-prompts.test.ts
@@ -1,0 +1,176 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { promptInstallScope, selectBundleSkills } from "./install-prompts";
+import type { BundleSkillRef, ProviderConfig } from "../utils/types";
+
+const mocks = vi.hoisted(() => ({
+  checkboxPicker: vi.fn<(opts: any) => Promise<number[]>>(() =>
+    Promise.resolve([]),
+  ),
+}));
+vi.mock("../utils/checkbox-picker", () => ({
+  checkboxPicker: (opts: unknown) => mocks.checkboxPicker(opts),
+}));
+
+const provider: ProviderConfig = {
+  name: "claude",
+  label: "Claude Code",
+  global: "/tmp/asm-global",
+  project: "/tmp/asm-project",
+  enabled: true,
+};
+
+function bundleSkills(): BundleSkillRef[] {
+  return [
+    { name: "skill-a", installUrl: "/tmp/skill-a" },
+    { name: "skill-b", installUrl: "/tmp/skill-b" },
+  ];
+}
+
+beforeEach(() => {
+  mocks.checkboxPicker.mockReset();
+  mocks.checkboxPicker.mockResolvedValue([]);
+});
+
+// ─── selectBundleSkills ──────────────────────────────────────────────────────
+
+describe("selectBundleSkills", () => {
+  test("non-TTY installs all without prompting", async () => {
+    const skills = bundleSkills();
+    const result = await selectBundleSkills(skills, {
+      isTTY: false,
+      yes: false,
+    });
+    expect(result).toEqual(skills);
+    expect(mocks.checkboxPicker).not.toHaveBeenCalled();
+  });
+
+  test("--yes installs all without prompting", async () => {
+    const skills = bundleSkills();
+    const result = await selectBundleSkills(skills, {
+      isTTY: true,
+      yes: true,
+    });
+    expect(result).toEqual(skills);
+    expect(mocks.checkboxPicker).not.toHaveBeenCalled();
+  });
+
+  test("single-skill bundle installs without prompting", async () => {
+    const skills = bundleSkills().slice(0, 1);
+    const result = await selectBundleSkills(skills, {
+      isTTY: true,
+      yes: false,
+    });
+    expect(result).toEqual(skills);
+    expect(mocks.checkboxPicker).not.toHaveBeenCalled();
+  });
+
+  test("TTY multi-skill bundle returns only picked entries", async () => {
+    mocks.checkboxPicker.mockResolvedValueOnce([1]);
+    const result = await selectBundleSkills(bundleSkills(), {
+      isTTY: true,
+      yes: false,
+    });
+    expect(result).toEqual([bundleSkills()[1]]);
+    expect(mocks.checkboxPicker).toHaveBeenCalledOnce();
+  });
+
+  test("dismissed picker throws", async () => {
+    mocks.checkboxPicker.mockResolvedValueOnce([]);
+    await expect(
+      selectBundleSkills(bundleSkills(), { isTTY: true, yes: false }),
+    ).rejects.toThrow("No skills selected");
+  });
+});
+
+// ─── promptInstallScope ──────────────────────────────────────────────────────
+
+describe("promptInstallScope", () => {
+  test("explicit --scope global wins without prompting", async () => {
+    const logs: string[] = [];
+    const scope = await promptInstallScope({
+      scopeFlag: "global",
+      provider,
+      isTTY: true,
+      yes: false,
+      log: (m) => logs.push(m),
+    });
+    expect(scope).toBe("global");
+    expect(mocks.checkboxPicker).not.toHaveBeenCalled();
+    expect(logs.join("\n")).toContain("scope: global");
+  });
+
+  test("explicit --scope project wins without prompting", async () => {
+    const scope = await promptInstallScope({
+      scopeFlag: "project",
+      provider,
+      isTTY: true,
+      yes: false,
+      log: () => {},
+    });
+    expect(scope).toBe("project");
+    expect(mocks.checkboxPicker).not.toHaveBeenCalled();
+  });
+
+  test("non-TTY defaults to global", async () => {
+    const scope = await promptInstallScope({
+      scopeFlag: "both",
+      provider,
+      isTTY: false,
+      yes: false,
+      log: () => {},
+    });
+    expect(scope).toBe("global");
+    expect(mocks.checkboxPicker).not.toHaveBeenCalled();
+  });
+
+  test("--yes defaults to global", async () => {
+    const scope = await promptInstallScope({
+      scopeFlag: "both",
+      provider,
+      isTTY: true,
+      yes: true,
+      log: () => {},
+    });
+    expect(scope).toBe("global");
+    expect(mocks.checkboxPicker).not.toHaveBeenCalled();
+  });
+
+  test("TTY picker global", async () => {
+    mocks.checkboxPicker.mockResolvedValueOnce([0]);
+    const scope = await promptInstallScope({
+      scopeFlag: "both",
+      provider,
+      isTTY: true,
+      yes: false,
+      log: () => {},
+    });
+    expect(scope).toBe("global");
+    expect(mocks.checkboxPicker).toHaveBeenCalledOnce();
+  });
+
+  test("TTY picker project", async () => {
+    mocks.checkboxPicker.mockResolvedValueOnce([1]);
+    const scope = await promptInstallScope({
+      scopeFlag: "both",
+      provider,
+      isTTY: true,
+      yes: false,
+      log: () => {},
+    });
+    expect(scope).toBe("project");
+    expect(mocks.checkboxPicker).toHaveBeenCalledOnce();
+  });
+
+  test("dismissed scope picker throws", async () => {
+    mocks.checkboxPicker.mockResolvedValueOnce([]);
+    await expect(
+      promptInstallScope({
+        scopeFlag: null,
+        provider,
+        isTTY: true,
+        yes: false,
+        log: () => {},
+      }),
+    ).rejects.toThrow("No scope selected");
+  });
+});

--- a/src/commands/install-prompts.ts
+++ b/src/commands/install-prompts.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared interactive install preamble (issue #612).
+ *
+ * `asm install` and `asm bundle install` offer the same two decisions before
+ * writing anything: which skills to install and which scope to install them
+ * into. Both helpers below are TTY-gated (`isTTY && !yes`) so `--yes` and
+ * non-interactive runs keep the historical defaults (all skills, global
+ * scope). All user-facing output goes to stderr via the injected `log`
+ * (default `console.error`); machine/JSON output on stdout stays clean.
+ */
+
+import { ansi } from "../formatter";
+import { checkboxPicker } from "../utils/checkbox-picker";
+import { resolveInstallScope } from "../installer-link";
+import type { BundleSkillRef, ProviderConfig } from "../utils/types";
+
+export type InstallScope = "global" | "project";
+
+export interface ScopePromptOptions {
+  scopeFlag: string | null;
+  provider: ProviderConfig;
+  isTTY: boolean;
+  yes: boolean;
+  log?: (message: string) => void;
+}
+
+/**
+ * Resolve the install scope, logging the decision like the `asm install`
+ * flow does. Single-skill and bundle installs share this so the scope offer
+ * cannot drift between the two commands.
+ */
+export async function promptInstallScope(
+  opts: ScopePromptOptions,
+): Promise<InstallScope> {
+  const {
+    scopeFlag,
+    provider,
+    isTTY,
+    yes,
+    log = (message: string) => console.error(message),
+  } = opts;
+
+  if (scopeFlag === "global" || scopeFlag === "project") {
+    // Explicit --scope flag provided
+    log(
+      `  ${ansi.dim(`scope: ${scopeFlag}`)}${scopeFlag === "global" ? ` (${provider.global})` : ` (${provider.project})`}`,
+    );
+    return scopeFlag;
+  }
+
+  if (!isTTY || yes) {
+    // Non-interactive mode: default to global
+    log(`  ${ansi.dim(`scope: global (default)`)} (${provider.global})`);
+    return "global";
+  }
+
+  // Interactive: prompt user to choose
+  log(""); // blank line before picker
+  const scope = await resolveInstallScope({
+    scopeFlag,
+    provider,
+    isTTY,
+    yes,
+  });
+  log(
+    `  Selected: ${ansi.bold(scope)} ${ansi.dim(`(${scope === "global" ? provider.global : provider.project})`)}`,
+  );
+  return scope;
+}
+
+export interface SkillPromptOptions {
+  isTTY: boolean;
+  yes: boolean;
+  log?: (message: string) => void;
+}
+
+/**
+ * Let the user pick which bundle entries to install. Non-interactive runs,
+ * `--yes`, and single-skill bundles install everything without prompting.
+ * Multi-skill TTY runs show a checkbox picker (all checked by default).
+ *
+ * Throws when the picker is dismissed with nothing selected; callers turn
+ * that into `error()` + `process.exit(1)` (bundle style) or let their
+ * `try/catch` report it (install style).
+ */
+export async function selectBundleSkills(
+  skills: BundleSkillRef[],
+  opts: SkillPromptOptions,
+): Promise<BundleSkillRef[]> {
+  const {
+    isTTY,
+    yes,
+    log = (message: string) => console.error(message),
+  } = opts;
+
+  if (skills.length <= 1 || !isTTY || yes) {
+    return skills;
+  }
+
+  log(ansi.bold(`Select skills to install from this bundle:\n`));
+  const items = skills.map((s) => ({
+    label: s.name,
+    hint: s.description
+      ? s.description.slice(0, 60) + (s.description.length > 60 ? "..." : "")
+      : s.version
+        ? `v${s.version}`
+        : s.installUrl,
+    checked: true,
+  }));
+  const indices = await checkboxPicker({ items });
+
+  if (indices.length === 0) {
+    throw new Error("No skills selected. Aborting.");
+  }
+  return indices.map((i) => skills[i]);
+}

--- a/src/commands/install-run.ts
+++ b/src/commands/install-run.ts
@@ -48,6 +48,7 @@ import { relative as relativePath } from "path";
 import { toPortableRelativePath } from "../utils/fs";
 import { error, readLine } from "./shared";
 import type { ParsedArgs } from "../cli";
+import { promptInstallScope } from "./install-prompts";
 import type { SkillInspection } from "./install-inspect";
 import {
   printInstallHelp,
@@ -306,46 +307,15 @@ export async function cmdInstall(args: ParsedArgs) {
       provider = resolved.provider;
       allProviders = resolved.allProviders;
 
-      // Step 3: Select scope (global or project)
+      // Step 3: Select scope (global or project) — shared preamble (#612)
       console.info(stepHeader("Selecting scope"));
-
-      if (args.flags.scope === "global" || args.flags.scope === "project") {
-        // Explicit --scope flag provided
-        installScope = args.flags.scope;
-        console.info(
-          `  ${ansi.dim(`scope: ${installScope}`)}${installScope === "global" ? ` (${provider.global})` : ` (${provider.project})`}`,
-        );
-      } else if (!process.stdin.isTTY || args.flags.yes) {
-        // Non-interactive mode: default to global
-        installScope = "global";
-        console.info(
-          `  ${ansi.dim(`scope: global (default)`)} (${provider.global})`,
-        );
-      } else {
-        // Interactive: prompt user to choose
-        const scopeItems = [
-          {
-            label: `Global (${provider.global})`,
-            hint: "Available in all projects",
-            checked: true,
-          },
-          {
-            label: `Project (${provider.project})`,
-            hint: "Available only in this project",
-            checked: false,
-          },
-        ];
-        console.info(""); // blank line before picker
-        const scopeIndices = await checkboxPicker({ items: scopeItems });
-        if (scopeIndices.length === 0) {
-          throw new Error("No scope selected. Aborting.");
-        }
-        // Use the first selected scope (single-select behavior)
-        installScope = scopeIndices[0] === 0 ? "global" : "project";
-        console.info(
-          `  Selected: ${ansi.bold(installScope)} ${ansi.dim(`(${installScope === "global" ? provider.global : provider.project})`)}`,
-        );
-      }
+      installScope = await promptInstallScope({
+        scopeFlag: args.flags.scope,
+        provider,
+        isTTY: !!process.stdin.isTTY,
+        yes: !!args.flags.yes,
+        log: (message: string) => console.info(message),
+      });
     }
 
     // Step 4: Clone repository (or read local source)

--- a/src/installer-link.ts
+++ b/src/installer-link.ts
@@ -238,6 +238,54 @@ export async function resolveProvider(
   return { provider: primary, allProviders: selectedProviders };
 }
 
+// ─── Scope Selection ─────────────────────────────────────────────────────────
+
+/**
+ * Shared scope decision for the install preamble (issue #612).
+ *
+ * An explicit `--scope global|project` flag always wins. Otherwise
+ * non-interactive runs (`!isTTY`) and `--yes` default to `"global"`, and
+ * TTY runs offer an interactive single-select picker. Callers own the
+ * step-header/logging output; this helper only decides and prompts.
+ *
+ * Throws when the interactive picker is dismissed with nothing selected.
+ */
+export async function resolveInstallScope(opts: {
+  scopeFlag: string | null;
+  provider: ProviderConfig;
+  isTTY: boolean;
+  yes: boolean;
+}): Promise<"global" | "project"> {
+  const { scopeFlag, provider, isTTY, yes } = opts;
+
+  if (scopeFlag === "global" || scopeFlag === "project") {
+    return scopeFlag;
+  }
+
+  if (!isTTY || yes) {
+    return "global";
+  }
+
+  const scopeItems = [
+    {
+      label: `Global (${provider.global})`,
+      hint: "Available in all projects",
+      checked: true,
+    },
+    {
+      label: `Project (${provider.project})`,
+      hint: "Available only in this project",
+      checked: false,
+    },
+  ];
+  const scopeIndices = await checkboxPicker({ items: scopeItems });
+  if (scopeIndices.length === 0) {
+    throw new Error("No scope selected. Aborting.");
+  }
+  // Single-select behavior: the first checked entry wins.
+  return scopeIndices[0] === 0 ? "global" : "project";
+}
+
 export function buildInstallPlan(
   source: ParsedSource,
   tempDir: string,

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -19,6 +19,7 @@ import {
   scanForWarnings,
   classifyWarningRisk,
   resolveProvider,
+  resolveInstallScope,
   executeInstall,
   executeInstallAllProviders,
   buildInstallPlan,
@@ -1117,6 +1118,100 @@ describe("resolveProvider", () => {
     const result = await resolveProvider(config, "claude", false);
     expect(result.provider.name).toBe("claude");
     expect(result.allProviders).toBeNull();
+  });
+});
+
+// ─── resolveInstallScope tests (issue #612) ──────────────────────────────────
+
+describe("resolveInstallScope", () => {
+  beforeEach(() => {
+    mocks.checkboxPicker.mockReset();
+  });
+
+  const claude: ProviderConfig = {
+    name: "claude",
+    label: "Claude Code",
+    global: "~/.claude/skills",
+    project: ".claude/skills",
+    enabled: true,
+  };
+
+  test("explicit global flag wins without prompting", async () => {
+    const scope = await resolveInstallScope({
+      scopeFlag: "global",
+      provider: claude,
+      isTTY: true,
+      yes: false,
+    });
+    expect(scope).toBe("global");
+    expect(mocks.checkboxPicker).not.toHaveBeenCalled();
+  });
+
+  test("explicit project flag wins without prompting", async () => {
+    const scope = await resolveInstallScope({
+      scopeFlag: "project",
+      provider: claude,
+      isTTY: true,
+      yes: false,
+    });
+    expect(scope).toBe("project");
+    expect(mocks.checkboxPicker).not.toHaveBeenCalled();
+  });
+
+  test("non-TTY defaults to global", async () => {
+    const scope = await resolveInstallScope({
+      scopeFlag: "both",
+      provider: claude,
+      isTTY: false,
+      yes: false,
+    });
+    expect(scope).toBe("global");
+    expect(mocks.checkboxPicker).not.toHaveBeenCalled();
+  });
+
+  test("--yes defaults to global", async () => {
+    const scope = await resolveInstallScope({
+      scopeFlag: null,
+      provider: claude,
+      isTTY: true,
+      yes: true,
+    });
+    expect(scope).toBe("global");
+    expect(mocks.checkboxPicker).not.toHaveBeenCalled();
+  });
+
+  test("TTY picker maps first entry to global", async () => {
+    mocks.checkboxPicker.mockResolvedValueOnce([0]);
+    const scope = await resolveInstallScope({
+      scopeFlag: null,
+      provider: claude,
+      isTTY: true,
+      yes: false,
+    });
+    expect(scope).toBe("global");
+  });
+
+  test("TTY picker maps second entry to project", async () => {
+    mocks.checkboxPicker.mockResolvedValueOnce([1]);
+    const scope = await resolveInstallScope({
+      scopeFlag: null,
+      provider: claude,
+      isTTY: true,
+      yes: false,
+    });
+    expect(scope).toBe("project");
+  });
+
+  test("dismissed picker throws", async () => {
+    mocks.checkboxPicker.mockResolvedValueOnce([]);
+    await expect(
+      resolveInstallScope({
+        scopeFlag: null,
+        provider: claude,
+        isTTY: true,
+        yes: false,
+      }),
+    ).rejects.toThrow("No scope selected");
   });
 });
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -45,6 +45,7 @@ export {
   buildRepoUrl,
   // ── Provider selection ──
   resolveProvider,
+  resolveInstallScope,
   buildInstallPlan,
   checkConflict,
   // ── Cross-tool linking ──


### PR DESCRIPTION
Closes #612

## Summary

Bundle install now offers the same interactive tool and scope selection as single-skill install by extracting a shared preamble used by both flows.

## Approach

Option 3 — Comprehensive: shared interactive install preamble with persistent selection surface.

## Decision Record

- **Root cause:** Bundle install duplicated install-run UX but hardcoded scope to global and resolved provider after confirm; canonical pickers already existed in installer-link.ts with #602 establishing provider-before-confirm.
- **Options considered:** Option 1 — Minimal; Option 2 — Balanced; Option 3 — Comprehensive
- **Options rejected:** Option 1 — Does not achieve requested UX parity or #602 ordering; Option 2 — Leaves duplicate logic for later cleanup
- **Selected option:** Option 3 — Comprehensive
- **Residual risk:** Confirm-text snapshot churn on TTY mocks; non-TTY/--yes bypass paths must stay non-interactive
- **Effort profile:** full pipeline (pre-work Effort M)

Analyzed at: `feat/612-add-interactive-tool-and-scope @ 13bb1ac` (2026-09-04)

## Changes

| File | Change |
|------|--------|
| `src/commands/install-prompts.ts` | New shared promptInstallScope + selectBundleSkills preamble |
| `src/installer-link.ts` | Added resolveInstallScope helper |
| `src/installer.ts` | Re-exported resolveInstallScope |
| `src/commands/bundle.ts` | Provider → skill pick → scope pick → confirm; installs subset into chosen scope; JSON gains scope |
| `src/commands/install-run.ts` | Scope block refactored to shared helper, output identical |

## Test Results

- Unit tests: 2661 passed
- Integration tests: skipped (no separate leg; covered by unit TTY mocks)
- E2e tests: skipped (tests/e2e/ excluded from npm test)
- Build: passed (tsc --noEmit clean, eslint clean)
- QA cycles: 2

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Installing a bundle without specified tools shows an interactive tool-selection step consistent with normal installation | pass | src/cli.test.ts TTY multi-skill picks only selected skill; install-prompts.test.ts 12/12 |
| Bundle installation offers a scope-selection step before completing | pass | promptInstallScope picker precedes confirm in bundle.ts; project-scope TTY test |
| Only the tools chosen in the interactive step are installed | pass | Loop over skillsToInstall only; TTY test asserts total:1 |
| The bundle is installed into the scope chosen in the scope-selection step | pass | installScope threads into buildInstallPlan; project-dir file assertion + scope in JSON |

<!-- gitissue:qa v1 head=13bb1ac79f277b5d3fece18e7ca0a5f9688c58b6 profile=full cycles=2 review=clean tests=2661@13bb1ac79f277b5d3fece18e7ca0a5f9688c58b6 ui=none -->
