### PR TITLE
refactor(catalog): diversify popularity sort across repos (#622)

### DIFF
--- a/website-src/src/__tests__/filter-sort.test.js
+++ b/website-src/src/__tests__/filter-sort.test.js
@@ -4,6 +4,7 @@ import {
   anyFilterActive,
   buildNameCollisionKeys,
   defaultSort,
+  diversifyByRepo,
 } from "../lib/filter-sort.js";
 import { computeFacetCounts, emptyFacetState } from "../lib/facets.js";
 
@@ -206,6 +207,71 @@ describe("applyFilters", () => {
     ]);
     const out = applyFilters(skills, state, { scoreById });
     expect(out.map((s) => s.id)).toEqual(["gamma", "beta"]);
+  });
+
+  it("sort: stars — diversifies top across repos, keeps all discoverable (#622)", () => {
+    const skills = [
+      mk({
+        id: "s1",
+        owner: "obra",
+        repo: "superpowers",
+        stars: 10000,
+        evalSummary: { overallScore: 90, grade: "A" },
+      }),
+      mk({
+        id: "s2",
+        owner: "obra",
+        repo: "superpowers",
+        stars: 10000,
+        evalSummary: { overallScore: 85, grade: "A" },
+      }),
+      mk({
+        id: "s3",
+        owner: "obra",
+        repo: "superpowers",
+        stars: 10000,
+        evalSummary: { overallScore: 80, grade: "A" },
+      }),
+      mk({
+        id: "s4",
+        owner: "obra",
+        repo: "superpowers",
+        stars: 10000,
+        evalSummary: { overallScore: 75, grade: "A" },
+      }),
+      mk({
+        id: "o1",
+        owner: "other",
+        repo: "repo-a",
+        stars: 9000,
+        evalSummary: { overallScore: 95, grade: "A" },
+      }),
+      mk({
+        id: "o2",
+        owner: "third",
+        repo: "repo-b",
+        stars: 8000,
+        evalSummary: { overallScore: 95, grade: "A" },
+      }),
+    ];
+    const out = applyFilters(skills, { ...base(), sort: "stars" });
+    // Same set, only reordered — nothing hidden.
+    expect(out.map((s) => s.id).sort()).toEqual(
+      ["s1", "s2", "s3", "s4", "o1", "o2"].sort(),
+    );
+    // Top 3 mix repos instead of one repo filling the top.
+    const top3Repos = new Set(
+      out.slice(0, 3).map((s) => s.owner + "/" + s.repo),
+    );
+    expect(top3Repos.size).toBe(3);
+  });
+
+  it("diversifyByRepo keeps featured pinned and is a pure reorder", () => {
+    const feat = mk({ id: "f", stars: 1, featured: true });
+    const pop = mk({ id: "p", owner: "a", repo: "ra", stars: 9999 });
+    expect(diversifyByRepo([feat, pop]).map((s) => s.id)).toEqual(["f", "p"]);
+    const single = [mk({ id: "a" }), mk({ id: "b" })];
+    expect(diversifyByRepo(single).map((s) => s.id)).toEqual(["a", "b"]);
   });
 });
 

--- a/website-src/src/lib/filter-sort.js
+++ b/website-src/src/lib/filter-sort.js
@@ -110,6 +110,10 @@ export function applyFilters(skills, state, options = {}) {
     // "Most popular": the source repo's GitHub stars, best eval score as
     // the tiebreak so skills from the same repo still rank meaningfully,
     // then name. Missing/zero stars sink to the bottom.
+    // Diversified by repo (issue #622): skills share their repo's star
+    // count, so a pure stars sort fills the top with one repo
+    // (e.g. obra/superpowers). Round-robin across repos keeps every skill
+    // discoverable (pure reorder, no filtering) while the top mixes repos.
     results = results.slice().sort((a, b) => {
       const f = featuredFirst(a, b);
       if (f !== 0) return f;
@@ -121,6 +125,7 @@ export function applyFilters(skills, state, options = {}) {
       if (as !== bs) return bs - as;
       return a.name.localeCompare(b.name);
     });
+    results = diversifyByRepo(results);
   } else if (sortMode === "grade") {
     const gradeRank = { A: 0, B: 1, C: 2, D: 3, F: 4 };
     results = results.slice().sort((a, b) => {
@@ -155,6 +160,50 @@ export function applyFilters(skills, state, options = {}) {
   }
 
   return results;
+}
+
+/**
+ * Round-robin interleave of a popularity-sorted list across repos.
+ * Featured rows stay pinned on top in their existing order; the rest
+ * interleave one skill per repo per round, preserving within-repo order.
+ * Pure reorder — nothing is filtered, so every skill stays discoverable
+ * via pagination, search, or repo browsing (issue #622).
+ *
+ * @param {object[]} sorted Popularity-sorted rows (featured first).
+ * @returns {object[]}
+ */
+export function diversifyByRepo(sorted) {
+  let split = 0;
+  while (split < sorted.length && sorted[split].featured === true) split++;
+  const featured = sorted.slice(0, split);
+  const rest = sorted.slice(split);
+  if (rest.length < 2) return sorted.slice();
+  const groups = new Map();
+  const repoOrder = [];
+  for (const s of rest) {
+    const key = (s.owner || "") + "/" + (s.repo || "");
+    let g = groups.get(key);
+    if (!g) {
+      g = [];
+      groups.set(key, g);
+      repoOrder.push(key);
+    }
+    g.push(s);
+  }
+  if (repoOrder.length < 2) return sorted.slice();
+  const out = [];
+  for (let i = 0; ; i++) {
+    let pushed = false;
+    for (const key of repoOrder) {
+      const g = groups.get(key);
+      if (i < g.length) {
+        out.push(g[i]);
+        pushed = true;
+      }
+    }
+    if (!pushed) break;
+  }
+  return featured.concat(out);
 }
 
 /**


### PR DESCRIPTION
Closes #622

## Summary
Popularity sorting ("Most popular") ranked by repo GitHub stars, so every skill from the top-starred repo (e.g. obra/superpowers) filled the top of the catalog. The stars sort now round-robins across repos: one skill per repo per round in popularity order, keeping every skill in the list (pure reorder, pagination/search/repo browsing unchanged).

## Approach
Client-side only in `website-src/src/lib/filter-sort.js`: after the existing stars sort, `diversifyByRepo()` interleaves groups by `owner/repo`, preserving within-repo order and keeping featured pins on top. Single-repo views are a no-op; relevance/name/grade/token sorts untouched.

## Changes
| File | Change |
|------|--------|
| `website-src/src/lib/filter-sort.js` | Round-robin repo diversification for stars sort + exported `diversifyByRepo` |
| `website-src/src/__tests__/filter-sort.test.js` | Regression tests: diverse top-3, no filtering, featured pinning |

## Test Results
- `npx vitest run website-src/src/__tests__/filter-sort.test.js`: 29/29 passed
- `npx vitest run website-src/src/__tests__/`: 125/125 passed
- `npm test`: 84 files, 2675 tests passed

## Acceptance Criteria
- [x] Sorting the catalog by popularity shows skills from multiple repos among the top results
- [x] A single repo does not fill the top of the popularity-sorted catalog
- [x] Skills outside the top remain discoverable via search or repo browsing (reorder only, nothing filtered)

<!-- gitissue:qa v1 head=2d9127e7fae1f7fa965ea8935ba298d98cbc6b57 profile=light cycles=1 review=clean tests=2675@2d9127e7fae1f7fa965ea8935ba298d98cbc6b57 ui=none:skipped@2d9127e7fae1f7fa965ea8935ba298d98cbc6b57 -->