### PR TITLE
feat(catalog): one-click bundle download with defaults (#626)

### DIFF
--- a/website-src/src/__tests__/bundle-cart.test.jsx
+++ b/website-src/src/__tests__/bundle-cart.test.jsx
@@ -234,27 +234,46 @@ describe("Bundle cart flow", () => {
     expect(skillLink?.className).toContain("min-h-11");
     expect(skillLink?.className).toContain("min-w-11");
 
-    // Export button is enabled (there's ≥1 skill) but the name is blank,
-    // so clicking should show a validation error message
+    // Export works with zero input (#626): the checkout form starts
+    // pre-filled with defaults, and clearing every field still exports
+    // a valid bundle built from those defaults.
     const exportBtn = screen.getByRole("button", { name: /Export \.json/i });
     expect(exportBtn.disabled).toBe(false);
-    await act(async () => {
-      fireEvent.click(exportBtn);
-    });
-    await waitFor(() => {
-      expect(screen.getByText(/Bundle name is required/i)).toBeTruthy();
-    });
-
-    // Fill a valid name + description + author (all three required —
-    // mirrors the CLI's validateBundle) and publish. Opens a new tab
-    // so we stub window.open.
-    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
     const nameInput = container.querySelector("#bundle-name");
     const descInput = container.querySelector("#bundle-description");
     const authorInput = container.querySelector("#bundle-author");
     expect(nameInput).toBeTruthy();
     expect(descInput).toBeTruthy();
     expect(authorInput).toBeTruthy();
+    // Form starts pre-filled with the export defaults.
+    expect(nameInput.value).toBe("my-bundle");
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "" } });
+      fireEvent.change(descInput, { target: { value: "" } });
+      fireEvent.change(authorInput, { target: { value: "" } });
+    });
+    const createSpy = vi
+      .spyOn(window.URL, "createObjectURL")
+      .mockImplementation(() => "blob:mock");
+    const revokeSpy = vi
+      .spyOn(window.URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    await act(async () => {
+      fireEvent.click(exportBtn);
+    });
+    await waitFor(() => expect(createSpy).toHaveBeenCalledOnce());
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(screen.queryByText(/Bundle name is required/i)).toBeNull();
+    createSpy.mockRestore();
+    revokeSpy.mockRestore();
+    clickSpy.mockRestore();
+
+    // Fill a valid name + description + author and publish. Opens a new
+    // tab so we stub window.open.
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
     await act(async () => {
       fireEvent.change(nameInput, { target: { value: "my-test-pack" } });
       fireEvent.change(descInput, { target: { value: "A test pack." } });

--- a/website-src/src/__tests__/bundle-export.test.js
+++ b/website-src/src/__tests__/bundle-export.test.js
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildBundleJson,
   buildIssueUrl,
+  DEFAULT_BUNDLE_META,
   validateBundleForm,
+  withBundleDefaults,
 } from "../lib/bundle-export.js";
 
 const NOW = new Date("2026-04-24T12:00:00.000Z");
@@ -71,29 +73,25 @@ describe("buildBundleJson", () => {
 });
 
 describe("validateBundleForm", () => {
-  it("requires name, description, author, and ≥1 skill", () => {
+  it("requires ≥1 skill but no metadata fields", () => {
     const errors = validateBundleForm({ name: "" }, []);
-    const fields = errors.map((e) => e.field);
-    expect(fields).toContain("name");
-    expect(fields).toContain("description");
-    expect(fields).toContain("author");
-    expect(fields).toContain("skills");
+    expect(errors.map((e) => e.field)).toEqual(["skills"]);
   });
 
-  it("flags an empty description even when name and skills are valid", () => {
+  it("accepts blank description (falls back to the default)", () => {
     const errors = validateBundleForm(
       { name: "ok-name", description: "  ", author: "alice" },
       SKILLS,
     );
-    expect(errors.map((e) => e.field)).toEqual(["description"]);
+    expect(errors).toEqual([]);
   });
 
-  it("flags an empty author even when name and skills are valid", () => {
+  it("accepts a blank author (falls back to the default)", () => {
     const errors = validateBundleForm(
       { name: "ok-name", description: "has one", author: "" },
       SKILLS,
     );
-    expect(errors.map((e) => e.field)).toEqual(["author"]);
+    expect(errors).toEqual([]);
   });
 
   it("rejects invalid name characters", () => {
@@ -117,7 +115,46 @@ describe("validateBundleForm", () => {
   });
 });
 
+describe("withBundleDefaults", () => {
+  it("fills blank fields with the defaults and keeps provided values", () => {
+    expect(withBundleDefaults({})).toMatchObject(DEFAULT_BUNDLE_META);
+    expect(
+      withBundleDefaults({ name: "  ", description: "", author: "" }),
+    ).toMatchObject(DEFAULT_BUNDLE_META);
+    const out = withBundleDefaults({
+      name: "custom",
+      description: "d",
+      author: "a",
+      tags: "x",
+    });
+    expect(out).toMatchObject({
+      name: "custom",
+      description: "d",
+      author: "a",
+      tags: "x",
+    });
+  });
+
+  it("zero-input download produces a CLI-valid bundle", () => {
+    // Mirrors the non-empty checks in src/bundler.ts validateBundle().
+    const bundle = buildBundleJson(SKILLS, {}, NOW);
+    expect(bundle.name).toBeTruthy();
+    expect(bundle.description).toBeTruthy();
+    expect(bundle.author).toBeTruthy();
+    expect(bundle.createdAt).toBe(NOW.toISOString());
+    expect(bundle.skills.length).toBeGreaterThan(0);
+  });
+});
+
 describe("buildIssueUrl", () => {
+  it("falls back to the default bundle name in the issue title", () => {
+    const url = buildIssueUrl(SKILLS, {});
+    const qs = new URLSearchParams(url.split("?")[1]);
+    expect(qs.get("title")).toBe(
+      `[FEATURE] Bundle: ${DEFAULT_BUNDLE_META.name}`,
+    );
+  });
+
   it("produces a github issues URL with title/body/labels", () => {
     const url = buildIssueUrl(SKILLS, {
       name: "my-pack",

--- a/website-src/src/components/CartDrawer.jsx
+++ b/website-src/src/components/CartDrawer.jsx
@@ -273,13 +273,14 @@ export default function CartDrawer({ open, onClose }) {
             </legend>
             <p className="text-xs text-[var(--fg-dim)] -mt-1">
               These become the metadata of the bundle you export or publish.
+              Leave any field blank to use its default — Export works with zero
+              input.
             </p>
             <Field
               id="bundle-name"
               label="Bundle name"
               hint="Short identifier. Letters, digits, '.', '_', '-' (max 64)."
               error={submitted ? errorsByField.name : undefined}
-              required
             >
               <Input
                 id="bundle-name"
@@ -295,7 +296,6 @@ export default function CartDrawer({ open, onClose }) {
               label="Description"
               hint="One or two sentences about what the bundle does."
               error={submitted ? errorsByField.description : undefined}
-              required
             >
               <textarea
                 id="bundle-description"
@@ -311,7 +311,6 @@ export default function CartDrawer({ open, onClose }) {
                 id="bundle-author"
                 label="Author"
                 error={submitted ? errorsByField.author : undefined}
-                required
               >
                 <Input
                   id="bundle-author"

--- a/website-src/src/hooks/useBundleCart.jsx
+++ b/website-src/src/hooks/useBundleCart.jsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { DEFAULT_BUNDLE_META } from "../lib/bundle-export.js";
 
 /**
  * Bundle cart state + localStorage persistence (#238). Mirrors the
@@ -39,7 +40,12 @@ const BundleCartContext = createContext({
   dismissNotice: () => {},
 });
 
-const DEFAULT_META = { name: "", description: "", author: "", tags: "" };
+/**
+ * The checkout form starts pre-filled with the export defaults (#626),
+ * so the bundle can be downloaded as-is. Clearing a field falls back
+ * to the same defaults at export time (see `withBundleDefaults`).
+ */
+const DEFAULT_META = { ...DEFAULT_BUNDLE_META, tags: "" };
 
 function loadInitial() {
   if (typeof localStorage === "undefined") {

--- a/website-src/src/lib/bundle-export.js
+++ b/website-src/src/lib/bundle-export.js
@@ -10,18 +10,50 @@ const REPO_OWNER = "luongnv89";
 const REPO_NAME = "asm";
 
 /**
+ * Defaults applied when the user exports without filling in the
+ * checkout form (#626). Every field the CLI's `validateBundle()` in
+ * `src/bundler.ts` requires (non-empty `name`, `description`,
+ * `author`) gets a sensible value, so a zero-input download is still
+ * a valid, installable bundle. `name` is JSON-filename-safe per the
+ * form's name check below.
+ */
+export const DEFAULT_BUNDLE_META = {
+  name: "my-bundle",
+  description: "Skill bundle exported from the ASM catalog.",
+  author: "anonymous",
+};
+
+/**
+ * Return a copy of `meta` with blank fields replaced by
+ * `DEFAULT_BUNDLE_META`. Whitespace-only counts as blank.
+ */
+export function withBundleDefaults(meta = {}) {
+  const pick = (key) => {
+    const v = (meta[key] ?? "").toString().trim();
+    return v ? v : DEFAULT_BUNDLE_META[key];
+  };
+  return {
+    ...meta,
+    name: pick("name"),
+    description: pick("description"),
+    author: pick("author"),
+  };
+}
+
+/**
  * Build a `BundleManifest` (matching `src/utils/types.ts`) from the
  * in-memory cart + the metadata form values. `createdAt` is set here
  * — not when the cart row is added — so the timestamp reflects when
  * the user exported, not when they started shopping.
  */
 export function buildBundleJson(skills, meta, now = new Date()) {
-  const tags = splitTags(meta.tags);
+  const effective = withBundleDefaults(meta);
+  const tags = splitTags(effective.tags);
   const manifest = {
     version: 1,
-    name: (meta.name || "").trim(),
-    description: (meta.description || "").trim(),
-    author: (meta.author || "").trim(),
+    name: effective.name,
+    description: effective.description,
+    author: effective.author,
     createdAt: now.toISOString(),
     skills: skills.map((s) => {
       const ref = {
@@ -38,33 +70,22 @@ export function buildBundleJson(skills, meta, now = new Date()) {
 }
 
 /**
- * Validate the fields the CLI's `validateBundle()` in `src/bundler.ts`
- * enforces server-side (non-empty `name`, `description`, `author`, and
- * ≥ 1 skill), plus a JSON-filename-safe name check. Mirroring these
- * here prevents users from exporting a `.json` that `asm bundle
- * install` would then reject. Returns an array of { field, message }
- * — empty means valid.
+ * Validate the fields the user can influence in the builder form.
+ * Only ≥ 1 skill is required: blank `name`/`description`/`author`
+ * fall back to `DEFAULT_BUNDLE_META` at build time (#626), so the
+ * form never blocks a download. A non-blank name must still be
+ * JSON-filename-safe. Returns an array of { field, message } —
+ * empty means valid.
  */
 export function validateBundleForm(meta, skills) {
   const errors = [];
   const name = (meta.name || "").trim();
-  if (!name) {
-    errors.push({ field: "name", message: "Bundle name is required." });
-  } else if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(name)) {
+  if (name && !/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(name)) {
     errors.push({
       field: "name",
       message:
         "Name must start with a letter or digit and use only letters, digits, '.', '_', or '-' (max 64 chars).",
     });
-  }
-  if (!(meta.description || "").trim()) {
-    errors.push({
-      field: "description",
-      message: "Description is required.",
-    });
-  }
-  if (!(meta.author || "").trim()) {
-    errors.push({ field: "author", message: "Author is required." });
   }
   if (!Array.isArray(skills) || skills.length === 0) {
     errors.push({
@@ -117,8 +138,9 @@ export function buildIssueUrl(skills, meta, opts = {}) {
   const catalogBaseUrl = opts.catalogBaseUrl || "https://luongnv.com/asm/";
   const maxBytes = opts.maxBodyBytes || 7000;
 
-  const title = `[FEATURE] Bundle: ${(meta.name || "untitled").trim()}`;
-  const body = buildIssueBody(skills, meta, { catalogBaseUrl, maxBytes });
+  const effective = withBundleDefaults(meta);
+  const title = `[FEATURE] Bundle: ${effective.name}`;
+  const body = buildIssueBody(skills, effective, { catalogBaseUrl, maxBytes });
 
   const params = new URLSearchParams({
     title,


### PR DESCRIPTION
## Summary

One-click bundle download on the catalog page: the cart checkout form starts pre-filled with defaults, and Export works with zero input.

- `DEFAULT_BUNDLE_META` + `withBundleDefaults()` in `website-src/src/lib/bundle-export.js`: blank name/description/author fall back to `my-bundle` / catalog description / `anonymous`, so a zero-input download is still a valid bundle per the CLI's `validateBundle()`.
- `buildBundleJson` and `buildIssueUrl` apply the defaults; `validateBundleForm` now only requires ≥1 skill (non-blank names still filename-checked).
- Checkout form pre-filled via `useBundleCart` defaults; `required` markers dropped, helper copy notes zero-input export.

## Decision Record

- Chose build-time defaults over relaxing the CLI schema: `src/bundler.ts` still requires non-empty name/description/author, so defaults keep every export installable without touching install validation.
- Single Export path (no separate quick-export button): the existing Export button becomes the one-click action.

## Test Results

- Website suite: 15 files, 128 tests passed (`npx vitest run` in `website-src`).
- New: zero-input export produces CLI-valid bundle; issue URL falls back to default name; drawer test clears all fields and asserts the download fires with no validation error.

## Acceptance Criteria Verification

- [x] Bundle downloadable with default information pre-filled (form pre-filled; #626)
- [x] Bundle downloadable without providing any information (validation skills-only; #626)
- [x] Zero-input download produces a valid, usable bundle (defaults satisfy CLI validation; #626)

Closes #626