### PR TITLE
feat(bundle): add iOS development skill bundle (#631)

### DIFF
--- a/data/bundles/ios-release.json
+++ b/data/bundles/ios-release.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "swiftui-expert-skill",
-      "installUrl": "github:AvdLee/SwiftUI-Agent-Skill:swiftui-expert-skill",
+      "installUrl": "github:AvdLee/SwiftUI-Agent-Skill:skills/swiftui-expert-skill",
       "description": "Expert SwiftUI guidance for state, composition, performance, and API migrations"
     },
     {

--- a/src/repo-bundles.test.ts
+++ b/src/repo-bundles.test.ts
@@ -226,6 +226,42 @@ describe("repo-derived bundle inference", () => {
     ]);
   });
 
+  it("infers a mobile bundle from iOS skills without studios/scenarios noise", () => {
+    const bundles = inferRepoBundles(
+      repo([
+        skill({
+          name: "swiftui-expert-skill",
+          description: "Expert SwiftUI guidance for iOS apps",
+          installUrl: "github:owner/repo:skills/swiftui-expert-skill",
+          relPath: "skills/swiftui-expert-skill",
+        }),
+        skill({
+          name: "xcode-build-orchestrator",
+          description: "Coordinate Xcode build optimization",
+          installUrl: "github:owner/repo:skills/xcode-build-orchestrator",
+          relPath: "skills/xcode-build-orchestrator",
+        }),
+        skill({
+          name: "scenario-tester",
+          description: "Test usage scenarios and aspect ratios",
+          installUrl: "github:owner/repo:skills/scenario-tester",
+          relPath: "skills/scenario-tester",
+        }),
+      ]),
+    );
+
+    const mobile = bundles.find(
+      (bundle) => bundle.name === "owner-repo-mobile",
+    );
+    expect(mobile).toBeDefined();
+    expect(mobile!.inferred).toBe(true);
+    // "scenarios"/"ratios" must not match the mobile group ("ios" guard)
+    expect(mobile!.skills.map((s) => s.name)).toEqual([
+      "swiftui-expert-skill",
+      "xcode-build-orchestrator",
+    ]);
+  });
+
   it("dedupes bundles by name", () => {
     const merged = mergeRepoBundles([
       {

--- a/src/repo-bundles.ts
+++ b/src/repo-bundles.ts
@@ -158,6 +158,30 @@ const GROUPS: BundleGroup[] = [
     ],
   },
   {
+    id: "mobile",
+    title: "Mobile & iOS Skills",
+    description:
+      "iOS, Swift, SwiftUI, Xcode, macOS, and App Store skills.",
+    tags: ["mobile", "ios", "swift"],
+    keywords: [
+      "swift",
+      "swiftui",
+      "uikit",
+      "swiftdata",
+      "coredata",
+      "xcode",
+      "testflight",
+      "macos",
+      "watchos",
+      "appstore",
+      "app store",
+      "mobile",
+      "apple",
+      "iphone",
+      "ipad",
+    ],
+  },
+  {
     id: "devops",
     title: "DevOps Skills",
     description:


### PR DESCRIPTION
Closes #631. Adds mobile inference group, fixes broken swiftui-expert-skill URL in ios-release.json (verified against skill index).