### PR TITLE
fix(bundle): repair frontend-dev bundle skill refs (#632)

### DIFF
--- a/data/bundles/frontend-dev.json
+++ b/data/bundles/frontend-dev.json
@@ -17,14 +17,14 @@
       "description": "Review UI for usability issues using Don't Make Me Think principles"
     },
     {
-      "name": "qa",
-      "installUrl": "github:mattpocock/skills:qa",
-      "description": "Systematically QA test a web application"
+      "name": "browser-qa",
+      "installUrl": "github:affaan-m/everything-claude-code:skills/browser-qa",
+      "description": "Automate visual testing and UI interaction verification with browser automation"
     },
     {
-      "name": "browse",
-      "installUrl": "github:luongnv89/skills:skills/browse",
-      "description": "Fast headless browser for QA testing and site dogfooding"
+      "name": "e2e-testing",
+      "installUrl": "github:affaan-m/everything-claude-code:skills/e2e-testing",
+      "description": "Playwright E2E testing patterns, Page Object Model, and CI integration"
     },
     {
       "name": "code-review",


### PR DESCRIPTION
Closes #632. Two refs in frontend-dev.json resolved to nothing in the skill index; replaced with browser-qa and e2e-testing (both verified).