### PR TITLE
test(bundle): pin the tool picker heading (#629)

### DIFF
--- a/src/commands/bundle.test.ts
+++ b/src/commands/bundle.test.ts
@@ -155,5 +155,9 @@ describe("bundle install picker dismissal (#629)", () => {
     expect(mocks.resolveProvider.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.promptInstallScope.mock.invocationCallOrder[0],
     );
+    // Without the heading the picker reads as a second skill list — the
+    // original #629 symptom. loadConfig is unmocked, so the default config's
+    // many enabled providers satisfy the `> 1` gate.
+    expect(err.join("\n")).toContain("Select tool(s) to install into:");
   });
 });


### PR DESCRIPTION
Type: chore

## Summary

Follow-up to #641. The `Select tool(s) to install into:` heading that PR added
had no assertion anywhere in the suite, so a future edit could drop it and
silently reintroduce the original #629 symptom: the tool picker rendering
directly under the bundle's skill listing, reading as a second skill list.

No production code changes. One assertion, in the test that already exercises
the path that prints the heading.

## Changes

- `src/commands/bundle.test.ts` — assert the heading reaches stderr in
  "TTY run without flags prompts for tool, then scope", with a comment
  recording why the unmocked config satisfies the heading's `> 1` enabled
  provider gate.

## Decision Record

- **Root cause:** #641 added the heading as a fix for the #629 symptom but
  pinned only the picker call order, not the heading itself. The gate
  (`isTTY && !flags.provider && enabled > 1`) was therefore untested.
- **Options considered:** (a) one assertion in the existing TTY test;
  (b) a dedicated test for the heading with its own mock setup; (c) leave it,
  relying on the call-order test.
- **Options rejected:** (b) duplicates the whole TTY fixture to assert one
  string, and would need its own config mock to hit the `> 1` gate. (c) is
  what let the gap exist — the call-order test passes whether or not the
  heading prints.
- **Selected option:** (a). The existing test already runs with `isTTY` true,
  no `--tool` flag, and an unmocked `loadConfig`, so the heading branch fires
  and lands in the captured stderr buffer. One line, no new fixture.
- **Residual risk:** the assertion depends on the default config having more
  than one enabled provider. If a future default disabled all but one tool,
  the gate would stop firing and this test would fail confusingly rather than
  informatively. The inline comment names that coupling.

## Test Results

```
npx vitest run src/commands/bundle.test.ts  ->  4 tests passed
npm run typecheck                           ->  clean
npx eslint src/commands/bundle.test.ts      ->  clean
```

**Reproduction:** removing the `console.error(ansi.bold("\nSelect tool(s) to
install into:\n"))` call from `src/commands/bundle.ts` makes the test fail with
`expected '...' to contain 'Select tool(s) to install into:'`; restoring it
turns the test green again. Red -> green confirmed before committing.

## Acceptance Criteria Verification

No acceptance criteria defined — this is a test-coverage follow-up raised by
review of #641, not a tracked issue. Issue #629 is already closed by #641.

https://claude.ai/code/session_013VvtrZ4xnuAsFMbCgQGgbo
