### PR TITLE
feat(website): add Google Analytics tracking (#645)

### DIFF
--- a/website-src/index.html
+++ b/website-src/index.html
@@ -1,6 +1,19 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-33TXRCFMWM"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-33TXRCFMWM");
+    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>asm — One tool to manage every AI agent's skills</title>


### PR DESCRIPTION
Closes #645

## Summary
Add Google Analytics tracking to the website using the provided Google tag and measurement ID `G-33TXRCFMWM`.

## Changes
- Added the `gtag.js` loader to the site entry HTML.
- Initialized Google Analytics with the requested measurement ID.

## Test Results
- `npm run lint:site`
- `npm run test:site` — 128 tests passed
- `npm run build:site`
- Pre-push checks passed: unit tests, build, and Node e2e tests

## Acceptance Criteria
- [x] Google Analytics loads with measurement ID `G-33TXRCFMWM`.
- [x] The site build completes successfully.
- [x] Site tests and lint pass.