### PR TITLE
feat(bundle): add game development skill bundle (#630)

### DIFF
--- a/data/bundles/game-dev.json
+++ b/data/bundles/game-dev.json
@@ -1,0 +1,60 @@
+{
+  "version": 1,
+  "name": "game-dev",
+  "description": "Build Three.js browser games end to end: game direction, gameplay systems, 3D/image/audio asset generation, game UI, debugging, and release QA.",
+  "author": "ASM",
+  "createdAt": "2026-09-06T00:00:00.000Z",
+  "tags": ["game", "gamedev", "threejs", "browser-games"],
+  "skills": [
+    {
+      "name": "threejs-game-director",
+      "installUrl": "github:majidmanzarpour/threejs-game-skills:skills/threejs-game-director",
+      "description": "Entrypoint for building, upgrading, and finishing Three.js browser games"
+    },
+    {
+      "name": "threejs-gameplay-systems",
+      "installUrl": "github:majidmanzarpour/threejs-game-skills:skills/threejs-gameplay-systems",
+      "description": "Build and iterate playable Three.js game systems: core loops, levels, entities, physics, and game feel"
+    },
+    {
+      "name": "threejs-fundamentals",
+      "installUrl": "github:cloudai-x/threejs-skills:skills/threejs-fundamentals",
+      "description": "Three.js scene setup, cameras, renderer, Object3D hierarchy, coordinate systems"
+    },
+    {
+      "name": "threejs-3d-generator",
+      "installUrl": "github:majidmanzarpour/threejs-game-skills:skills/threejs-3d-generator",
+      "description": "Generate, texture, rig, and animate 3D assets for Three.js games"
+    },
+    {
+      "name": "threejs-image-generator",
+      "installUrl": "github:majidmanzarpour/threejs-game-skills:skills/threejs-image-generator",
+      "description": "Generate and edit 2D image assets for Three.js games"
+    },
+    {
+      "name": "threejs-audio-generator",
+      "installUrl": "github:majidmanzarpour/threejs-game-skills:skills/threejs-audio-generator",
+      "description": "Generate, convert, clean, and integrate audio for Three.js browser games"
+    },
+    {
+      "name": "threejs-game-ui-designer",
+      "installUrl": "github:majidmanzarpour/threejs-game-skills:skills/threejs-game-ui-designer",
+      "description": "Design premium Three.js game UI: HUDs, menus, overlays, and touch UI"
+    },
+    {
+      "name": "threejs-aaa-graphics-builder",
+      "installUrl": "github:majidmanzarpour/threejs-game-skills:skills/threejs-aaa-graphics-builder",
+      "description": "Upgrade Three.js games from prototype visuals to premium browser graphics"
+    },
+    {
+      "name": "threejs-debug-profiler",
+      "installUrl": "github:majidmanzarpour/threejs-game-skills:skills/threejs-debug-profiler",
+      "description": "Debug and profile Three.js browser games: render bugs, draw calls, memory, and bundle size"
+    },
+    {
+      "name": "threejs-qa-release",
+      "installUrl": "github:majidmanzarpour/threejs-game-skills:skills/threejs-qa-release",
+      "description": "Verify and release Three.js browser games: playtest QA, mobile checks, and release risk reports"
+    }
+  ]
+}

--- a/src/repo-bundles.test.ts
+++ b/src/repo-bundles.test.ts
@@ -197,6 +197,35 @@ describe("repo-derived bundle inference", () => {
     }
   });
 
+  it("infers a game bundle from game development skills", () => {
+    const bundles = inferRepoBundles(
+      repo([
+        skill({
+          name: "threejs-game-director",
+          description: "Entrypoint for building Three.js browser games",
+          installUrl: "github:owner/repo:skills/threejs-game-director",
+          relPath: "skills/threejs-game-director",
+        }),
+        skill({
+          name: "threejs-gameplay-systems",
+          description: "Build playable game systems and levels",
+          installUrl: "github:owner/repo:skills/threejs-gameplay-systems",
+          relPath: "skills/threejs-gameplay-systems",
+        }),
+      ]),
+    );
+
+    const game = bundles.find(
+      (bundle) => bundle.name === "owner-repo-game",
+    );
+    expect(game).toBeDefined();
+    expect(game!.inferred).toBe(true);
+    expect(game!.skills.map((s) => s.name)).toEqual([
+      "threejs-game-director",
+      "threejs-gameplay-systems",
+    ]);
+  });
+
   it("dedupes bundles by name", () => {
     const merged = mergeRepoBundles([
       {

--- a/src/repo-bundles.ts
+++ b/src/repo-bundles.ts
@@ -143,6 +143,21 @@ const GROUPS: BundleGroup[] = [
     ],
   },
   {
+    id: "game",
+    title: "Game Development Skills",
+    description:
+      "Game development, gameplay systems, game UI, 3D assets, and Three.js skills.",
+    tags: ["game", "gamedev", "threejs"],
+    keywords: [
+      "game",
+      "playtest",
+      "godot",
+      "unreal",
+      "threejs",
+      "sprite",
+    ],
+  },
+  {
     id: "devops",
     title: "DevOps Skills",
     description:


### PR DESCRIPTION
Closes #630.

- Add game inference group to src/repo-bundles.ts (game, threejs, godot, unreal, playtest, sprite keywords)
- Ship curated data/bundles/game-dev.json (Three.js game workflow, 10 skills, all refs verified against data/skill-index)
- Unit test for game inference