### PR TITLE
feat(website): track SPA page views and add GoatCounter (#645)

### DIFF
--- a/website-src/index.html
+++ b/website-src/index.html
@@ -1,7 +1,15 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <!-- Google tag (gtag.js) -->
+    <!-- Google tag (gtag.js) + GoatCounter (issue #645) -->
+    <script>
+      window.goatcounter = { no_onload: true };
+    </script>
+    <script
+      data-goatcounter="https://luongnv89.goatcounter.com/count"
+      async
+      src="//gc.zgo.at/count.js"
+    ></script>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-33TXRCFMWM"
@@ -12,7 +20,8 @@
         dataLayer.push(arguments);
       }
       gtag("js", new Date());
-      gtag("config", "G-33TXRCFMWM");
+      // Virtual page views are sent from usePageTracking on each HashRouter nav.
+      gtag("config", "G-33TXRCFMWM", { send_page_view: false });
     </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/website-src/src/App.jsx
+++ b/website-src/src/App.jsx
@@ -14,6 +14,7 @@ import ProfilePage from "./pages/ProfilePage.jsx";
 import RepoPage from "./pages/RepoPage.jsx";
 import { CatalogProvider } from "./hooks/useCatalog.jsx";
 import { BundleCartProvider } from "./hooks/useBundleCart.jsx";
+import { usePageTracking } from "./hooks/usePageTracking.js";
 
 /**
  * Root application shell.
@@ -39,6 +40,7 @@ import { BundleCartProvider } from "./hooks/useBundleCart.jsx";
  * `BundleCartProvider` wraps everything so cart state is shared.
  */
 export default function App() {
+  usePageTracking();
   const [cartOpen, setCartOpen] = useState(false);
   // Stable references so the drawer's mount effect (which listens on
   // `onClose` in its dep array) doesn't re-fire on every App render and

--- a/website-src/src/__tests__/analytics.test.js
+++ b/website-src/src/__tests__/analytics.test.js
@@ -74,6 +74,21 @@ describe("analytics (issue #645)", () => {
       expect(count).toHaveBeenCalledWith({ path: "/asm/docs" });
     });
 
+    it("retries GoatCounter until count.js defines count()", () => {
+      vi.useFakeTimers();
+      const count = vi.fn();
+      const location = { pathname: "/docs", search: "" };
+
+      trackPageView(location);
+      expect(count).not.toHaveBeenCalled();
+
+      window.goatcounter = { count };
+      vi.advanceTimersByTime(100);
+
+      expect(count).toHaveBeenCalledWith({ path: "/asm/docs" });
+      vi.useRealTimers();
+    });
+
     it("swallows provider errors so navigation is never blocked", () => {
       window.gtag = () => {
         throw new Error("gtag blocked");

--- a/website-src/src/__tests__/analytics.test.js
+++ b/website-src/src/__tests__/analytics.test.js
@@ -1,0 +1,92 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildGoatCounterPath,
+  buildPageViewParams,
+  trackPageView,
+} from "../lib/analytics.js";
+
+describe("analytics (issue #645)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete window.gtag;
+    delete window.goatcounter;
+  });
+
+  describe("buildPageViewParams", () => {
+    it("maps HashRouter locations to GA4 page_view fields", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          origin: "https://luongnv.com",
+          pathname: "/asm/",
+          search: "",
+          hash: "#/skills",
+        },
+        configurable: true,
+      });
+
+      expect(
+        buildPageViewParams({ pathname: "/skills", search: "?q=test" }),
+      ).toEqual({
+        page_path: "/skills?q=test",
+        page_location: "https://luongnv.com/asm/#/skills?q=test",
+      });
+    });
+  });
+
+  describe("buildGoatCounterPath", () => {
+    it("prefixes routes with /asm for the shared GoatCounter site", () => {
+      expect(buildGoatCounterPath({ pathname: "/", search: "" })).toBe("/asm");
+      expect(buildGoatCounterPath({ pathname: "/skills", search: "" })).toBe(
+        "/asm/skills",
+      );
+      expect(
+        buildGoatCounterPath({
+          pathname: "/bundles/marketing",
+          search: "?x=1",
+        }),
+      ).toBe("/asm/bundles/marketing?x=1");
+    });
+  });
+
+  describe("trackPageView", () => {
+    it("calls gtag and goatcounter when both are available", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          origin: "https://luongnv.com",
+          pathname: "/asm/",
+          search: "",
+          hash: "#/docs",
+        },
+        configurable: true,
+      });
+      const gtag = vi.fn();
+      const count = vi.fn();
+      window.gtag = gtag;
+      window.goatcounter = { count };
+
+      trackPageView({ pathname: "/docs", search: "" });
+
+      expect(gtag).toHaveBeenCalledWith("event", "page_view", {
+        page_path: "/docs",
+        page_location: "https://luongnv.com/asm/#/docs",
+      });
+      expect(count).toHaveBeenCalledWith({ path: "/asm/docs" });
+    });
+
+    it("swallows provider errors so navigation is never blocked", () => {
+      window.gtag = () => {
+        throw new Error("gtag blocked");
+      };
+      window.goatcounter = {
+        count: () => {
+          throw new Error("goatcounter blocked");
+        },
+      };
+
+      expect(() =>
+        trackPageView({ pathname: "/stats", search: "" }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/website-src/src/hooks/usePageTracking.js
+++ b/website-src/src/hooks/usePageTracking.js
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { trackPageView } from "../lib/analytics.js";
+
+/**
+ * Send virtual page views on HashRouter navigations (issue #645).
+ *
+ * The gtag snippet in index.html sets `send_page_view: false` so the initial
+ * load is counted here once, same as every subsequent route change.
+ */
+export function usePageTracking() {
+  const location = useLocation();
+
+  useEffect(() => {
+    trackPageView(location);
+  }, [location]);
+}

--- a/website-src/src/lib/analytics.js
+++ b/website-src/src/lib/analytics.js
@@ -1,0 +1,63 @@
+/** GA4 measurement ID — also wired in `website-src/index.html`. */
+export const GA_MEASUREMENT_ID = "G-33TXRCFMWM";
+
+/** GoatCounter site for luongnv89-hosted properties (issue #645). */
+export const GOATCOUNTER_SITE = "https://luongnv89.goatcounter.com";
+
+/** Path prefix so asm traffic is separable in the shared GoatCounter site. */
+export const GOATCOUNTER_PATH_PREFIX = "/asm";
+
+/**
+ * Build GA4 page_view params for HashRouter locations.
+ *
+ * `location.pathname` is the virtual route (`/skills`, `/bundles/foo`, …).
+ * `page_location` must include the hash so GA sees the real URL.
+ */
+export function buildPageViewParams(location) {
+  const pagePath = location.pathname + location.search;
+  const pageLocation =
+    typeof window !== "undefined"
+      ? `${window.location.origin}${window.location.pathname}${window.location.search}#${pagePath}`
+      : pagePath;
+  return { page_path: pagePath, page_location: pageLocation };
+}
+
+/** GoatCounter path with the `/asm` prefix for multi-site separation. */
+export function buildGoatCounterPath(location) {
+  const pagePath = location.pathname + location.search;
+  return pagePath === "/"
+    ? GOATCOUNTER_PATH_PREFIX
+    : `${GOATCOUNTER_PATH_PREFIX}${pagePath}`;
+}
+
+function getGtag() {
+  if (typeof window === "undefined") return undefined;
+  return typeof window.gtag === "function" ? window.gtag : undefined;
+}
+
+function getGoatCounter() {
+  if (typeof window === "undefined") return undefined;
+  const gc = window.goatcounter;
+  return gc && typeof gc.count === "function" ? gc : undefined;
+}
+
+/** Fire GA4 + GoatCounter page views for a HashRouter navigation. */
+export function trackPageView(location) {
+  const gtag = getGtag();
+  if (gtag) {
+    try {
+      gtag("event", "page_view", buildPageViewParams(location));
+    } catch {
+      /* never block navigation */
+    }
+  }
+
+  const gc = getGoatCounter();
+  if (gc) {
+    try {
+      gc.count({ path: buildGoatCounterPath(location) });
+    } catch {
+      /* never block navigation */
+    }
+  }
+}

--- a/website-src/src/lib/analytics.js
+++ b/website-src/src/lib/analytics.js
@@ -41,6 +41,37 @@ function getGoatCounter() {
   return gc && typeof gc.count === "function" ? gc : undefined;
 }
 
+/** Poll interval while waiting for async count.js (GoatCounter docs). */
+const GOATCOUNTER_POLL_MS = 100;
+
+/** Stop polling after ~5s so a blocked script cannot leak timers. */
+const GOATCOUNTER_POLL_MAX = 50;
+
+function sendGoatCounterPageView(location) {
+  const path = buildGoatCounterPath(location);
+
+  const trySend = () => {
+    const gc = getGoatCounter();
+    if (!gc) return false;
+    try {
+      gc.count({ path });
+    } catch {
+      /* never block navigation */
+    }
+    return true;
+  };
+
+  if (trySend()) return;
+
+  let attempts = 0;
+  const timer = setInterval(() => {
+    attempts += 1;
+    if (trySend() || attempts >= GOATCOUNTER_POLL_MAX) {
+      clearInterval(timer);
+    }
+  }, GOATCOUNTER_POLL_MS);
+}
+
 /** Fire GA4 + GoatCounter page views for a HashRouter navigation. */
 export function trackPageView(location) {
   const gtag = getGtag();
@@ -52,12 +83,5 @@ export function trackPageView(location) {
     }
   }
 
-  const gc = getGoatCounter();
-  if (gc) {
-    try {
-      gc.count({ path: buildGoatCounterPath(location) });
-    } catch {
-      /* never block navigation */
-    }
-  }
+  sendGoatCounterPageView(location);
 }


### PR DESCRIPTION
## Summary
- Add GoatCounter alongside the existing GA4 snippet to complete issue #645.
- Track virtual page views on every HashRouter navigation so catalog, bundle, and docs routes are counted in both GA4 and GoatCounter.
- Disable automatic page-view firing in `index.html` (`send_page_view: false`, GoatCounter `no_onload`) to avoid double-counting the initial load.

## Test plan
- [x] `npm run lint:site`
- [x] `npm run test:site` (132 tests)
- [x] Pre-push checks passed (unit tests, build, e2e)
- [ ] After deploy: confirm GA4 Realtime shows page views for `#/skills`, `#/bundles`, etc.
- [ ] After deploy: confirm GoatCounter shows paths under `/asm/*`

Closes #645

Made with [Cursor](https://cursor.com)