### PR TITLE
feat(seo): indexable static category pages + sitemap/llms wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ website/assets/index-*.css
 # stale numbers/dates — website-src/ templates are the single source of truth.
 website/llms.txt
 website/sitemap.xml
+website/categories/
 website/assets/og-image.svg
 website/assets/og-image.png
 

--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -22,6 +22,12 @@ import { fileURLToPath } from "url";
 import MiniSearch from "minisearch";
 import { MINISEARCH_OPTIONS } from "./minisearch-options";
 import {
+  categoryMeta,
+  renderCategoryPage,
+  renderLlmsCategoryLines,
+  renderSitemapCategoryUrls,
+} from "./category-seo";
+import {
   repoBundlesForIndex,
   type RepoBundleManifest,
 } from "../src/repo-bundles";
@@ -914,12 +920,15 @@ if (existsSync(ogImagePngSrc)) {
 // of sync with the catalog again. index.html counts are injected separately by
 // the Vite `inject-catalog-counts` plugin during `build:site`.
 const seoSrcDir = join(root, "website-src");
+// catalog.generatedAt is an ISO timestamp; sitemap <lastmod> wants YYYY-MM-DD.
+const seoLastmod = catalog.generatedAt.slice(0, 10);
 const seoTokens: Record<string, string> = {
   "{{SKILL_COUNT}}": String(catalog.totalSkills),
   "{{REPO_COUNT}}": String(catalog.totalRepos),
   "{{CATEGORY_COUNT}}": String(categories.length),
-  // catalog.generatedAt is an ISO timestamp; sitemap <lastmod> wants YYYY-MM-DD.
-  "{{LASTMOD}}": catalog.generatedAt.slice(0, 10),
+  "{{LASTMOD}}": seoLastmod,
+  "{{CATEGORY_URLS}}": renderSitemapCategoryUrls(categories, seoLastmod),
+  "{{CATEGORY_LINKS}}": renderLlmsCategoryLines(categories),
 };
 // Each entry renders website-src/<from> → website/<to> with token substitution.
 const seoTemplates: { from: string; to: string }[] = [
@@ -949,6 +958,44 @@ function renderSeoTemplate(from: string, to: string): void {
 }
 for (const { from, to } of seoTemplates) {
   renderSeoTemplate(from, to);
+}
+
+// ─── Static category pages (category SEO) ───────────────────────────────────
+// One crawlable HTML page per category at website/categories/<slug>.html:
+// unique title/description/H1, self-canonical, CollectionPage + ItemList +
+// BreadcrumbList JSON-LD. The SPA keeps its HashRouter — these static pages
+// are the indexable surface crawlers (including no-JS AI crawlers) read.
+// Skills sort best-score-first, same comparator as the related-skills shelf.
+const categoriesDir = join(outDir, "categories");
+mkdirSync(categoriesDir, { recursive: true });
+for (const category of categories) {
+  categoryMeta(category); // validates the slug has a label/description
+  const catSkills = skills
+    .filter((s) => s.categories.includes(category))
+    .sort(
+      (a, b) =>
+        (b.evalSummary?.overallScore ?? -1) -
+          (a.evalSummary?.overallScore ?? -1) || a.name.localeCompare(b.name),
+    )
+    .map((s) => ({
+      id: s.id,
+      name: s.name,
+      description: s.description,
+      owner: s.owner,
+      repo: s.repo,
+      overallScore: s.evalSummary?.overallScore,
+      grade: s.evalSummary?.grade,
+    }));
+  writeFileSync(
+    join(categoriesDir, `${category}.html`),
+    renderCategoryPage({
+      slug: category,
+      skills: catSkills,
+      totalRepos: repos.length,
+      lastmod: seoLastmod,
+    }),
+    "utf-8",
+  );
 }
 
 // ─── Per-Repo and Per-Author Stats (issue #344) ─────────────────────────────
@@ -1164,7 +1211,7 @@ console.log(
 );
 console.log(`    skills/*.json:    ${detailFilesWritten} files`);
 console.log(
-  `  SEO: llms.txt, sitemap.xml, robots.txt, og-image.svg rendered (skills=${catalog.totalSkills}, repos=${catalog.totalRepos}, lastmod=${seoTokens["{{LASTMOD}}"]})`,
+  `  SEO: llms.txt, sitemap.xml, robots.txt, og-image.svg rendered + ${categories.length} category pages (skills=${catalog.totalSkills}, repos=${catalog.totalRepos}, lastmod=${seoTokens["{{LASTMOD}}"]})`,
 );
 
 // Category distribution

--- a/scripts/category-seo.ts
+++ b/scripts/category-seo.ts
@@ -157,7 +157,7 @@ export function renderCategoryPage(input: CategoryPageInput): string {
       const skillUrl = `${SITE_BASE}/#/skills/${encodeURIComponent(s.id)}`;
       const score =
         s.overallScore !== undefined
-          ? ` · score ${s.overallScore}/100 (grade ${s.grade})`
+          ? ` · score ${escapeHtml(String(s.overallScore ?? ""))}/100 (grade ${escapeHtml(s.grade ?? "")})`
           : "";
       return (
         `      <li><a href="${skillUrl}">${escapeHtml(s.name)}</a>\n` +

--- a/scripts/category-seo.ts
+++ b/scripts/category-seo.ts
@@ -1,0 +1,263 @@
+/**
+ * Category SEO helpers — static category pages, sitemap + llms.txt tokens.
+ *
+ * Pure, zero-dependency module imported by `scripts/build-catalog.ts`.
+ * Asserted by `tests/e2e/build-verification.test.ts`.
+ *
+ * Single source of truth for category labels/descriptions. The website
+ * runtime mirror (`website-src/src/lib/category-seo.js`, labels/URLs only)
+ * must stay in sync — curated descriptions live here alone.
+ */
+
+export const SITE_BASE = "https://luongnv.com/asm";
+
+export interface CategoryMeta {
+  label: string;
+  description: string;
+}
+
+/** Display labels + indexable intro copy per category slug. */
+export const CATEGORY_META: Record<string, CategoryMeta> = {
+  "ai-agents": {
+    label: "AI Agents",
+    description: "Skills for building and managing AI agents",
+  },
+  backend: {
+    label: "Backend",
+    description: "Server-side development skills",
+  },
+  coding: {
+    label: "Coding",
+    description: "General coding assistance and utilities",
+  },
+  design: {
+    label: "Design",
+    description: "UI/UX design and frontend styling",
+  },
+  devops: {
+    label: "DevOps",
+    description: "CI/CD, deployment, and infrastructure",
+  },
+  finance: {
+    label: "Finance",
+    description: "Financial tools and analysis",
+  },
+  frontend: {
+    label: "Frontend",
+    description: "Client-side web development",
+  },
+  git: {
+    label: "Git",
+    description: "Version control and repository management",
+  },
+  marketing: {
+    label: "Marketing",
+    description: "Content creation and SEO",
+  },
+  mobile: {
+    label: "Mobile",
+    description: "iOS and Android development",
+  },
+  productivity: {
+    label: "Productivity",
+    description: "Workflow automation and efficiency",
+  },
+  research: {
+    label: "Research",
+    description: "Information gathering and analysis",
+  },
+  security: {
+    label: "Security",
+    description: "Security auditing and hardening",
+  },
+  testing: {
+    label: "Testing",
+    description: "Test automation and QA",
+  },
+  writing: {
+    label: "Writing",
+    description: "Documentation and content writing",
+  },
+  general: {
+    label: "General",
+    description: "Miscellaneous utility skills",
+  },
+};
+
+/** Label/description for a slug, with a title-case fallback for new categories. */
+export function categoryMeta(slug: string): CategoryMeta {
+  const known = CATEGORY_META[slug];
+  if (known) return known;
+  const label = slug
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+  return {
+    label,
+    description: `Open-source agent skills for ${label.toLowerCase()}`,
+  };
+}
+
+/** Canonical URL of a static category page. */
+export function categoryPageUrl(slug: string): string {
+  return `${SITE_BASE}/categories/${slug}.html`;
+}
+
+/** SPA URL with the category pre-filtered (for "open in catalog" links). */
+export function categoryAppUrl(slug: string): string {
+  return `${SITE_BASE}/#/skills?cat=${encodeURIComponent(slug)}`;
+}
+
+export function escapeHtml(s: string): string {
+  return (s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export interface CategoryPageSkill {
+  id: string;
+  name: string;
+  description: string;
+  owner: string;
+  repo: string;
+  overallScore?: number;
+  grade?: string;
+}
+
+export interface CategoryPageInput {
+  slug: string;
+  skills: CategoryPageSkill[];
+  totalRepos: number;
+  lastmod: string;
+}
+
+/**
+ * Full static HTML for one category page: unique title/description/H1,
+ * self-canonical, and CollectionPage + ItemList + BreadcrumbList JSON-LD.
+ * The visible list and the ItemList markup describe the same skills.
+ */
+export function renderCategoryPage(input: CategoryPageInput): string {
+  const { label, description } = categoryMeta(input.slug);
+  const url = categoryPageUrl(input.slug);
+  const count = input.skills.length;
+  const title = `${label} Skills (${count}) — asm skill catalog`;
+  const metaDesc =
+    `${description}. Browse ${count} free, open-source ${label} ` +
+    `skills for AI coding agents — install any of them with a single command.`;
+
+  const items = input.skills
+    .map((s) => {
+      const skillUrl = `${SITE_BASE}/#/skills/${encodeURIComponent(s.id)}`;
+      const score =
+        s.overallScore !== undefined
+          ? ` · score ${s.overallScore}/100 (grade ${s.grade})`
+          : "";
+      return (
+        `      <li><a href="${skillUrl}">${escapeHtml(s.name)}</a>\n` +
+        `        <span>${escapeHtml(s.owner)}/${escapeHtml(s.repo)}${score}</span><br>\n` +
+        `        ${escapeHtml(s.description)}</li>`
+      );
+    })
+    .join("\n");
+
+  const listItems = input.skills
+    .map(
+      (s, i) => `      {
+        "@type": "ListItem",
+        "position": ${i + 1},
+        "name": ${JSON.stringify(s.name)},
+        "url": "${SITE_BASE}/#/skills/${encodeURIComponent(s.id)}"
+      }`,
+    )
+    .join(",\n");
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${escapeHtml(title)}</title>
+    <meta name="description" content="${escapeHtml(metaDesc)}" />
+    <link rel="canonical" href="${url}" />
+    <meta property="og:title" content="${escapeHtml(title)}" />
+    <meta property="og:description" content="${escapeHtml(metaDesc)}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="${url}" />
+    <meta property="og:image" content="${SITE_BASE}/assets/og-image.png" />
+    <meta property="og:image:alt" content="agent-skill-manager (asm) — one tool to manage every AI agent's skills" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="${escapeHtml(title)}" />
+    <meta name="twitter:description" content="${escapeHtml(metaDesc)}" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "@id": "${url}",
+        "url": "${url}",
+        "name": ${JSON.stringify(`${label} Skills — asm skill catalog`)},
+        "description": ${JSON.stringify(metaDesc)},
+        "isPartOf": { "@id": "${SITE_BASE}/#webapp" },
+        "mainEntity": {
+          "@type": "ItemList",
+          "numberOfItems": ${count},
+          "itemListElement": [
+${listItems}
+          ]
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "Home", "item": "${SITE_BASE}/" },
+          { "@type": "ListItem", "position": 2, "name": "Skills", "item": "${SITE_BASE}/#/skills" },
+          { "@type": "ListItem", "position": 3, "name": ${JSON.stringify(label)}, "item": "${url}" }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <main style="max-width: 860px; margin: 0 auto; padding: 2rem 1.25rem; font-family: system-ui, sans-serif; line-height: 1.6;">
+      <nav aria-label="Breadcrumb"><a href="${SITE_BASE}/">Home</a> / <a href="${SITE_BASE}/#/skills">Skills</a> / ${escapeHtml(label)}</nav>
+      <h1>${escapeHtml(label)} Skills</h1>
+      <p>${escapeHtml(description)}. This page lists all ${count} ${escapeHtml(label)} skills indexed from ${input.totalRepos} repositories (updated ${escapeHtml(input.lastmod)}). Every skill is free and open source — open one for the install command, or <a href="${categoryAppUrl(input.slug)}">filter the interactive catalog to ${escapeHtml(label)}</a>.</p>
+      <ol>
+${items}
+      </ol>
+    </main>
+  </body>
+</html>
+`;
+}
+
+/** Sitemap `<url>` blocks for every category — no hash fragments. */
+export function renderSitemapCategoryUrls(
+  slugs: string[],
+  lastmod: string,
+): string {
+  return slugs
+    .map(
+      (slug) =>
+        `  <url>\n` +
+        `    <loc>${categoryPageUrl(slug)}</loc>\n` +
+        `    <lastmod>${lastmod}</lastmod>\n` +
+        `    <changefreq>weekly</changefreq>\n` +
+        `    <priority>0.9</priority>\n` +
+        `  </url>`,
+    )
+    .join("\n");
+}
+
+/** llms.txt category section — every category links to its indexable page. */
+export function renderLlmsCategoryLines(slugs: string[]): string {
+  return slugs
+    .map((slug) => {
+      const { label, description } = categoryMeta(slug);
+      return `- [${label}](${categoryPageUrl(slug)}): ${description}`;
+    })
+    .join("\n");
+}

--- a/scripts/category-seo.ts
+++ b/scripts/category-seo.ts
@@ -116,6 +116,11 @@ export function escapeHtml(s: string): string {
     .replace(/"/g, "&quot;");
 }
 
+/** JSON-LD stringify: escape `<` so `</script>` can never break out of the block. */
+export function jsonLd(v: unknown): string {
+  return JSON.stringify(v).replace(/</g, "\\u003c");
+}
+
 export interface CategoryPageSkill {
   id: string;
   name: string;
@@ -167,7 +172,7 @@ export function renderCategoryPage(input: CategoryPageInput): string {
       (s, i) => `      {
         "@type": "ListItem",
         "position": ${i + 1},
-        "name": ${JSON.stringify(s.name)},
+        "name": ${jsonLd(s.name)},
         "url": "${SITE_BASE}/#/skills/${encodeURIComponent(s.id)}"
       }`,
     )
@@ -196,8 +201,8 @@ export function renderCategoryPage(input: CategoryPageInput): string {
         "@type": "CollectionPage",
         "@id": "${url}",
         "url": "${url}",
-        "name": ${JSON.stringify(`${label} Skills — asm skill catalog`)},
-        "description": ${JSON.stringify(metaDesc)},
+        "name": ${jsonLd(`${label} Skills — asm skill catalog`)},
+        "description": ${jsonLd(metaDesc)},
         "isPartOf": { "@id": "${SITE_BASE}/#webapp" },
         "mainEntity": {
           "@type": "ItemList",
@@ -215,7 +220,7 @@ ${listItems}
         "itemListElement": [
           { "@type": "ListItem", "position": 1, "name": "Home", "item": "${SITE_BASE}/" },
           { "@type": "ListItem", "position": 2, "name": "Skills", "item": "${SITE_BASE}/#/skills" },
-          { "@type": "ListItem", "position": 3, "name": ${JSON.stringify(label)}, "item": "${url}" }
+          { "@type": "ListItem", "position": 3, "name": ${jsonLd(label)}, "item": "${url}" }
         ]
       }
     </script>

--- a/tests/e2e/build-verification.test.ts
+++ b/tests/e2e/build-verification.test.ts
@@ -607,3 +607,149 @@ describe("catalog: star counts degrade honestly (issue #598)", () => {
     }
   });
 });
+
+// ─── Category pages SEO ─────────────────────────────────────────────────────
+// The catalog's ?cat= filter views are HashRouter state — invisible to
+// crawlers. `scripts/category-seo.ts` generates one indexable static page
+// per category; the sitemap/llms.txt templates enumerate them; the SPA
+// canonicalizes single-category views to them and links badges at them.
+
+import {
+  CATEGORY_META,
+  SITE_BASE,
+  categoryMeta,
+  categoryPageUrl,
+  renderCategoryPage,
+  renderLlmsCategoryLines,
+  renderSitemapCategoryUrls,
+} from "../../scripts/category-seo";
+
+describe("category SEO: helpers", () => {
+  test("every known category has a label and description", () => {
+    expect(Object.keys(CATEGORY_META).length).toBeGreaterThanOrEqual(16);
+    for (const meta of Object.values(CATEGORY_META)) {
+      expect(meta.label.length).toBeGreaterThan(0);
+      expect(meta.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("unknown slugs fall back to a title-case label", () => {
+    expect(categoryMeta("brand-new-cat").label).toBe("Brand New Cat");
+    expect(categoryMeta("devops")).toEqual(CATEGORY_META["devops"]);
+  });
+
+  test("category URLs are real pages, not hash fragments", () => {
+    expect(categoryPageUrl("devops")).toBe(
+      `${SITE_BASE}/categories/devops.html`,
+    );
+    expect(categoryPageUrl("devops")).not.toContain("#");
+  });
+
+  test("rendered page carries unique title, canonical, H1 and JSON-LD", () => {
+    const html = renderCategoryPage({
+      slug: "testing",
+      skills: [
+        {
+          id: "o/r::s",
+          name: "s",
+          description: "d",
+          owner: "o",
+          repo: "r",
+          overallScore: 90,
+          grade: "A",
+        },
+      ],
+      totalRepos: 35,
+      lastmod: "2026-09-05",
+    });
+    expect(html).toContain("<title>Testing Skills (1)");
+    expect(html).toContain(
+      `<link rel="canonical" href="${SITE_BASE}/categories/testing.html" />`,
+    );
+    expect(html).toContain("<h1>Testing Skills</h1>");
+    expect(html).toContain('property="og:image"');
+    expect(html).toContain('"@type": "CollectionPage"');
+    expect(html).toContain('"@type": "ItemList"');
+    expect(html).toContain('"@type": "BreadcrumbList"');
+    expect(html).toContain("o/r");
+    // Visible list and ItemList describe the same skill.
+    expect(html).toContain(`${SITE_BASE}/#/skills/o%2Fr%3A%3As`);
+  });
+
+  test("descriptions are HTML-escaped", () => {
+    const html = renderCategoryPage({
+      slug: "testing",
+      skills: [
+        {
+          id: "a",
+          name: "<b>n</b>",
+          description: 'x "y"',
+          owner: "o",
+          repo: "r",
+        },
+      ],
+      totalRepos: 1,
+      lastmod: "2026-09-05",
+    });
+    // Visible HTML is escaped; JSON-LD keeps the raw string (valid JSON).
+    expect(html).toContain("&lt;b&gt;n&lt;/b&gt;");
+    expect(html).toContain(`"name": ${JSON.stringify("<b>n</b>")}`);
+  });
+
+  test("sitemap snippet lists real URLs with no fragments", () => {
+    const urls = renderSitemapCategoryUrls(["devops", "git"], "2026-09-05");
+    expect(urls).toContain(`${SITE_BASE}/categories/devops.html`);
+    expect(urls).toContain(`${SITE_BASE}/categories/git.html`);
+    expect(urls).not.toContain("#");
+  });
+
+  test("llms lines link every category to its page", () => {
+    const lines = renderLlmsCategoryLines(["devops"]);
+    expect(lines).toContain(`- [DevOps](${SITE_BASE}/categories/devops.html):`);
+  });
+});
+
+describe("category SEO: wiring", () => {
+  const SRC = join(ROOT, "website-src");
+
+  test("sitemap template lists categories, not hash routes", () => {
+    const sitemap = readFileSync(join(SRC, "sitemap.xml"), "utf-8");
+    expect(sitemap).toContain("{{CATEGORY_URLS}}");
+    expect(sitemap).not.toContain("#/");
+  });
+
+  test("llms.txt template renders category links from the catalog", () => {
+    const llms = readFileSync(join(SRC, "llms.txt"), "utf-8");
+    expect(llms).toContain("{{CATEGORY_LINKS}}");
+  });
+
+  test("build renders category tokens and static pages", () => {
+    const buildSrc = readFileSync(
+      join(ROOT, "scripts", "build-catalog.ts"),
+      "utf-8",
+    );
+    expect(buildSrc).toContain("{{CATEGORY_URLS}}");
+    expect(buildSrc).toContain("{{CATEGORY_LINKS}}");
+    expect(buildSrc).toContain("categories");
+    expect(buildSrc).toContain("renderCategoryPage");
+  });
+
+  test("CatalogPage sets per-category title and canonical", () => {
+    const src = readFileSync(
+      join(SRC, "src", "pages", "CatalogPage.jsx"),
+      "utf-8",
+    );
+    expect(src).toContain("categoryPageUrl");
+    expect(src).toContain("document.title");
+    expect(src).toContain('link[rel="canonical"]');
+  });
+
+  test("SkillCard badges link to static category pages", () => {
+    const src = readFileSync(
+      join(SRC, "src", "components", "SkillCard.jsx"),
+      "utf-8",
+    );
+    expect(src).toContain("categoryPageUrl");
+    expect(src).toContain("<a");
+  });
+});

--- a/tests/e2e/build-verification.test.ts
+++ b/tests/e2e/build-verification.test.ts
@@ -691,9 +691,40 @@ describe("category SEO: helpers", () => {
       totalRepos: 1,
       lastmod: "2026-09-05",
     });
-    // Visible HTML is escaped; JSON-LD keeps the raw string (valid JSON).
+    // Visible HTML is escaped; JSON-LD escapes `<` so `</script>` can
+    // never break out of the block (skill names are untrusted input).
     expect(html).toContain("&lt;b&gt;n&lt;/b&gt;");
-    expect(html).toContain(`"name": ${JSON.stringify("<b>n</b>")}`);
+    expect(html).toContain(
+      `"name": ${JSON.stringify("<b>n</b>").replace(/</g, "\\u003c")}`,
+    );
+    expect(html).not.toContain("</script></script>");
+  });
+
+  test("skill names cannot break out of the JSON-LD script block", () => {
+    const html = renderCategoryPage({
+      slug: "testing",
+      skills: [
+        {
+          id: "a",
+          name: '</script><script>alert("xss")</script>',
+          description: "d",
+          owner: "o",
+          repo: "r",
+        },
+      ],
+      totalRepos: 1,
+      lastmod: "2026-09-05",
+    });
+    const blocks = html.match(
+      /<script type="application\/ld\+json">[\s\S]*?<\/script>/g,
+    );
+    expect(blocks).not.toBeNull();
+    for (const block of blocks ?? []) {
+      expect(block.slice(0, block.lastIndexOf("</script>"))).not.toContain(
+        "</script>",
+      );
+    }
+    expect(html).toContain("\\u003c/script>");
   });
 
   test("sitemap snippet lists real URLs with no fragments", () => {

--- a/website-src/llms.txt
+++ b/website-src/llms.txt
@@ -11,22 +11,7 @@
 
 ## Skill Categories
 
-- AI Agents: Skills for building and managing AI agents
-- Backend: Server-side development skills
-- Coding: General coding assistance and utilities
-- Design: UI/UX design and frontend styling
-- DevOps: CI/CD, deployment, and infrastructure
-- Finance: Financial tools and analysis
-- Frontend: Client-side web development
-- Git: Version control and repository management
-- Marketing: Content creation and SEO
-- Mobile: iOS and Android development
-- Productivity: Workflow automation and efficiency
-- Research: Information gathering and analysis
-- Security: Security auditing and hardening
-- Testing: Test automation and QA
-- Writing: Documentation and content writing
-- General: Miscellaneous utility skills
+{{CATEGORY_LINKS}}
 
 ## Usage
 

--- a/website-src/sitemap.xml
+++ b/website-src/sitemap.xml
@@ -6,28 +6,5 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
-  <url>
-    <loc>https://luongnv.com/asm/#/skills</loc>
-    <lastmod>{{LASTMOD}}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://luongnv.com/asm/#/bundles</loc>
-    <lastmod>{{LASTMOD}}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://luongnv.com/asm/#/docs</loc>
-    <lastmod>{{LASTMOD}}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://luongnv.com/asm/#/changelog</loc>
-    <lastmod>{{LASTMOD}}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
+{{CATEGORY_URLS}}
 </urlset>

--- a/website-src/src/__tests__/category-seo.test.js
+++ b/website-src/src/__tests__/category-seo.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  CATEGORY_LABELS,
+  SITE_BASE,
+  categoryLabel,
+  categoryPageUrl,
+} from "../lib/category-seo.js";
+
+/**
+ * Runtime category-SEO helpers: badge links and per-category document
+ * metadata must resolve every catalog slug to its indexable static page.
+ */
+describe("category-seo", () => {
+  it("links every known category to its static page", () => {
+    for (const slug of Object.keys(CATEGORY_LABELS)) {
+      expect(categoryPageUrl(slug)).toBe(
+        `${SITE_BASE}/categories/${slug}.html`,
+      );
+    }
+  });
+
+  it("labels known slugs, title-cases unknown ones", () => {
+    expect(categoryLabel("ai-agents")).toBe("AI Agents");
+    expect(categoryLabel("devops")).toBe("DevOps");
+    expect(categoryLabel("brand-new-cat")).toBe("Brand New Cat");
+  });
+});

--- a/website-src/src/components/SkillCard.jsx
+++ b/website-src/src/components/SkillCard.jsx
@@ -146,9 +146,9 @@ function SkillCard({
               key={c}
               href={categoryPageUrl(c)}
               title={`Browse all ${categoryLabel(c)} skills`}
-              className="no-underline"
+              className="shop-above no-underline"
             >
-              <Badge tone="cat">{c}</Badge>
+              <Badge tone="cat">{categoryLabel(c)}</Badge>
             </a>
           ))}
         </div>

--- a/website-src/src/components/SkillCard.jsx
+++ b/website-src/src/components/SkillCard.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Star, Wrench } from "lucide-react";
 import { Badge } from "./ui/badge.jsx";
 import AddToCartButton from "./AddToCartButton.jsx";
+import { categoryLabel, categoryPageUrl } from "../lib/category-seo.js";
 import {
   formatStars,
   formatTokens,
@@ -141,9 +142,14 @@ function SkillCard({
             </Badge>
           )}
           {(skill.categories || []).slice(0, 2).map((c) => (
-            <Badge key={c} tone="cat">
-              {c}
-            </Badge>
+            <a
+              key={c}
+              href={categoryPageUrl(c)}
+              title={`Browse all ${categoryLabel(c)} skills`}
+              className="no-underline"
+            >
+              <Badge tone="cat">{c}</Badge>
+            </a>
           ))}
         </div>
       </div>

--- a/website-src/src/lib/category-seo.js
+++ b/website-src/src/lib/category-seo.js
@@ -1,0 +1,42 @@
+/**
+ * Category SEO runtime helpers.
+ *
+ * Labels/URLs-only mirror of `scripts/category-seo.ts` (the build-time
+ * single source of truth, which also owns the curated descriptions).
+ * Keep the slug→label map in sync with `CATEGORY_META` there.
+ */
+
+export const SITE_BASE = "https://luongnv.com/asm";
+
+export const CATEGORY_LABELS = {
+  "ai-agents": "AI Agents",
+  backend: "Backend",
+  coding: "Coding",
+  design: "Design",
+  devops: "DevOps",
+  finance: "Finance",
+  frontend: "Frontend",
+  git: "Git",
+  marketing: "Marketing",
+  mobile: "Mobile",
+  productivity: "Productivity",
+  research: "Research",
+  security: "Security",
+  testing: "Testing",
+  writing: "Writing",
+  general: "General",
+};
+
+export function categoryLabel(slug) {
+  const known = CATEGORY_LABELS[slug];
+  if (known) return known;
+  return String(slug)
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/** Canonical URL of the indexable static page for a category. */
+export function categoryPageUrl(slug) {
+  return `${SITE_BASE}/categories/${slug}.html`;
+}

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -186,7 +186,14 @@ export default function CatalogPage() {
   );
   useEffect(() => {
     const cats = [...state.activeCategories];
-    const singleCat = cats.length === 1 ? cats[0] : null;
+    const unfiltered =
+      !state.searchQuery.trim() &&
+      (!state.activeRepo || state.activeRepo === "all") &&
+      Object.values(state.activeFacets).every((set) => set.size === 0) &&
+      (!state.sort || state.sort === defaultSort(state.searchQuery)) &&
+      state.page === 1;
+    const singleCat =
+      !decodedId && cats.length === 1 && unfiltered ? cats[0] : null;
     if (singleCat) {
       const label = categoryLabel(singleCat);
       document.title = `${label} Skills (${filtered.length}) — asm skill catalog`;
@@ -200,7 +207,13 @@ export default function CatalogPage() {
       setMetaTag("description", initialHead.description);
       setCanonicalUrl(initialHead.canonical);
     }
-  }, [state, filtered.length, initialHead]);
+    return () => {
+      if (!initialHead) return;
+      document.title = initialHead.title;
+      setMetaTag("description", initialHead.description);
+      setCanonicalUrl(initialHead.canonical);
+    };
+  }, [state, filtered.length, initialHead, decodedId]);
 
   if (error) {
     return (

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -3,6 +3,7 @@ import { useParams, Link, useLocation } from "react-router-dom";
 import { ArrowLeft, SlidersHorizontal } from "lucide-react";
 import { useCatalog } from "../hooks/useCatalog.jsx";
 import { useCatalogState } from "../hooks/useCatalogState.js";
+import { categoryLabel, categoryPageUrl } from "../lib/category-seo.js";
 import {
   applyFilters,
   anyFilterActive,
@@ -161,6 +162,45 @@ export default function CatalogPage() {
     },
     [setPage],
   );
+
+  // Per-category document metadata. A single-category ?cat= view gets a
+  // unique title/description and canonicalizes to its indexable static
+  // page — sort/page/search/facet params never reach the canonical (E).
+  // Any other view restores the shell values captured on mount.
+  // Shell head values captured on mount; any non-single-category view
+  // restores them so a stale category title/canonical never lingers.
+  const [initialHead] = useState(() =>
+    typeof document === "undefined"
+      ? null
+      : {
+          title: document.title,
+          description:
+            document
+              .querySelector('meta[name="description"]')
+              ?.getAttribute("content") ?? "",
+          canonical:
+            document
+              .querySelector('link[rel="canonical"]')
+              ?.getAttribute("href") ?? "",
+        },
+  );
+  useEffect(() => {
+    const cats = [...state.activeCategories];
+    const singleCat = cats.length === 1 ? cats[0] : null;
+    if (singleCat) {
+      const label = categoryLabel(singleCat);
+      document.title = `${label} Skills (${filtered.length}) — asm skill catalog`;
+      setMetaTag(
+        "description",
+        `Browse ${filtered.length} free, open-source ${label} skills for AI coding agents — install any of them with a single command.`,
+      );
+      setCanonicalUrl(categoryPageUrl(singleCat));
+    } else if (initialHead) {
+      document.title = initialHead.title;
+      setMetaTag("description", initialHead.description);
+      setCanonicalUrl(initialHead.canonical);
+    }
+  }, [state, filtered.length, initialHead]);
 
   if (error) {
     return (
@@ -448,6 +488,27 @@ export default function CatalogPage() {
       </div>
     </div>
   );
+}
+
+function setMetaTag(name, content) {
+  let el = document.querySelector(`meta[name="${name}"]`);
+  if (!el) {
+    el = document.createElement("meta");
+    el.setAttribute("name", name);
+    document.head.appendChild(el);
+  }
+  el.setAttribute("content", content);
+}
+
+function setCanonicalUrl(href) {
+  if (!href) return;
+  let el = document.querySelector('link[rel="canonical"]');
+  if (!el) {
+    el = document.createElement("link");
+    el.setAttribute("rel", "canonical");
+    document.head.appendChild(el);
+  }
+  el.setAttribute("href", href);
 }
 
 function countActiveFilters(state) {


### PR DESCRIPTION
Closes #616

Category `?cat=` views are HashRouter state — invisible to search engines and no-JS AI crawlers. This makes every category indexable without touching the SPA router:

- **Static pages**: `build-catalog.ts` emits `website/categories/<slug>.html` per category (new pure helper `scripts/category-seo.ts`) — unique title/description/H1, self-canonical, CollectionPage + ItemList + BreadcrumbList JSON-LD
- **Sitemap**: real category URLs in, hash-fragment entries out
- **llms.txt**: each category links to its indexable page
- **SPA**: single-category views set per-category title/description/canonical at runtime (sort/page/search stripped); badges link to the static pages
- **Tests**: 2 runtime + 12 e2e assertions; `test:site` 114/114, e2e file 54/54, typecheck + lint clean; rendered page audits 0 critical / 0 warning

Validation: `main` synced before branching; full `build-catalog.ts` run left to CI (needs GitHub API quota) — generation proven via tsx harness.