### PR TITLE
feat(website): add repo detail page with skills list (#623)

### DIFF
--- a/website-src/src/App.jsx
+++ b/website-src/src/App.jsx
@@ -11,6 +11,7 @@ import DocsPage from "./pages/DocsPage.jsx";
 import ChangelogPage from "./pages/ChangelogPage.jsx";
 import StatsPage from "./pages/StatsPage.jsx";
 import ProfilePage from "./pages/ProfilePage.jsx";
+import RepoPage from "./pages/RepoPage.jsx";
 import { CatalogProvider } from "./hooks/useCatalog.jsx";
 import { BundleCartProvider } from "./hooks/useBundleCart.jsx";
 
@@ -60,6 +61,7 @@ export default function App() {
               <Route path="/changelog" element={<ChangelogPage />} />
               <Route path="/stats" element={<StatsPage />} />
               <Route path="/profile/:owner" element={<ProfilePage />} />
+              <Route path="/repos/:owner/:repo" element={<RepoPage />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           </main>

--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -140,6 +140,7 @@ const FETCH_MAP = {
   "search.idx.json": () => new Response(buildIndexJson()),
   "bundles.json": () => new Response(JSON.stringify(BUNDLES)),
   "skills/hello.json": () => new Response(JSON.stringify(SKILL_DETAIL)),
+  "repo-stats.json": () => new Response(JSON.stringify({ stats: [] })),
 };
 
 function mockFetch() {
@@ -431,6 +432,28 @@ describe("App smoke", () => {
     expect(
       screen.getByRole("button", { name: /Add hello-world to cart/i }),
     ).toBeTruthy();
+  });
+
+  it("repo route renders the repo detail page with its skills", async () => {
+    window.history.replaceState(null, "", "/#/repos/owner/repo");
+    render(
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </HashRouter>,
+    );
+    // Header from catalog.repos plus both skills in the repo grid.
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "owner/repo" })).toBeTruthy();
+    });
+    expect(screen.getByText("hello-world")).toBeTruthy();
+    expect(screen.getByText("readme-generator")).toBeTruthy();
+    // Skill titles link to the product page.
+    const helloLink = screen.getByRole("link", { name: "hello-world" });
+    expect(helloLink.getAttribute("href")).toContain(
+      `/skills/${encodeSkillId("owner/repo::a::hello-world")}`,
+    );
   });
 
   it("root path renders the marketing landing page, not the catalog", async () => {

--- a/website-src/src/__tests__/repo-page.test.jsx
+++ b/website-src/src/__tests__/repo-page.test.jsx
@@ -1,0 +1,201 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { HashRouter, Route, Routes } from "react-router-dom";
+import MiniSearch from "minisearch";
+import RepoPage from "../pages/RepoPage.jsx";
+import { CatalogProvider } from "../hooks/useCatalog.jsx";
+import { MINISEARCH_OPTIONS } from "../lib/minisearch-options.js";
+import { encodeSkillId } from "../lib/utils.js";
+
+const generatedAt = "2026-09-05T00:00:00.000Z";
+
+const catalog = {
+  generatedAt,
+  totalSkills: 3,
+  totalRepos: 2,
+  categories: ["coding", "docs"],
+  categoryCounts: { coding: 2, docs: 1 },
+  repos: [
+    {
+      owner: "alice",
+      repo: "tools",
+      repoUrl: "https://github.com/alice/tools",
+      description: "Alice's toolbox",
+      maintainer: "Alice",
+      skillCount: 2,
+      stars: 1234,
+    },
+    {
+      owner: "bob",
+      repo: "other",
+      repoUrl: "https://github.com/bob/other",
+      description: "",
+      maintainer: "",
+      skillCount: 1,
+    },
+  ],
+  skills: [
+    {
+      id: "alice/tools::skills/alpha::alpha",
+      name: "alpha",
+      description: "Alpha skill",
+      owner: "alice",
+      repo: "tools",
+      categories: ["coding"],
+      installUrl: "github:alice/tools:skills/alpha",
+      license: "MIT",
+      version: "1.0.0",
+      verified: true,
+      tokenCount: 300,
+    },
+    {
+      id: "alice/tools::skills/beta::beta",
+      name: "beta",
+      description: "Beta skill",
+      owner: "alice",
+      repo: "tools",
+      categories: ["coding"],
+      installUrl: "github:alice/tools:skills/beta",
+      license: "MIT",
+      version: "1.0.0",
+      verified: false,
+      tokenCount: 500,
+    },
+    {
+      id: "bob/other::skills/gamma::gamma",
+      name: "gamma",
+      description: "Gamma skill",
+      owner: "bob",
+      repo: "other",
+      categories: ["docs"],
+      installUrl: "github:bob/other:skills/gamma",
+      license: "MIT",
+      version: "1.0.0",
+      verified: false,
+      tokenCount: 100,
+    },
+  ],
+};
+
+const repoStats = {
+  stats: [
+    {
+      owner: "alice",
+      repo: "tools",
+      repoUrl: "https://github.com/alice/tools",
+      skillCount: 2,
+      categories: { coding: 2 },
+      verifiedCount: 1,
+      totalTokens: 800,
+    },
+  ],
+};
+
+function buildIndexJson() {
+  const ms = new MiniSearch(MINISEARCH_OPTIONS);
+  ms.addAll(
+    catalog.skills.map((s, i) => ({
+      id: i,
+      name: s.name,
+      description: s.description,
+      categoriesStr: (s.categories || []).join(" "),
+    })),
+  );
+  const payload = ms.toJSON();
+  payload.generatedAt = generatedAt;
+  return JSON.stringify(payload);
+}
+
+function mockFetch() {
+  global.fetch = vi.fn(async (url) => {
+    const path = String(url);
+    if (path.endsWith("skills.min.json")) {
+      return { ok: true, json: async () => catalog };
+    }
+    if (path.endsWith("search.idx.json")) {
+      return { ok: true, text: async () => buildIndexJson() };
+    }
+    if (path.endsWith("repo-stats.json")) {
+      return { ok: true, json: async () => repoStats };
+    }
+    return { ok: false, status: 404, json: async () => null };
+  });
+}
+
+function renderRepoPage(initialHash) {
+  window.history.replaceState(null, "", initialHash);
+  return render(
+    <HashRouter>
+      <CatalogProvider>
+        <Routes>
+          <Route path="/repos/:owner/:repo" element={<RepoPage />} />
+        </Routes>
+      </CatalogProvider>
+    </HashRouter>,
+  );
+}
+
+describe("RepoPage — repo detail page (issue #623)", () => {
+  beforeEach(() => {
+    mockFetch();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the repo info header with description, stars, and counts", async () => {
+    renderRepoPage("/#/repos/alice/tools");
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "alice/tools" })).toBeTruthy();
+    });
+    expect(screen.getByText("Alice's toolbox")).toBeTruthy();
+    expect(screen.getByText(/2 skills/)).toBeTruthy();
+    expect(screen.getByText(/1 verified/)).toBeTruthy();
+    // 1234 -> "1.2k" via formatStars
+    expect(screen.getByText(/1\.2k/)).toBeTruthy();
+    const github = screen.getByRole("link", { name: /GitHub/ });
+    expect(github.getAttribute("href")).toBe("https://github.com/alice/tools");
+  });
+
+  it("lists every skill in the repo with links to the skill detail route", async () => {
+    renderRepoPage("/#/repos/alice/tools");
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "alice/tools" })).toBeTruthy();
+    });
+    const alpha = await screen.findByRole("link", { name: "alpha" });
+    expect(alpha.getAttribute("href")).toBe(
+      `#/skills/${encodeSkillId("alice/tools::skills/alpha::alpha")}`,
+    );
+    const beta = screen.getByRole("link", { name: "beta" });
+    expect(beta.getAttribute("href")).toBe(
+      `#/skills/${encodeSkillId("alice/tools::skills/beta::beta")}`,
+    );
+    // Skills from other repos must not leak in.
+    expect(screen.queryByText("gamma")).toBeNull();
+  });
+
+  it("links back to the filtered catalog and the author profile", async () => {
+    renderRepoPage("/#/repos/alice/tools");
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "alice/tools" })).toBeTruthy();
+    });
+    const filter = screen.getByRole("link", { name: "Filter in catalog" });
+    expect(filter.getAttribute("href")).toContain("/skills?repo=");
+    expect(filter.getAttribute("href")).toContain("alice");
+    const profile = screen.getByRole("link", {
+      name: "View stats for alice",
+    });
+    expect(profile.getAttribute("href")).toBe("#/profile/alice");
+  });
+
+  it("renders a not-found state for an unknown repo", async () => {
+    renderRepoPage("/#/repos/nobody/nothing");
+    await waitFor(() => {
+      expect(screen.getByText("Repository not found")).toBeTruthy();
+    });
+    expect(screen.getByRole("link", { name: /Back to Stats/ })).toBeTruthy();
+  });
+});

--- a/website-src/src/__tests__/skill-card.test.jsx
+++ b/website-src/src/__tests__/skill-card.test.jsx
@@ -98,6 +98,16 @@ describe("SkillCard — storefront anatomy", () => {
     expect(link.getAttribute("href")).toContain("page=2");
   });
 
+  it("links the repo label to the repo detail page", () => {
+    renderCard();
+    const link = screen.getByRole("link", {
+      name: "sickn33/antigravity-awesome-skills",
+    });
+    expect(link.getAttribute("href")).toBe(
+      "#/repos/sickn33/antigravity-awesome-skills",
+    );
+  });
+
   it("renders an add-to-cart button that names the skill", () => {
     renderCard();
     expect(

--- a/website-src/src/__tests__/skill-detail.test.jsx
+++ b/website-src/src/__tests__/skill-detail.test.jsx
@@ -171,3 +171,15 @@ describe("SkillDetail — author stats link (issue #351)", () => {
     expect(link.getAttribute("href")).toBe("#/profile/custom-author");
   });
 });
+
+describe("SkillDetail — repo detail link (issue #623)", () => {
+  afterEach(() => cleanup());
+
+  it("links the repo row to the repo detail page alongside GitHub", () => {
+    renderDetail();
+    const internal = screen.getByRole("link", { name: "(view all skills)" });
+    expect(internal.getAttribute("href")).toBe("#/repos/test/repo");
+    const external = screen.getByRole("link", { name: "test/repo" });
+    expect(external.getAttribute("href")).toBe("https://github.com/test/repo");
+  });
+});

--- a/website-src/src/__tests__/stats-page.test.jsx
+++ b/website-src/src/__tests__/stats-page.test.jsx
@@ -112,7 +112,19 @@ function mockFetch() {
       return { ok: true, text: async () => buildIndexJson() };
     }
     if (path.endsWith("repo-stats.json")) {
-      return { ok: true, json: async () => ({ stats: [] }) };
+      return {
+        ok: true,
+        json: async () => ({
+          stats: [
+            {
+              owner: "alice",
+              repo: "repo",
+              repoUrl: "https://github.com/alice/repo",
+              skillCount: 2,
+            },
+          ],
+        }),
+      };
     }
     if (path.endsWith("author-stats.json")) {
       return { ok: true, json: async () => authorStats };
@@ -173,6 +185,20 @@ describe("StatsPage — author view and pie chart (issue #351)", () => {
     expect(screen.getAllByText("dev").length).toBeGreaterThan(0);
     expect(screen.getByText("docs")).toBeTruthy();
     expect(screen.getByText("testing")).toBeTruthy();
+  });
+
+  it("links Top Repositories rows to the repo detail page (issue #623)", async () => {
+    renderStatsPage();
+    await waitFor(() => {
+      expect(screen.getByText("Top Repositories")).toBeTruthy();
+    });
+
+    const internal = screen.getByRole("link", { name: "alice/repo" });
+    expect(internal.getAttribute("href")).toBe("#/repos/alice/repo");
+    // GitHub stays as a secondary external link.
+    const external = screen.getByRole("link", { name: "GitHub" });
+    expect(external.getAttribute("href")).toBe("https://github.com/alice/repo");
+    expect(external.getAttribute("target")).toBe("_blank");
   });
 
   it("renders at most ten ranked skills in artifact order with detail links", async () => {

--- a/website-src/src/components/FilterRail.jsx
+++ b/website-src/src/components/FilterRail.jsx
@@ -1,4 +1,5 @@
 import { X } from "lucide-react";
+import { Link } from "react-router-dom";
 import SearchBox from "./SearchBox.jsx";
 import CategoryTabs from "./CategoryTabs.jsx";
 import FacetRow from "./FacetRow.jsx";
@@ -112,6 +113,17 @@ export default function FilterRail({
             </option>
           ))}
         </select>
+        {state.activeRepo && state.activeRepo !== "all" && (
+          <Link
+            to={`/repos/${state.activeRepo
+              .split("/")
+              .map(encodeURIComponent)
+              .join("/")}`}
+            className="text-xs text-[var(--brand)] hover:underline"
+          >
+            View {state.activeRepo} repo page →
+          </Link>
+        )}
       </div>
     </div>
   );

--- a/website-src/src/components/SkillCard.jsx
+++ b/website-src/src/components/SkillCard.jsx
@@ -110,7 +110,12 @@ function SkillCard({
           className="shop-meta truncate"
           title={`${skill.owner}/${skill.repo}`}
         >
-          {skill.owner}/{skill.repo}
+          <Link
+            to={`/repos/${encodeURIComponent(skill.owner)}/${encodeURIComponent(skill.repo)}`}
+            className="shop-above hover:text-[var(--brand)] hover:underline"
+          >
+            {skill.owner}/{skill.repo}
+          </Link>
         </div>
         {collisionPath && (
           <div

--- a/website-src/src/components/SkillDetail.jsx
+++ b/website-src/src/components/SkillDetail.jsx
@@ -133,7 +133,13 @@ export default function SkillDetail({ slim }) {
               rel="noopener noreferrer"
             >
               {skill.owner}/{skill.repo}
-            </a>
+            </a>{" "}
+            <Link
+              to={`/repos/${encodeURIComponent(skill.owner)}/${encodeURIComponent(skill.repo)}`}
+              className="text-[var(--brand)] hover:underline"
+            >
+              (view all skills)
+            </Link>
           </Row>
           {typeof skill.stars === "number" && skill.stars > 0 && (
             <Row label="GitHub" title="Source repository star count">

--- a/website-src/src/pages/RepoPage.jsx
+++ b/website-src/src/pages/RepoPage.jsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { useCatalog } from "../hooks/useCatalog.jsx";
+import { buildNameCollisionKeys } from "../lib/filter-sort.js";
+import { formatStars } from "../lib/utils.js";
+import SkillCard from "../components/SkillCard.jsx";
+import CopyButton from "../components/CopyButton.jsx";
+
+/**
+ * Repo detail page — header for one `owner/repo` plus a grid of all its
+ * skills. Header facts come from `catalog.repos` (description, maintainer,
+ * skillCount, stars, repoUrl) enriched by `repo-stats.json` aggregates
+ * (categories, verifiedCount); the skill list is filtered from the catalog
+ * via `useCatalog()` and rendered with the same `SkillCard` as the shop
+ * floor. Unknown repos render a not-found state.
+ */
+
+function repoShareUrl(owner, repo) {
+  if (typeof window === "undefined") return `#/repos/${owner}/${repo}`;
+  return `${window.location.origin}${window.location.pathname}#/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+}
+
+export default function RepoPage() {
+  const { owner, repo } = useParams();
+  const { loading: catalogLoading, catalog } = useCatalog();
+  const [stats, setStats] = useState(null);
+  const [statsLoading, setStatsLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("repo-stats.json")
+      .then((r) => r.json())
+      .then((data) => {
+        const found = data?.stats?.find(
+          (r) => r.owner === owner && r.repo === repo,
+        );
+        setStats(found || null);
+      })
+      .catch(() => setStats(null))
+      .finally(() => setStatsLoading(false));
+  }, [owner, repo]);
+
+  const repoMeta = useMemo(
+    () =>
+      catalog?.repos?.find((r) => r.owner === owner && r.repo === repo) || null,
+    [catalog, owner, repo],
+  );
+
+  const skills = useMemo(() => {
+    if (!catalog?.skills) return [];
+    return catalog.skills.filter((s) => s.owner === owner && s.repo === repo);
+  }, [catalog, owner, repo]);
+
+  const collisionKeys = useMemo(
+    () => (catalog ? buildNameCollisionKeys(catalog.skills) : null),
+    [catalog],
+  );
+
+  if (catalogLoading || statsLoading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-[var(--fg-dim)]">Loading repository...</div>
+      </div>
+    );
+  }
+
+  if (!repoMeta && !stats && skills.length === 0) {
+    return (
+      <div className="max-w-2xl mx-auto py-20 text-center">
+        <div className="text-xl font-semibold text-[var(--fg)] mb-2">
+          Repository not found
+        </div>
+        <p className="text-[var(--fg-dim)] mb-6">
+          No indexed skills found for{" "}
+          <strong>
+            {owner}/{repo}
+          </strong>
+          .
+        </p>
+        <Link to="/stats" className="text-[var(--brand)] hover:underline">
+          ← Back to Stats
+        </Link>
+      </div>
+    );
+  }
+
+  const description = repoMeta?.description || "";
+  const maintainer = repoMeta?.maintainer || "";
+  const repoUrl =
+    repoMeta?.repoUrl ||
+    stats?.repoUrl ||
+    `https://github.com/${owner}/${repo}`;
+  const skillCount = repoMeta?.skillCount ?? stats?.skillCount ?? skills.length;
+  const stars = repoMeta?.stars;
+  const verifiedCount =
+    stats?.verifiedCount ?? skills.filter((s) => s.verified).length;
+  const catEntries = Object.entries(stats?.categories || {}).sort(
+    (a, b) => b[1] - a[1],
+  );
+  const shareUrl = repoShareUrl(owner, repo);
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="flex items-start justify-between mb-4">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-bold text-[var(--fg)] truncate">
+            {owner}/{repo}
+          </h1>
+          {description && (
+            <p className="text-[var(--fg-dim)] text-sm mt-1">{description}</p>
+          )}
+          {maintainer && (
+            <p className="text-[var(--fg-muted)] text-xs mt-1">
+              Maintainer: {maintainer}
+            </p>
+          )}
+        </div>
+        <CopyButton text={shareUrl} size="sm" />
+      </div>
+
+      {/* Meta row */}
+      <div className="flex flex-wrap items-center gap-2 text-sm mb-6">
+        <span className="text-[var(--fg-dim)]">
+          {skillCount} skill{skillCount !== 1 ? "s" : ""}
+        </span>
+        {verifiedCount > 0 && (
+          <span className="text-[var(--fg-dim)]">
+            · {verifiedCount} verified
+          </span>
+        )}
+        {formatStars(stars) && (
+          <span className="text-[var(--fg-dim)]" title="GitHub stars">
+            · ★ {formatStars(stars)}
+          </span>
+        )}
+        <a
+          className="text-[var(--brand)] hover:underline"
+          href={repoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub →
+        </a>
+        <Link
+          to={`/skills?repo=${encodeURIComponent(owner + "/" + repo)}`}
+          className="text-[var(--brand)] hover:underline"
+        >
+          Filter in catalog
+        </Link>
+      </div>
+
+      {/* Categories */}
+      {catEntries.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-6">
+          {catEntries.map(([c, n]) => (
+            <Link
+              key={c}
+              to={`/skills?repo=${encodeURIComponent(owner + "/" + repo)}&cat=${encodeURIComponent(c)}`}
+              className="text-xs rounded-full border border-[var(--border)] px-2 py-0.5 text-[var(--fg-dim)] hover:text-[var(--brand)] hover:border-[var(--brand)]"
+              title={`${n} skill${n !== 1 ? "s" : ""} in ${c}`}
+            >
+              {c} · {n}
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {/* Skills grid */}
+      <section aria-label="Repository skills">
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+          {skills.map((s, i) => (
+            <SkillCard
+              key={s.id}
+              skill={s}
+              index={i}
+              searchQuery=""
+              searchTerms={null}
+              locationSearch=""
+              hasNameCollision={
+                !!collisionKeys &&
+                collisionKeys.has(s.owner + "/" + s.repo + "::" + s.name)
+              }
+            />
+          ))}
+        </div>
+        {skills.length === 0 && (
+          <div className="text-[var(--fg-dim)] text-sm py-8 text-center">
+            No skills indexed for this repository yet.
+          </div>
+        )}
+      </section>
+
+      {/* Related: other repos by the same owner are reachable via profile */}
+      <div className="mt-8 flex flex-wrap gap-4 text-sm">
+        <Link
+          to={`/profile/${encodeURIComponent(owner)}`}
+          className="text-[var(--brand)] hover:underline"
+        >
+          View stats for {owner}
+        </Link>
+        <Link to="/stats" className="text-[var(--brand)] hover:underline">
+          ← Back to Stats
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/website-src/src/pages/StatsPage.jsx
+++ b/website-src/src/pages/StatsPage.jsx
@@ -180,24 +180,33 @@ export default function StatsPage() {
               <span className="w-6 text-right font-mono text-[var(--fg-dim)]">
                 {i + 1}
               </span>
-              <a
-                href={r.repoUrl}
-                target="_blank"
-                rel="noopener noreferrer"
+              <Link
+                to={`/repos/${encodeURIComponent(r.owner)}/${encodeURIComponent(r.repo)}`}
                 className="min-w-0 font-medium text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
                 title={`${r.owner}/${r.repo}`}
               >
                 {r.owner}/{r.repo}
-              </a>
+              </Link>
               <span
                 className="hidden sm:block text-[var(--fg-dim)] text-xs truncate"
                 title={r.description}
               >
                 {r.description?.slice(0, 40)}
               </span>
-              <Badge variant="secondary" className="text-xs">
-                {r.skillCount} skills
-              </Badge>
+              <span className="flex items-center gap-2 justify-self-end">
+                <a
+                  href={r.repoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-[var(--fg-dim)] hover:text-[var(--brand)] hover:underline"
+                  title={`Open ${r.owner}/${r.repo} on GitHub`}
+                >
+                  GitHub
+                </a>
+                <Badge variant="secondary" className="text-xs">
+                  {r.skillCount} skills
+                </Badge>
+              </span>
             </div>
           ))}
           {repos.length === 0 && (


### PR DESCRIPTION
Closes #623

## Summary

Each repo now has its own detail page listing all of its skills plus relevant repo information, so users can explore everything a repo offers instead of only seeing its top-ranked skills in the catalog.

## Approach

Balanced approach — new RepoPage with stats-enriched header and SkillCard grid, wired from all catalog entry points (SkillCard, SkillDetail, StatsPage, FilterRail).

## Decision Record

- **Root cause:** The catalog had no per-repo detail view — per-repo exploration was only the `?repo=` grid filter, and only top-ranked skills surfaced via StatsPage rankings.
- **Options considered:** Option 1 — minimal; Option 2 — balanced; Option 3 — comprehensive
- **Options rejected:** Option 1 — thin header adds little over the existing `?repo=` filter and stays orphaned from StatsPage/FilterRail flows; Option 3 — over-engineered for size:M, generator changes add risk without approval
- **Selected option:** Option 2 — balanced

Analyzed at: `feat/623-add-repo-detail-page-with-skills-list @ a645bd8` (2026-09-05)

## Changes

| File | Change |
|------|--------|
| `website-src/src/pages/RepoPage.jsx` | New repo detail page: info header + full skills grid + not-found state |
| `website-src/src/App.jsx` | Added `/repos/:owner/:repo` route |
| `website-src/src/components/SkillCard.jsx` | Repo label links internally to the repo page |
| `website-src/src/components/SkillDetail.jsx` | Repo row gains "(view all skills)" internal link |
| `website-src/src/pages/StatsPage.jsx` | Top Repositories rows link internally; GitHub kept secondary |
| `website-src/src/components/FilterRail.jsx` | Active `?repo=` filter shows "View repo page" link |

## Test Results

- Unit tests: 123 passed
- Integration tests: skipped (no infra)
- E2e tests: skipped (no framework)
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Each repo has a dedicated detail page listing all of its skills | pass | `RepoPage.jsx` + `repo-page.test.jsx` (full list, no cross-repo leak) |
| The repo page shows relevant repo information alongside the skill list | pass | Header tests (description, maintainer, counts, stars, repoUrl) |
| Repo pages are reachable from the catalog | pass | Entry-link tests in `skill-card`, `skill-detail`, `stats-page`, `app-smoke` suites |

<!-- gitissue:qa v1 head=a645bd859582b3d34a2c00da508f4c2d62aa0afd profile=full cycles=1 review=clean tests=123@a645bd859582b3d34a2c00da508f4c2d62aa0afd ui=code:clean@a645bd859582b3d34a2c00da508f4c2d62aa0afd -->
