### PR TITLE
fix(bundle): make bundle install tool/scope pickers discoverable (#629)

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,14 @@ asm bundle install frontend-dev
 asm bundle install ./my-bundle.json
 ```
 
+In a terminal, `asm bundle install` prompts for the tool(s), then which bundle
+skills to install, then the install scope; Esc on any picker aborts. Pass
+`-p/--tool`, `-s/--scope global|project`, or `-y` to skip the matching prompt:
+
+```bash
+asm bundle install frontend-dev --tool claude --scope project --yes
+```
+
 ```bash
 asm bundle create my-workflow
 asm bundle export my-workflow ./my-workflow.json

--- a/README.md
+++ b/README.md
@@ -720,7 +720,8 @@ In a terminal, `asm bundle install` prompts for the tool(s), then which bundle
 skills to install, then the install scope; Esc on any picker aborts. Pass a
 prompt's own flag to skip it — `-p/--tool` for the tool picker,
 `-s/--scope global|project` for the scope picker, `-y` for the skill and scope
-pickers. Outside a terminal there are no pickers and `-p/--tool` is required:
+pickers. Outside a terminal there are no pickers, and `-p/--tool` is required
+unless exactly one tool is enabled:
 
 ```bash
 asm bundle install frontend-dev --tool claude --scope project --yes

--- a/README.md
+++ b/README.md
@@ -717,8 +717,10 @@ asm bundle install ./my-bundle.json
 ```
 
 In a terminal, `asm bundle install` prompts for the tool(s), then which bundle
-skills to install, then the install scope; Esc on any picker aborts. Pass
-`-p/--tool`, `-s/--scope global|project`, or `-y` to skip the matching prompt:
+skills to install, then the install scope; Esc on any picker aborts. Pass a
+prompt's own flag to skip it — `-p/--tool` for the tool picker,
+`-s/--scope global|project` for the scope picker, `-y` for the skill and scope
+pickers. Outside a terminal there are no pickers and `-p/--tool` is required:
 
 ```bash
 asm bundle install frontend-dev --tool claude --scope project --yes

--- a/src/commands/bundle.test.ts
+++ b/src/commands/bundle.test.ts
@@ -102,6 +102,11 @@ describe("bundle help discoverability (#629)", () => {
     expect(help).not.toMatch(/--yes.*all interactive pickers/);
     // Nor does piped input skip them: non-TTY runs require -p/--tool.
     expect(help).not.toMatch(/[Pp]iped input skips/);
+    // But not unconditionally — resolveProvider auto-selects before the
+    // non-TTY throw when exactly one tool is enabled.
+    expect(help).toMatch(
+      /-p\/--tool is required unless exactly one tool is enabled/,
+    );
   });
 });
 

--- a/src/commands/bundle.test.ts
+++ b/src/commands/bundle.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { parseArgs } from "../cli";
+import { cmdBundle } from "./bundle";
+
+// Issue #629 — the bundle install tool/scope pickers must be discoverable in
+// `--help` and must abort gracefully when dismissed.
+
+const mocks = vi.hoisted(() => ({
+  loadBundle: vi.fn(),
+  resolveProvider: vi.fn(),
+  promptInstallScope: vi.fn(),
+  selectBundleSkills: vi.fn(),
+  readLine: vi.fn(),
+}));
+
+vi.mock("../bundler", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../bundler")>()),
+  loadBundle: (...a: unknown[]) => mocks.loadBundle(...a),
+}));
+vi.mock("../installer", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../installer")>()),
+  resolveProvider: (...a: unknown[]) => mocks.resolveProvider(...a),
+}));
+vi.mock("./install-prompts", () => ({
+  promptInstallScope: (...a: unknown[]) => mocks.promptInstallScope(...a),
+  selectBundleSkills: (...a: unknown[]) => mocks.selectBundleSkills(...a),
+}));
+vi.mock("./shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./shared")>()),
+  readLine: (...a: unknown[]) => mocks.readLine(...a),
+}));
+
+const provider = {
+  name: "claude",
+  label: "Claude Code",
+  global: "/tmp/asm-global",
+  project: "/tmp/asm-project",
+  enabled: true,
+};
+
+class ExitError extends Error {
+  constructor(readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+let out: string[];
+let err: string[];
+let ttyDescriptor: PropertyDescriptor | undefined;
+
+function setTTY(value: boolean) {
+  ttyDescriptor ??= Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+  Object.defineProperty(process.stdin, "isTTY", {
+    value,
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  out = [];
+  err = [];
+  vi.spyOn(console, "log").mockImplementation((...a) => {
+    out.push(a.join(" "));
+  });
+  vi.spyOn(console, "error").mockImplementation((...a) => {
+    err.push(a.join(" "));
+  });
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ExitError(code ?? 0);
+  }) as never);
+
+  mocks.loadBundle.mockResolvedValue({
+    name: "demo",
+    description: "demo bundle",
+    skills: [{ name: "skill-a", installUrl: "/tmp/skill-a" }],
+  });
+  mocks.resolveProvider.mockResolvedValue({ provider, allProviders: null });
+  mocks.promptInstallScope.mockResolvedValue("global");
+  mocks.selectBundleSkills.mockImplementation(
+    async (skills: unknown) => skills,
+  );
+  mocks.readLine.mockResolvedValue("n");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  if (ttyDescriptor) {
+    Object.defineProperty(process.stdin, "isTTY", ttyDescriptor);
+    ttyDescriptor = undefined;
+  }
+});
+
+describe("bundle help discoverability (#629)", () => {
+  test("`bundle install --help` documents -p/--tool and the install scope", async () => {
+    await cmdBundle(parseArgs(["node", "asm", "bundle", "install", "--help"]));
+    const help = out.join("\n");
+    expect(help).toContain("-p, --tool <name>");
+    expect(help).toMatch(/-s, --scope[\s\S]*install scope/);
+    // The old text called scope a plain "Filter", hiding the install meaning.
+    expect(help).not.toMatch(/-s, --scope <s>\s+Filter:/);
+    expect(help).toMatch(
+      /the tool\(s\), then which bundle skills to install, then/,
+    );
+  });
+});
+
+describe("bundle install picker dismissal (#629)", () => {
+  test("dismissing the tool picker aborts gracefully", async () => {
+    setTTY(true);
+    mocks.resolveProvider.mockRejectedValue(
+      new Error("No tools selected. Aborting."),
+    );
+
+    await expect(
+      cmdBundle(parseArgs(["node", "asm", "bundle", "install", "demo"])),
+    ).rejects.toBeInstanceOf(ExitError);
+
+    expect(err.join("\n")).toContain("No tools selected. Aborting.");
+  });
+
+  test("dismissing the scope picker aborts gracefully", async () => {
+    setTTY(true);
+    mocks.promptInstallScope.mockRejectedValue(
+      new Error("No scope selected. Aborting."),
+    );
+
+    await expect(
+      cmdBundle(parseArgs(["node", "asm", "bundle", "install", "demo"])),
+    ).rejects.toBeInstanceOf(ExitError);
+
+    expect(err.join("\n")).toContain("No scope selected. Aborting.");
+  });
+
+  test("TTY run without flags prompts for tool, then scope", async () => {
+    setTTY(true);
+
+    await expect(
+      cmdBundle(parseArgs(["node", "asm", "bundle", "install", "demo"])),
+    ).rejects.toBeInstanceOf(ExitError);
+
+    expect(mocks.resolveProvider).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
+      true,
+    );
+    expect(mocks.promptInstallScope).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeFlag: "both", isTTY: true, yes: false }),
+    );
+    expect(mocks.resolveProvider.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.promptInstallScope.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/src/commands/bundle.test.ts
+++ b/src/commands/bundle.test.ts
@@ -46,10 +46,9 @@ class ExitError extends Error {
 
 let out: string[];
 let err: string[];
-let ttyDescriptor: PropertyDescriptor | undefined;
+const origIsTTY = process.stdin.isTTY;
 
 function setTTY(value: boolean) {
-  ttyDescriptor ??= Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
   Object.defineProperty(process.stdin, "isTTY", {
     value,
     configurable: true,
@@ -85,10 +84,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.clearAllMocks();
-  if (ttyDescriptor) {
-    Object.defineProperty(process.stdin, "isTTY", ttyDescriptor);
-    ttyDescriptor = undefined;
-  }
+  setTTY(origIsTTY);
 });
 
 describe("bundle help discoverability (#629)", () => {
@@ -99,9 +95,13 @@ describe("bundle help discoverability (#629)", () => {
     expect(help).toMatch(/-s, --scope[\s\S]*install scope/);
     // The old text called scope a plain "Filter", hiding the install meaning.
     expect(help).not.toMatch(/-s, --scope <s>\s+Filter:/);
-    expect(help).toMatch(
-      /the tool\(s\), then which bundle skills to install, then/,
-    );
+    expect(help).toContain("Interactive install:");
+    expect(help).toMatch(/prompts for the tool\(s\)/);
+    expect(help).toMatch(/-p\/--tool for the tool picker/);
+    // `-y` does not skip the tool picker — resolveProvider has no `yes` gate.
+    expect(help).not.toMatch(/--yes.*all interactive pickers/);
+    // Nor does piped input skip them: non-TTY runs require -p/--tool.
+    expect(help).not.toMatch(/[Pp]iped input skips/);
   });
 });
 

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -53,17 +53,19 @@ ${ansi.bold("Options:")}
   -p, --tool <name>    install: target tool (claude, codex, openclaw, agents, all)
   -s, --scope <s>      install: install scope, global or project (default: global)
                        create/list: filter by global, project, or both (default: both)
-  -y, --yes            Skip confirmation prompts (and all interactive pickers)
+  -y, --yes            Skip confirmation prompts and the skill/scope pickers
   --json               Output as JSON
   --predefined         Show pre-defined bundles shipped with ASM (for list)
   --no-color           Disable ANSI colors
   -V, --verbose        Show debug output
 
 ${ansi.bold("Interactive install:")}
-  ${ansi.dim("`asm bundle install` in a terminal, with no -p/-s/-y flag, prompts for")}
-  ${ansi.dim("the tool(s), then which bundle skills to install, then the install")}
-  ${ansi.dim("scope. Any picker can be dismissed with Esc to abort. Passing the")}
-  ${ansi.dim("matching flag, or piping input, skips that prompt.")}
+  ${ansi.dim("`asm bundle install` in a terminal prompts for the tool(s), then which")}
+  ${ansi.dim("bundle skills to install, then the install scope. Any picker can be")}
+  ${ansi.dim("dismissed with Esc to abort. Passing a prompt's own flag skips it:")}
+  ${ansi.dim("-p/--tool for the tool picker, -s/--scope for the scope picker, -y")}
+  ${ansi.dim("for the skill and scope pickers. Outside a terminal there are no")}
+  ${ansi.dim("pickers and -p/--tool is required.")}
 
 ${ansi.bold("Examples:")}
   asm bundle create my-workflow                ${ansi.dim("Create from installed skills")}

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -65,7 +65,7 @@ ${ansi.bold("Interactive install:")}
   ${ansi.dim("dismissed with Esc to abort. Passing a prompt's own flag skips it:")}
   ${ansi.dim("-p/--tool for the tool picker, -s/--scope for the scope picker, -y")}
   ${ansi.dim("for the skill and scope pickers. Outside a terminal there are no")}
-  ${ansi.dim("pickers and -p/--tool is required.")}
+  ${ansi.dim("pickers, and -p/--tool is required unless exactly one tool is enabled.")}
 
 ${ansi.bold("Examples:")}
   asm bundle create my-workflow                ${ansi.dim("Create from installed skills")}

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -50,12 +50,20 @@ ${ansi.bold("Subcommands:")}
   export <name> [file]   Export a bundle to a JSON file
 
 ${ansi.bold("Options:")}
-  -s, --scope <s>      Filter: global, project, or both (default: both)
-  -y, --yes            Skip confirmation prompts
+  -p, --tool <name>    install: target tool (claude, codex, openclaw, agents, all)
+  -s, --scope <s>      install: install scope, global or project (default: global)
+                       create/list: filter by global, project, or both (default: both)
+  -y, --yes            Skip confirmation prompts (and all interactive pickers)
   --json               Output as JSON
   --predefined         Show pre-defined bundles shipped with ASM (for list)
   --no-color           Disable ANSI colors
   -V, --verbose        Show debug output
+
+${ansi.bold("Interactive install:")}
+  ${ansi.dim("`asm bundle install` in a terminal, with no -p/-s/-y flag, prompts for")}
+  ${ansi.dim("the tool(s), then which bundle skills to install, then the install")}
+  ${ansi.dim("scope. Any picker can be dismissed with Esc to abort. Passing the")}
+  ${ansi.dim("matching flag, or piping input, skips that prompt.")}
 
 ${ansi.bold("Examples:")}
   asm bundle create my-workflow                ${ansi.dim("Create from installed skills")}
@@ -233,18 +241,33 @@ export async function cmdBundle(args: ParsedArgs) {
       }
 
       const config = await loadConfig();
-      const { provider, allProviders } = await resolveProvider(
-        config,
-        args.flags.provider,
-        !!process.stdin.isTTY,
-      );
 
       // Interactive skill selection (issue #612): mirror `asm install` —
       // TTY runs pick which bundle entries to install, --yes installs all.
-      // Both pickers dismiss into a friendly abort (not an unhandled throw).
+      // The tool picker joins them inside the try (#629) so dismissing any of
+      // the three pickers aborts with a friendly message, not a stack trace.
       let skillsToInstall = bundle.skills;
       let installScope!: "global" | "project";
+      let provider!: Awaited<ReturnType<typeof resolveProvider>>["provider"];
+      let allProviders!: Awaited<
+        ReturnType<typeof resolveProvider>
+      >["allProviders"];
       try {
+        // The tool picker used to render straight after the skill listing with
+        // no heading, reading as a second skill list (#629).
+        if (
+          process.stdin.isTTY &&
+          !args.flags.provider &&
+          config.providers.filter((p) => p.enabled).length > 1
+        ) {
+          console.error(ansi.bold("\nSelect tool(s) to install into:\n"));
+        }
+        ({ provider, allProviders } = await resolveProvider(
+          config,
+          args.flags.provider,
+          !!process.stdin.isTTY,
+        ));
+
         if (
           process.stdin.isTTY &&
           !args.flags.yes &&


### PR DESCRIPTION
## Summary

`asm bundle install` already ran tool, skill, and scope pickers on a TTY, but
nothing in normal use said so — which is why the reporter could not find them.

- `bundle --help` never listed `-p/--tool`, and described `-s/--scope` as a
  plain "Filter", so no one expected an install-scope picker.
- The tool picker rendered with no heading, directly under the bundle's skill
  listing, so it read as a second skill list.
- Dismissing the tool picker with Esc printed a `Fatal error:` stack trace,
  while the skill and scope pickers aborted cleanly.

## Changes

- `src/commands/bundle.ts` — help now documents `-p/--tool`, both meanings of
  `-s/--scope` (install scope for `install`, filter for `create`/`list`), and
  an "Interactive install" section naming the three pickers and Esc.
- `src/commands/bundle.ts` — print `Select tool(s) to install into:` before the
  tool picker, only when it will actually render.
- `src/commands/bundle.ts` — `resolveProvider` moved inside the existing
  try/catch so an Esc dismissal aborts with a message and exit 1.
- `src/commands/bundle.test.ts` — new; help text, picker order, and graceful
  dismissal of the tool and scope pickers.
- `README.md` — document the interactive flow and the flags that skip it.

A second commit corrects two help claims the first pass got wrong, caught by
review and confirmed against the CLI: `-y` does not skip the tool picker
(`resolveProvider` has no `yes` gate), and a non-TTY run without `-p/--tool`
exits 1 rather than skipping it. Both are now stated accurately and pinned by
negative assertions in the test.

A third commit corrects one more: the claim that `-p/--tool` is required
outside a terminal was unconditional, but `resolveProvider` auto-selects at
`enabled.length === 1` before reaching the non-TTY throw, so a user with
exactly one enabled tool does not need the flag. Both the help and the README
now say "required unless exactly one tool is enabled", pinned by a positive
assertion in the help test.

## Decision Record

- **Chosen:** extend the shared `printBundleHelp()` rather than add a
  per-subcommand help function. `asm bundle install --help` prints that same
  help, so this satisfies the criterion with the smallest diff.
- **Rejected — per-subcommand help functions:** a new dispatch layer and seven
  more help strings for one documented flag.
- **Rejected — rewriting the scope line to install-only:** `bundle create`
  passes `--scope` straight into `scanAllSkills`, where `both` is real. The
  line documents both meanings instead.
- **Rejected — catching the dismissal inside `resolveProvider`:** it is shared
  with `install`, `link`, `init`, and `activate`, which already handle the
  throw. Fixing the one caller that did not is the smaller change.

## Test Results

```
CI=true npm test   →  85 files, 2684 tests passed
npm run typecheck  →  clean
npm run lint       →  clean
```

End-to-end runs against a real pty (`script -q /dev/null`) with `HOME` and
`ASM_CONFIG_DIR` pointed at a scratch dir, using a local two-skill bundle:

| Scenario | Result |
| --- | --- |
| `bundle install --help` | lists `-p, --tool`, install scope, and the picker flow |
| TTY, no flags | tool picker (labelled) → skill picker → scope picker → install, exit 0 |
| Esc on tool picker | `Error: No tools selected. Aborting.` exit 1 (was a stack trace) |
| Esc on scope picker | `Error: No scope selected. Aborting.` exit 1 |
| `-y` alone on a TTY | tool picker shows; skill and scope prompts skipped, exit 0 |
| non-TTY, no `-p/--tool` | exits 1: `--tool ... is required in non-interactive mode` |
| `--tool claude --scope project -y` | installs into `.claude/skills`, no prompts, exit 0 |

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
| --- | --- | --- |
| `asm bundle install --help` documents `-p/--tool` and install scope | Met | help output; `bundle.test.ts` help assertions |
| Scope help text says install scope, not Filter | Met | `-s, --scope` now names install scope first; test asserts the old `Filter:` text is gone |
| Esc on tool picker aborts gracefully | Met | pty run above; `bundle.test.ts` dismissal test |
| TTY run without flags shows tool then scope pickers | Met | pty run above; `bundle.test.ts` call-order test |

Closes #629

https://claude.ai/code/session_013VvtrZ4xnuAsFMbCgQGgbo

<!-- gitissue:qa v1 head=f35cc8534a1be4a0b51c421b1520ea2ed55a8f39 profile=light cycles=1 review=clean tests=2684@f35cc8534a1be4a0b51c421b1520ea2ed55a8f39 -->


