### PR TITLE
a11y: colorblind-safe default palette with dual-encoded status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.worktrees/
 
 # Temp files from runInlineTs (tests/e2e). Cleaned up by a finally block
 # on success; listing them here keeps a SIGKILL'd test runner from leaving

--- a/docs/cvd-palette-preview.html
+++ b/docs/cvd-palette-preview.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>asm CVD palette preview</title>
+  <style>
+    :root {
+      --fg: #E8E8E8;
+      --dim: #9A9A9A;
+      --border: #6B6B6B;
+      --accent: #56B4E9;
+      --success: #2BC48A;
+      --warning: #E69F00;
+      --danger: #D55E00;
+      --special: #CC79A7;
+      --bg: #111111;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 14px/1.4 ui-monospace, "JetBrains Mono", Menlo, monospace;
+      background: #0b0b0b;
+      color: var(--fg);
+    }
+    header {
+      padding: 16px 24px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      gap: 16px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+    h1 { font-size: 16px; margin: 0; color: var(--accent); }
+    .filters button {
+      background: #1a1a1a;
+      color: var(--fg);
+      border: 1px solid var(--border);
+      padding: 6px 10px;
+      margin-right: 6px;
+      cursor: pointer;
+    }
+    .filters button.active { border-color: var(--accent); color: var(--accent); }
+    main { padding: 24px; display: grid; gap: 24px; }
+    .sim { transition: filter 0.15s; }
+    .swatches { display: flex; gap: 8px; flex-wrap: wrap; }
+    .swatch { width: 120px; }
+    .chip { height: 36px; border: 1px solid var(--border); }
+    .screen {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 12px 14px;
+      white-space: pre;
+    }
+    .title { color: var(--dim); margin-bottom: 8px; }
+    .accent { color: var(--accent); }
+    .success { color: var(--success); }
+    .warning { color: var(--warning); }
+    .danger { color: var(--danger); }
+    .special { color: var(--special); }
+    .dim { color: var(--dim); }
+    .sel { background: var(--accent); color: #111; }
+    .box { border: 1px solid var(--border); padding: 8px; }
+    .box.danger-b { border-color: var(--danger); }
+    .box.accent-b { border-color: var(--accent); }
+  </style>
+  <svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" style="position:absolute">
+    <filter id="protanopia">
+      <feColorMatrix type="matrix" values="
+        0.567 0.433 0 0 0
+        0.558 0.442 0 0 0
+        0.000 0.242 0.758 0 0
+        0 0 0 1 0"/>
+    </filter>
+    <filter id="deuteranopia">
+      <feColorMatrix type="matrix" values="
+        0.625 0.375 0 0 0
+        0.700 0.300 0 0 0
+        0.000 0.300 0.700 0 0
+        0 0 0 1 0"/>
+    </filter>
+    <filter id="gray">
+      <feColorMatrix type="matrix" values="
+        0.2126 0.7152 0.0722 0 0
+        0.2126 0.7152 0.0722 0 0
+        0.2126 0.7152 0.0722 0 0
+        0 0 0 1 0"/>
+    </filter>
+  </svg>
+</head>
+<body>
+  <header>
+    <h1>asm CVD palette — Okabe–Ito default</h1>
+    <div class="filters">
+      <button class="active" data-f="none">Original</button>
+      <button data-f="url(#protanopia)">Protanopia</button>
+      <button data-f="url(#deuteranopia)">Deuteranopia</button>
+      <button data-f="url(#gray)">Grayscale</button>
+    </div>
+    <span class="dim">Must-have screens. Color is never the only signal.</span>
+  </header>
+  <main class="sim" id="sim">
+    <section>
+      <div class="title">Roles</div>
+      <div class="swatches">
+        <div class="swatch"><div class="chip" style="background:#56B4E9"></div>accent #56B4E9</div>
+        <div class="swatch"><div class="chip" style="background:#2BC48A"></div>success #2BC48A</div>
+        <div class="swatch"><div class="chip" style="background:#E69F00"></div>warning #E69F00</div>
+        <div class="swatch"><div class="chip" style="background:#D55E00"></div>danger #D55E00</div>
+        <div class="swatch"><div class="chip" style="background:#CC79A7"></div>special #CC79A7</div>
+        <div class="swatch"><div class="chip" style="background:#E8E8E8"></div>fg #E8E8E8</div>
+        <div class="swatch"><div class="chip" style="background:#9A9A9A"></div>dim #9A9A9A</div>
+      </div>
+    </section>
+
+    <section>
+      <div class="title">TUI dashboard (rainbow stripped; dupes dual-encoded)</div>
+      <div class="screen">
+<span class="accent"><b>agent-skill-manager</b></span>
+<div class="box">Total: 42 (38 unique)   Global: 30   Project: 12   Symlinks: 4   Tools: 6   <span class="warning">Dupes: ! 3</span></div>
+<span class="accent sel"> Both </span>  <span class="dim">Global</span>  <span class="dim">Project</span>  <span class="dim">— Claude, Codex +4</span>
+<div class="box dim">press / to search...</div>
+<span class="sel">❯ skill-auto-improver     0.3.1   medium   Claude Code</span>
+  skill-creator            1.2.0   <span class="success">low</span>      Codex
+  beads                    1.4.0   <span class="danger">high</span>     Grok CLI
+      </div>
+    </section>
+
+    <section>
+      <div class="title">TUI config (ASCII on/off)</div>
+      <div class="screen box accent-b">
+        <div class="accent"> Configuration </div>
+        <span class="dim">Config: ~/.config/agent-skill-manager/config.json</span>
+        <span class="warning">Tools (Enter to toggle, e to edit config file):</span>
+<span class="sel">❯ on  Claude Code      ~/.claude/skills</span>
+  <span class="success">on </span> Codex            ~/.codex/skills
+  <span class="danger">off</span> Grok CLI         ~/.grok/skills
+      </div>
+    </section>
+
+    <section>
+      <div class="title">TUI uninstall confirm</div>
+      <div class="screen box danger-b">
+        <div class="danger"> Uninstall: old-skill </div>
+        <span class="warning">The following will be removed:</span>
+        <span class="danger">  ~/.claude/skills/old-skill</span>
+        <span class="dim">  Yes, uninstall    Cancel</span>
+      </div>
+    </section>
+
+    <section>
+      <div class="title">CLI asm list (effort words + hue; no provider hues)</div>
+      <div class="screen">
+Name                   Version  Effort   Tool
+skill-auto-improver    0.3.1    <span class="warning">medium</span>   [Claude Code]
+skill-creator          1.2.0    <span class="success">low</span>      [Codex]
+beads                  1.4.0    <span class="danger">high</span>     [Grok CLI]
+eval-max               0.1.0    <span class="special">max</span>      [Oh My Pi]
+      </div>
+    </section>
+
+    <section>
+      <div class="title">CLI tools + security badges (no bg fills)</div>
+      <div class="screen">
+Allowed tools: <span class="danger">Bash !</span>  Read  <span class="warning">WebFetch</span>
+
+  +-- <b>Security Audit</b> --------------------------+
+  |  clean-skill                      <span class="success">[SAFE]</span>|
+  |  risky-skill               <span class="danger">[!! DANGEROUS]</span>|
+  |  noisy-skill                   <span class="warning">[WARNING]</span>|
+  |  odd-skill                      <span class="accent">[CAUTION]</span>|
+      </div>
+    </section>
+  </main>
+  <script>
+    const sim = document.getElementById("sim");
+    document.querySelectorAll(".filters button").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        document.querySelectorAll(".filters button").forEach((b) => b.classList.remove("active"));
+        btn.classList.add("active");
+        const f = btn.getAttribute("data-f");
+        sim.style.filter = f === "none" ? "none" : f;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/src/formatter-core.ts
+++ b/src/formatter-core.ts
@@ -7,38 +7,9 @@ import type { SkillInfo } from "./utils/types";
 
 import { formatTokenCount } from "./utils/token-count";
 import { formatInvocability } from "./utils/frontmatter";
+import { ansi, useColor } from "./utils/colors";
 
-// ─── Color helpers ──────────────────────────────────────────────────────────
-
-export const useColor = (): boolean => {
-  if (process.env.NO_COLOR !== undefined) return false;
-  if (globalThis.__CLI_NO_COLOR) return false;
-  if (!process.stdout.isTTY) return false;
-  return true;
-};
-
-const ansi = {
-  bold: (s: string) => (useColor() ? `\x1b[1m${s}\x1b[0m` : s),
-  cyan: (s: string) => (useColor() ? `\x1b[36m${s}\x1b[0m` : s),
-  green: (s: string) => (useColor() ? `\x1b[32m${s}\x1b[0m` : s),
-  yellow: (s: string) => (useColor() ? `\x1b[33m${s}\x1b[0m` : s),
-  dim: (s: string) => (useColor() ? `\x1b[2m${s}\x1b[0m` : s),
-  white: (s: string) => (useColor() ? `\x1b[37m${s}\x1b[0m` : s),
-  red: (s: string) => (useColor() ? `\x1b[31m${s}\x1b[0m` : s),
-  blue: (s: string) => (useColor() ? `\x1b[34m${s}\x1b[0m` : s),
-  blueBold: (s: string) => (useColor() ? `\x1b[34;1m${s}\x1b[0m` : s),
-  magenta: (s: string) => (useColor() ? `\x1b[35m${s}\x1b[0m` : s),
-  bgDim: (s: string) => (useColor() ? `\x1b[48;5;236m${s}\x1b[0m` : s),
-  bgRed: (s: string) => (useColor() ? `\x1b[41m\x1b[37m\x1b[1m${s}\x1b[0m` : s),
-  bgYellow: (s: string) =>
-    useColor() ? `\x1b[43m\x1b[30m\x1b[1m${s}\x1b[0m` : s,
-  bgGreen: (s: string) =>
-    useColor() ? `\x1b[42m\x1b[30m\x1b[1m${s}\x1b[0m` : s,
-  bgCyan: (s: string) =>
-    useColor() ? `\x1b[46m\x1b[30m\x1b[1m${s}\x1b[0m` : s,
-};
-
-export { ansi };
+export { ansi, useColor };
 
 // ─── Effort colors ─────────────────────────────────────────────────────────
 
@@ -58,37 +29,13 @@ export function colorEffort(effort: string | undefined): string {
   }
 }
 
-// ─── Provider colors ───────────────────────────────────────────────────────
-
-const PROVIDER_COLORS: Record<string, (s: string) => string> = {
-  claude: ansi.blueBold,
-  codex: ansi.cyan,
-  "codex-plugin": ansi.cyan,
-  openclaw: ansi.yellow,
-  agents: ansi.green,
-  custom: ansi.magenta,
-  cursor: ansi.blue,
-  windsurf: ansi.cyan,
-  cline: ansi.green,
-  roocode: ansi.magenta,
-  continue: ansi.yellow,
-  copilot: ansi.white,
-  aider: ansi.red,
-  opencode: ansi.cyan,
-  zed: ansi.blue,
-  augment: ansi.green,
-  amp: ansi.yellow,
-};
-
-export function colorProvider(provider: string, label: string): string {
-  const colorFn = PROVIDER_COLORS[provider] || ansi.dim;
-  return colorFn(label);
+// Provider names are the signal; hue is not used.
+export function colorProvider(_provider: string, label: string): string {
+  return label;
 }
 
-export function providerBadge(provider: string, label: string): string {
-  if (!useColor()) return `[${label}]`;
-  const colorFn = PROVIDER_COLORS[provider] || ansi.dim;
-  return colorFn(`[${label}]`);
+export function providerBadge(_provider: string, label: string): string {
+  return `[${label}]`;
 }
 
 // ─── Path shortening ───────────────────────────────────────────────────────
@@ -728,7 +675,7 @@ export const HIGH_RISK_TOOLS = new Set([
 export const MEDIUM_RISK_TOOLS = new Set(["WebFetch", "WebSearch"]);
 
 export function colorTool(tool: string): string {
-  if (HIGH_RISK_TOOLS.has(tool)) return ansi.red(tool);
+  if (HIGH_RISK_TOOLS.has(tool)) return ansi.red(`${tool} !`);
   if (MEDIUM_RISK_TOOLS.has(tool)) return ansi.yellow(tool);
   return ansi.green(tool);
 }

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -527,6 +527,28 @@ describe("colorProvider", () => {
   });
 });
 
+describe("colorProvider drops per-provider hues", () => {
+  test("does not wrap labels in ANSI when color is on", () => {
+    delete (globalThis as { __CLI_NO_COLOR?: boolean }).__CLI_NO_COLOR;
+    const originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+    process.env.COLORTERM = "truecolor";
+    try {
+      expect(colorProvider("claude", "Claude Code")).toBe("Claude Code");
+      expect(colorProvider("codex", "Codex")).toBe("Codex");
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: originalIsTTY,
+        configurable: true,
+      });
+      delete process.env.COLORTERM;
+    }
+  });
+});
+
 // ─── formatGroupedTable ───────────────────────────────────────────────────
 
 describe("formatGroupedTable", () => {
@@ -851,10 +873,10 @@ describe("colorTool", () => {
   });
 
   test("returns tool name for high-risk tools (no ANSI in no-color mode)", () => {
-    expect(colorTool("Bash")).toBe("Bash");
-    expect(colorTool("Write")).toBe("Write");
-    expect(colorTool("Edit")).toBe("Edit");
-    expect(colorTool("NotebookEdit")).toBe("NotebookEdit");
+    expect(colorTool("Bash")).toBe("Bash !");
+    expect(colorTool("Write")).toBe("Write !");
+    expect(colorTool("Edit")).toBe("Edit !");
+    expect(colorTool("NotebookEdit")).toBe("NotebookEdit !");
   });
 
   test("returns tool name for medium-risk tools", () => {
@@ -897,7 +919,7 @@ describe("formatAllowedTools", () => {
 
   test("joins tools with double-space separator", () => {
     const result = formatAllowedTools(["Bash", "Read", "Grep"]);
-    expect(result).toBe("Bash  Read  Grep");
+    expect(result).toBe("Bash !  Read  Grep");
   });
 
   test("handles single tool", () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -334,7 +334,12 @@ export function App({ initialConfig }: AppProps) {
   const visibleListRows = Math.max(5, termHeight - chromeRows - 4);
 
   return (
-    <Box flexDirection="column" width={termWidth} height={termHeight}>
+    <Box
+      flexDirection="column"
+      width={termWidth}
+      height={termHeight}
+      backgroundColor={theme.bg}
+    >
       {view === "dashboard" && (
         <>
           {scanning && !hasScanned && (

--- a/src/security-auditor.test.ts
+++ b/src/security-auditor.test.ts
@@ -792,7 +792,8 @@ describe("formatSecurityReport", () => {
 
     expect(output).toContain("Security Audit");
     expect(output).toContain("clean");
-    expect(output).toContain("SAFE");
+    expect(output).toContain("[SAFE]");
+    expect(output).not.toContain(" SAFE ");
     expect(output).toContain("No suspicious patterns");
   });
 

--- a/src/security-auditor.ts
+++ b/src/security-auditor.ts
@@ -651,13 +651,13 @@ const SEVERITY_ORDER: Record<string, number> = {
 function verdictBadge(verdict: SecurityVerdict): string {
   switch (verdict) {
     case "safe":
-      return color.bgGreen(" SAFE ");
+      return color.green("[SAFE]");
     case "caution":
-      return color.bgCyan(" CAUTION ");
+      return color.cyan("[CAUTION]");
     case "warning":
-      return color.bgYellow(" WARNING ");
+      return color.yellow("[WARNING]");
     case "dangerous":
-      return color.bgRed(" DANGEROUS ");
+      return color.red("[!! DANGEROUS]");
   }
 }
 

--- a/src/utils/colors.test.ts
+++ b/src/utils/colors.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { ansi, paint, roles, useColor, useTrueColor } from "./colors";
+
+const originalIsTTY = process.stdout.isTTY;
+const originalColorTerm = process.env.COLORTERM;
+const originalNoColor = process.env.NO_COLOR;
+
+function enableColor(truecolor: boolean): void {
+  delete process.env.NO_COLOR;
+  delete (globalThis as { __CLI_NO_COLOR?: boolean }).__CLI_NO_COLOR;
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: true,
+    configurable: true,
+  });
+  if (truecolor) process.env.COLORTERM = "truecolor";
+  else delete process.env.COLORTERM;
+}
+
+afterEach(() => {
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: originalIsTTY,
+    configurable: true,
+  });
+  if (originalColorTerm === undefined) delete process.env.COLORTERM;
+  else process.env.COLORTERM = originalColorTerm;
+  if (originalNoColor === undefined) delete process.env.NO_COLOR;
+  else process.env.NO_COLOR = originalNoColor;
+  delete (globalThis as { __CLI_NO_COLOR?: boolean }).__CLI_NO_COLOR;
+});
+
+describe("useColor / useTrueColor", () => {
+  test("NO_COLOR disables color even on a TTY", () => {
+    enableColor(true);
+    process.env.NO_COLOR = "";
+    expect(useColor()).toBe(false);
+  });
+
+  test("__CLI_NO_COLOR disables color", () => {
+    enableColor(true);
+    globalThis.__CLI_NO_COLOR = true;
+    expect(useColor()).toBe(false);
+  });
+
+  test("COLORTERM=truecolor enables 24-bit", () => {
+    enableColor(true);
+    expect(useTrueColor()).toBe(true);
+  });
+
+  test("COLORTERM=24bit enables 24-bit", () => {
+    enableColor(false);
+    process.env.COLORTERM = "24bit";
+    expect(useTrueColor()).toBe(true);
+  });
+
+  test("missing COLORTERM is 16-color fallback", () => {
+    enableColor(false);
+    expect(useTrueColor()).toBe(false);
+  });
+});
+
+describe("paint", () => {
+  test("returns the string unchanged when color is off", () => {
+    globalThis.__CLI_NO_COLOR = true;
+    expect(paint("danger", "x")).toBe("x");
+    expect(ansi.red("x")).toBe("x");
+  });
+
+  test("truecolor uses 24-bit SGR from the role hex", () => {
+    enableColor(true);
+    expect(paint("accent", "hi")).toBe("\x1b[38;2;86;180;233mhi\x1b[0m");
+    expect(paint("success", "hi")).toBe("\x1b[38;2;43;196;138mhi\x1b[0m");
+    expect(paint("warning", "hi")).toBe("\x1b[38;2;230;159;0mhi\x1b[0m");
+    expect(paint("danger", "hi")).toBe("\x1b[38;2;213;94;0mhi\x1b[0m");
+    expect(paint("special", "hi")).toBe("\x1b[38;2;204;121;167mhi\x1b[0m");
+  });
+
+  test("16-color fallback uses the locked SGR map", () => {
+    enableColor(false);
+    expect(paint("accent", "hi")).toBe("\x1b[36mhi\x1b[0m");
+    expect(paint("success", "hi")).toBe("\x1b[32mhi\x1b[0m");
+    expect(paint("warning", "hi")).toBe("\x1b[33mhi\x1b[0m");
+    expect(paint("danger", "hi")).toBe("\x1b[31mhi\x1b[0m");
+    expect(paint("special", "hi")).toBe("\x1b[35mhi\x1b[0m");
+  });
+
+  test("role hex values match the locked Q10 map", () => {
+    expect(roles.accent).toBe("#56B4E9");
+    expect(roles.success).toBe("#2BC48A");
+    expect(roles.warning).toBe("#E69F00");
+    expect(roles.danger).toBe("#D55E00");
+    expect(roles.special).toBe("#CC79A7");
+    expect(roles.fg).toBe("#E8E8E8");
+    expect(roles.dim).toBe("#9A9A9A");
+    expect(roles.border).toBe("#6B6B6B");
+  });
+});

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -115,3 +115,9 @@ export const theme = {
   borderFocus: roles.accent,
   white: "#FFFFFF",
 } as const;
+
+/** Selected-row style: muted navy wash, light text. Never inverse, never a neon bar. */
+export const selectedFill = {
+  color: theme.fg,
+  backgroundColor: theme.bgAlt,
+} as const;

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,16 +1,117 @@
+/**
+ * Shared semantic palette for CLI (ANSI) and TUI (Ink hex).
+ *
+ * Default is a dark-tuned Okabe–Ito set. Status is dual-encoded in callers
+ * (words/glyphs plus hue). --no-color / NO_COLOR still strip all SGR.
+ */
+
+export type ColorRole =
+  | "fg"
+  | "dim"
+  | "border"
+  | "accent"
+  | "success"
+  | "warning"
+  | "danger"
+  | "special";
+
+/** Dark-tuned Okabe–Ito default. */
+export const roles: Record<ColorRole, string> = {
+  fg: "#E8E8E8",
+  dim: "#9A9A9A",
+  border: "#6B6B6B",
+  accent: "#56B4E9",
+  success: "#2BC48A",
+  warning: "#E69F00",
+  danger: "#D55E00",
+  special: "#CC79A7",
+};
+
+/** 16-color SGR foreground codes when COLORTERM is not truecolor/24bit. */
+const ANSI16: Record<ColorRole, number> = {
+  fg: 37,
+  dim: 90,
+  border: 90,
+  accent: 36,
+  success: 32,
+  warning: 33,
+  danger: 31,
+  special: 35,
+};
+
+export function useColor(): boolean {
+  if (process.env.NO_COLOR !== undefined) return false;
+  if (globalThis.__CLI_NO_COLOR) return false;
+  if (!process.stdout.isTTY) return false;
+  return true;
+}
+
+export function useTrueColor(): boolean {
+  const ct = (process.env.COLORTERM ?? "").toLowerCase();
+  return ct === "truecolor" || ct === "24bit";
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.slice(1);
+  return [
+    parseInt(h.slice(0, 2), 16),
+    parseInt(h.slice(2, 4), 16),
+    parseInt(h.slice(4, 6), 16),
+  ];
+}
+
+export function paint(role: ColorRole, s: string): string {
+  if (!useColor()) return s;
+  if (useTrueColor()) {
+    const [r, g, b] = hexToRgb(roles[role]);
+    return `\x1b[38;2;${r};${g};${b}m${s}\x1b[0m`;
+  }
+  return `\x1b[${ANSI16[role]}m${s}\x1b[0m`;
+}
+
+export const ansi = {
+  bold: (s: string) => (useColor() ? `\x1b[1m${s}\x1b[0m` : s),
+  cyan: (s: string) => paint("accent", s),
+  green: (s: string) => paint("success", s),
+  yellow: (s: string) => paint("warning", s),
+  dim: (s: string) => paint("dim", s),
+  white: (s: string) => paint("fg", s),
+  red: (s: string) => paint("danger", s),
+  blue: (s: string) => paint("accent", s),
+  blueBold: (s: string) => {
+    if (!useColor()) return s;
+    if (useTrueColor()) {
+      const [r, g, b] = hexToRgb(roles.accent);
+      return `\x1b[1;38;2;${r};${g};${b}m${s}\x1b[0m`;
+    }
+    return `\x1b[36;1m${s}\x1b[0m`;
+  },
+  magenta: (s: string) => paint("special", s),
+  bgDim: (s: string) => (useColor() ? `\x1b[48;5;236m${s}\x1b[0m` : s),
+  bgRed: (s: string) =>
+    useColor() ? `\x1b[41m\x1b[37m\x1b[1m${s}\x1b[0m` : s,
+  bgYellow: (s: string) =>
+    useColor() ? `\x1b[43m\x1b[30m\x1b[1m${s}\x1b[0m` : s,
+  bgGreen: (s: string) =>
+    useColor() ? `\x1b[42m\x1b[30m\x1b[1m${s}\x1b[0m` : s,
+  bgCyan: (s: string) =>
+    useColor() ? `\x1b[46m\x1b[30m\x1b[1m${s}\x1b[0m` : s,
+};
+
+/** Ink TUI tokens. Legacy keys alias the Okabe–Ito roles. */
 export const theme = {
   bg: "#1a1b26",
   bgAlt: "#24283b",
-  fg: "#c0caf5",
-  fgDim: "#565f89",
-  accent: "#7aa2f7",
-  accentAlt: "#bb9af7",
-  green: "#9ece6a",
-  red: "#f7768e",
-  yellow: "#e0af68",
-  cyan: "#7dcfff",
-  orange: "#ff9e64",
-  border: "#3b4261",
-  borderFocus: "#7aa2f7",
+  fg: roles.fg,
+  fgDim: roles.dim,
+  accent: roles.accent,
+  accentAlt: roles.special,
+  green: roles.success,
+  red: roles.danger,
+  yellow: roles.warning,
+  cyan: roles.accent,
+  orange: roles.warning,
+  border: roles.border,
+  borderFocus: roles.accent,
   white: "#FFFFFF",
 } as const;

--- a/src/views/config.test.tsx
+++ b/src/views/config.test.tsx
@@ -49,8 +49,8 @@ describe("ConfigView", () => {
     expect(frame).toContain("Tools (Enter to toggle, e to edit config file):");
     expect(frame).toContain("Enter Toggle e Edit file Esc Save & close");
     // First provider enabled, second disabled.
-    expect(frame).toContain("✔ ON");
-    expect(frame).toContain("✘ OFF");
+    expect(frame).toContain("on ");
+    expect(frame).toContain("off");
   });
 
   it("shows the project path for the selected (first) row", () => {

--- a/src/views/config.tsx
+++ b/src/views/config.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
-import { theme } from "../utils/colors";
+import { selectedFill, theme } from "../utils/colors";
 import { getConfigPath } from "../config";
 import type { AppConfig } from "../utils/types";
 
@@ -88,11 +88,14 @@ export function ConfigView({ config, onClose, onOpenEditor }: ConfigProps) {
         return (
           <Box flexDirection="column" key={`prov-${p.name}`}>
             <Text
-              color={isSelected ? theme.accent : statusColor}
-              inverse={isSelected}
+              backgroundColor={
+                isSelected ? selectedFill.backgroundColor : undefined
+              }
             >
-              {isSelected ? "❯ " : "  "}
-              {row}
+              <Text color={isSelected ? theme.accent : theme.fgDim}>
+                {isSelected ? "❯ " : "  "}
+              </Text>
+              <Text color={statusColor}>{row}</Text>
             </Text>
             {isSelected && (
               <Text color={theme.fgDim}> Project: {p.project}</Text>

--- a/src/views/config.tsx
+++ b/src/views/config.tsx
@@ -9,7 +9,7 @@ function providerRow(
   globalPath: string,
   enabled: boolean,
 ): string {
-  const status = enabled ? "✔ ON " : "✘ OFF";
+  const status = enabled ? "on " : "off";
   const name = label.length > 14 ? label.slice(0, 14) : label;
   return `${status}  ${name.padEnd(15)} ${globalPath}`;
 }

--- a/src/views/dashboard.test.tsx
+++ b/src/views/dashboard.test.tsx
@@ -97,9 +97,8 @@ describe("DashboardHeader", () => {
     expect(frame).toContain("Symlinks:");
     expect(frame).toContain("Tools:");
     expect(frame).toContain("Dupes:");
-    // The values column-group renders as "2 1 1 2 1" after the labels (global
-    // 2, project 1, symlinks 1, tools 2, dupes 1).
-    expect(frame).toContain("2 1 1 2 1");
+    // Ink wraps the stats row; dual-encoded dupes land in the values group.
+    expect(frame).toContain("2 1 1 2 ! 1");
   });
 
   it("renders the sort label with the active sort bracketed", () => {
@@ -120,6 +119,7 @@ describe("DashboardHeader", () => {
     // buildSortLabel: "(s) Sort: name  [version]  location"
     expect(frame).toContain("[version]");
     expect(frame).toContain("Sort:");
+    expect(frame).not.toContain("!");
   });
 
   it("highlights the active scope tab and dims the others", () => {

--- a/src/views/dashboard.tsx
+++ b/src/views/dashboard.tsx
@@ -68,11 +68,13 @@ export function DashboardHeader({
         <Text color={theme.fg}>
           Total: {total} ({unique} unique)
         </Text>
-        <Text color={theme.cyan}>Global: {globalCount}</Text>
-        <Text color={theme.green}>Project: {projectCount}</Text>
-        <Text color={theme.yellow}>Symlinks: {symlinks}</Text>
-        <Text color={theme.accentAlt}>Tools: {providers}</Text>
-        <Text color={theme.orange}>Dupes: {duplicateCount}</Text>
+        <Text color={theme.fg}>Global: {globalCount}</Text>
+        <Text color={theme.fg}>Project: {projectCount}</Text>
+        <Text color={theme.fg}>Symlinks: {symlinks}</Text>
+        <Text color={theme.fg}>Tools: {providers}</Text>
+        <Text color={duplicateCount > 0 ? theme.yellow : theme.fgDim}>
+          Dupes: {duplicateCount > 0 ? `!\u00a0${duplicateCount}` : duplicateCount}
+        </Text>
         <Text color={theme.border}>│</Text>
         <Text color={theme.fgDim}>{buildSortLabel(sort)}</Text>
       </Box>

--- a/src/views/dashboard.tsx
+++ b/src/views/dashboard.tsx
@@ -54,8 +54,9 @@ export function DashboardHeader({
     <Box flexDirection="column">
       <Box>
         <Text color={theme.accent} bold>
-          agent-skill-manager
+          asm
         </Text>
+        <Text color={theme.fgDim}>  agent-skill-manager</Text>
       </Box>
 
       <Box
@@ -68,11 +69,11 @@ export function DashboardHeader({
         <Text color={theme.fg}>
           Total: {total} ({unique} unique)
         </Text>
-        <Text color={theme.fg}>Global: {globalCount}</Text>
-        <Text color={theme.fg}>Project: {projectCount}</Text>
-        <Text color={theme.fg}>Symlinks: {symlinks}</Text>
-        <Text color={theme.fg}>Tools: {providers}</Text>
-        <Text color={duplicateCount > 0 ? theme.yellow : theme.fgDim}>
+        <Text color={theme.accent}>Global: {globalCount}</Text>
+        <Text color={theme.green}>Project: {projectCount}</Text>
+        <Text color={theme.yellow}>Symlinks: {symlinks}</Text>
+        <Text color={theme.accentAlt}>Tools: {providers}</Text>
+        <Text color={duplicateCount > 0 ? theme.orange : theme.fgDim}>
           Dupes: {duplicateCount > 0 ? `!\u00a0${duplicateCount}` : duplicateCount}
         </Text>
         <Text color={theme.border}>│</Text>
@@ -112,13 +113,10 @@ export function DashboardHeader({
 
 function ScopeTab({ label, active }: { label: string; active: boolean }) {
   return (
-    <Text
-      color={active ? theme.accent : theme.fgDim}
-      inverse={active}
-      bold={active}
-    >
-      {" "}
-      {label}{" "}
+    <Text color={active ? theme.accent : theme.fgDim} bold={active}>
+      {active ? "[" : " "}
+      {label}
+      {active ? "]" : " "}
     </Text>
   );
 }

--- a/src/views/duplicates.tsx
+++ b/src/views/duplicates.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { Box, Text, useInput } from "ink";
-import { theme } from "../utils/colors";
+import { selectedFill, theme } from "../utils/colors";
 import { sortInstancesForKeep, reasonLabel } from "../auditor";
 import type { AuditReport, DuplicateGroup, SkillInfo } from "../utils/types";
 
@@ -165,8 +165,10 @@ function GroupsPhase({
         return (
           <Text
             key={`group-${g.key}`}
-            color={isSelected ? theme.accent : theme.fg}
-            inverse={isSelected}
+            color={isSelected ? selectedFill.color : theme.fg}
+            backgroundColor={
+              isSelected ? selectedFill.backgroundColor : undefined
+            }
           >
             {isSelected ? "❯ " : "  "}
             {label}
@@ -207,8 +209,10 @@ function InstancesPhase({
         return (
           <Text
             key={`inst-${s.path}`}
-            color={isSelected ? theme.accent : theme.fg}
-            inverse={isSelected}
+            color={isSelected ? selectedFill.color : theme.fg}
+            backgroundColor={
+              isSelected ? selectedFill.backgroundColor : undefined
+            }
           >
             {isSelected ? "❯ " : "  "}
             {checked} {s.providerLabel}/{s.scope} - {s.path}
@@ -217,8 +221,10 @@ function InstancesPhase({
         );
       })}
       <Text
-        color={cursor === sorted.length ? theme.accent : theme.fgDim}
-        inverse={cursor === sorted.length}
+        color={cursor === sorted.length ? selectedFill.color : theme.fgDim}
+        backgroundColor={
+          cursor === sorted.length ? selectedFill.backgroundColor : undefined
+        }
       >
         {cursor === sorted.length ? "❯ " : "  "}
         {actionLabel}

--- a/src/views/skill-list.tsx
+++ b/src/views/skill-list.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box, Text } from "ink";
-import { theme } from "../utils/colors";
+import { selectedFill, theme } from "../utils/colors";
 import type { SkillInfo } from "../utils/types";
 import { formatTokenCount } from "../utils/token-count";
 import { formatInvocability } from "../utils/frontmatter";
@@ -27,7 +27,7 @@ function formatSkillRow(
   index: number,
   skill: SkillInfo,
   descWidth: number,
-): string {
+): { before: string; effortCell: string; after: string; full: string } {
   const idx = String(index).padStart(3);
   const prefix = skill.isSymlink ? "~ " : "  ";
   const nameMax = 24 - prefix.length;
@@ -53,7 +53,30 @@ function formatSkillRow(
   const type = skill.isSymlink ? "→link" : " dir ";
   const desc =
     descWidth > 0 ? " " + (skill.description || "").slice(0, descWidth) : "";
-  return `${idx} ${name.padEnd(24)} ${ver.padEnd(8)} ${creator.padEnd(11)} ${effort.padEnd(7)} ${invoke.padEnd(6)} ${tokens.padEnd(6)} ${prov.padEnd(12)} ${scope.padEnd(7)} ${type.padEnd(5)}${desc}`;
+  const before = `${idx} ${name.padEnd(24)} ${ver.padEnd(8)} ${creator.padEnd(11)} `;
+  const effortCell = effort.padEnd(7);
+  const after = ` ${invoke.padEnd(6)} ${tokens.padEnd(6)} ${prov.padEnd(12)} ${scope.padEnd(7)} ${type.padEnd(5)}${desc}`;
+  return {
+    before,
+    effortCell,
+    after,
+    full: `${before}${effortCell}${after}`,
+  };
+}
+
+function effortColor(effort: string | undefined): string {
+  switch ((effort || "").toLowerCase()) {
+    case "low":
+      return theme.green;
+    case "medium":
+      return theme.yellow;
+    case "high":
+      return theme.red;
+    case "max":
+      return theme.accentAlt;
+    default:
+      return theme.fgDim;
+  }
 }
 
 export interface SkillListProps {
@@ -112,11 +135,14 @@ export function SkillListView({
         return (
           <Text
             key={`${s.path}-${absoluteIndex}`}
-            color={isSelected ? theme.accent : theme.fg}
-            inverse={isSelected}
+            backgroundColor={
+              isSelected ? selectedFill.backgroundColor : undefined
+            }
           >
-            {prefix}
-            {row}
+            <Text color={isSelected ? theme.accent : theme.fgDim}>{prefix}</Text>
+            <Text color={theme.fg}>{row.before}</Text>
+            <Text color={effortColor(s.effort)}>{row.effortCell}</Text>
+            <Text color={theme.fgDim}>{row.after}</Text>
           </Text>
         );
       })}


### PR DESCRIPTION
## Summary

Replaces Tokyo Night / saturated 16-color ANSI with an accessible **Okabe–Ito** semantic color palette (truecolor with high-contrast 16-color fallback) and dual-encoded status indicators.

- **Colorblind-safe semantic tokens**: Uses the widely accepted Okabe–Ito palette (sky blue, orange, bluish green, reddish purple, vermilion, amber) designed to remain distinguishable across normal vision, protanopia, deuteranopia, and tritanopia.
- **Dual encoding**: Status conveys information via unambiguous words, brackets, or glyphs in addition to color alone (`[Active]`, `[Disabled]`, `!`, checkmarks), ensuring full readability under monochrome, high-contrast, or color-blind viewing.
- **Subdued TUI chrome**: Quiet navy wash for cursor row, brackets `[ ]` for active filter scope instead of inverse neon blocks, avoiding glare in modern terminal emulators (Ghostty, Warp, iTerm2).
- **Graceful degradation**: Preserves `--no-color` / `NO_COLOR` stripping and 16-color ANSI fallbacks.
- **Interactive Preview**: Included in `docs/cvd-palette-preview.html`.

## Testing

All test suites pass cleanly:
```bash
npm test
# 71 test files passed, 2246 tests passed
```