### PR TITLE
feat(get): borrow full skill directories with explicit cleanup (#654)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,12 +200,12 @@ asm audit residency --json
 
 The advice assumes this demotion ladder:
 
-| Tier                      | `asm` mechanism                           | Residency                    |
-| ------------------------- | ----------------------------------------- | ---------------------------- |
-| Installed (auto-triggers) | provider directory / `asm activate`       | description resident, always |
-| Saved (adapt, no trigger) | `asm install --library`, `asm deactivate` | none until `asm activate`    |
-| Disabled (kept on disk)   | `asm disable` (reverse with `asm enable`) | none                         |
-| Reference (read on use)   | `asm get` — nothing on disk at all        | none                         |
+| Tier                      | `asm` mechanism                            | Residency                    |
+| ------------------------- | ------------------------------------------ | ---------------------------- |
+| Installed (auto-triggers) | provider directory / `asm activate`        | description resident, always |
+| Saved (adapt, no trigger) | `asm install --library`, `asm deactivate`  | none until `asm activate`    |
+| Disabled (kept on disk)   | `asm disable` (reverse with `asm enable`)  | none                         |
+| Reference (read on use)   | default `asm get` — no retained skill copy | none                         |
 
 Which command a candidate gets depends on how it is installed. `asm deactivate`
 only works on a live symlink into the `asm` library, so it is suggested only
@@ -229,8 +229,8 @@ entirely against your local filesystem.
 
 Demoting a skill does not mean losing it. `asm get <skill>` resolves a skill and
 writes its `SKILL.md` body to **stdout** — no provider directory, no library
-entry, no residency. The skill is paid for once, at the point of use, and costs
-nothing afterwards.
+entry, no residency. Default `get` retains no skill copy. With `--path`, it
+instead borrows a full directory on disk until you explicitly clean it up.
 
 ```bash
 asm get code-review                       # body to stdout
@@ -265,12 +265,43 @@ The catalog stores metadata, not bodies, so an `index`, `registry` or remote
 `asm get` costs a shallow clone into a temp directory, which is deleted before
 the command returns. Those fetches run the **same pre-install security scan
 `asm install` runs**; the verdict goes to stderr and into `--json` under
-`security`. It reports rather than blocks — `asm get` writes nothing — and
+`security`. It reports rather than blocks — `asm get` never installs or executes the skill — and
 `--audit` prints the full `asm audit security` report for the fetched skill.
 
 Output discipline: stdout carries the body (or, with `--json`, a single JSON
 object) and nothing else, so piping and redirecting are safe. Provenance,
 progress, and the security verdict go to stderr.
+
+#### Borrow the full skill directory
+
+When a skill needs supporting scripts, templates, references or binary assets:
+
+```bash
+borrowed_path="$(asm get --path code-review)"  # also: asm get code-review --path
+# Read "$borrowed_path/SKILL.md" and its supporting files after get exits.
+asm cleanup "$borrowed_path"                 # caller cleans up when finished
+```
+
+Every source tier is **copied**, including local paths, installed skills and
+library entries. The original is never changed or deleted. The copy lives under
+ASM's config directory in `get-borrows/`, independently of dependency sessions;
+the remote staging clone is still deleted before `get` returns. There is no
+exit-triggered borrow deletion and no `--keep` requirement. `asm install` remains
+the permanent installation workflow.
+
+Plain `--path` stdout is one absolute directory path plus a newline; provenance,
+security and cleanup guidance stay on stderr. `--path --json` (or `--machine`)
+returns `path`, sorted relative `files`, existing provenance/security fields,
+and `cleanup: {command: "asm", args: ["cleanup", path]}` instead of `content`.
+Git internals and ASM ownership metadata are omitted from the file list; `.git`
+is not copied. Executable modes and binary files are preserved. Installed root
+symlinks are resolved before copying; nested symlinks are refused.
+
+`asm cleanup <borrowed-path>` accepts only an exact registered borrow root, not
+an original source, parent, child, or symlink alias. Unknown and repeated cleanup
+are safe no-ops. Missing or mismatched ownership proof refuses deletion and may
+quarantine suspicious replacement content for inspection. Cleanup also supports
+`--json` and `--machine`.
 
 ### Just-in-time optional dependencies
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -7121,6 +7121,24 @@ describe("asm get --path and cleanup (issue #654)", () => {
       error: { code: "INVALID_ARGUMENT" },
     });
   });
+
+  test("rejects cleanup --dry-run without deleting the borrow", async () => {
+    const got = await run("get", sourceDir, "--path", "--json");
+    expect(got.exitCode, got.stderr).toBe(0);
+    const result = JSON.parse(got.stdout);
+    const refused = await run("cleanup", result.path, "--dry-run");
+    expect(refused.exitCode).toBe(2);
+    expect(refused.stderr).toContain("does not support --dry-run");
+    expect(await readFile(join(result.path, "SKILL.md"), "utf-8")).toBe(body);
+    const machine = await run("cleanup", result.path, "--dry-run", "--machine");
+    expect(machine.exitCode).toBe(2);
+    expect(JSON.parse(machine.stdout)).toMatchObject({
+      status: "error",
+      error: { code: "INVALID_ARGUMENT" },
+    });
+    expect((await run("cleanup", result.path)).exitCode).toBe(0);
+    await expect(lstat(result.path)).rejects.toMatchObject({ code: "ENOENT" });
+  });
 });
 
 // ─── Caller-owned dependency leases (issue #621) ───────────────────────────

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -6845,6 +6845,284 @@ One line of body text.
   });
 });
 
+// ─── Durable full-directory get borrows (issue #654) ───────────────────────
+
+describe("parseArgs: get --path and cleanup", () => {
+  test.each([
+    ["get", "--path", "helper"],
+    ["get", "helper", "--path"],
+    ["get", "--path", "helper", "--json"],
+    ["get", "helper", "--path", "--machine"],
+  ])("distinguishes the boolean get flag: %j", (...argv) => {
+    expect(parseArgs(["node", "asm", ...argv])).toMatchObject({
+      command: "get",
+      subcommand: "helper",
+      positional: [],
+      flags: { getPath: true, path: null },
+    });
+  });
+
+  test.each(["install", "init"])(
+    "preserves %s --path as a string",
+    (command) => {
+      expect(
+        parseArgs(["node", "asm", command, "helper", "--path", "/target"]),
+      ).toMatchObject({ flags: { getPath: false, path: "/target" } });
+    },
+  );
+
+  test("recognizes cleanup and its exact path positional", () => {
+    expect(isCLIMode(["node", "asm", "cleanup", "/borrow"])).toBe(true);
+    expect(parseArgs(["node", "asm", "cleanup", "/borrow"])).toMatchObject({
+      command: "cleanup",
+      subcommand: "/borrow",
+    });
+  });
+});
+
+describe("asm get --path and cleanup (issue #654)", () => {
+  let tempDir: string;
+  let sourceDir: string;
+  let home: string;
+  let configDir: string;
+  const body =
+    "---\nname: borrow-fixture\ndescription: Full skill fixture\n---\n# Borrow fixture\n";
+  const binary = Buffer.from([0, 255, 128, 1]);
+
+  async function run(...args: string[]) {
+    return spawnCollect(["npx", "tsx", CLI_BIN, ...args], {
+      cwd: tempDir,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        ASM_CONFIG_DIR: configDir,
+        NO_COLOR: "1",
+      },
+    });
+  }
+
+  beforeEach(async () => {
+    tempDir = await realpath(await mkdtemp(join(tmpdir(), "asm-borrow-cli-")));
+    home = join(tempDir, "home");
+    configDir = join(home, ".config", "agent-skill-manager");
+    sourceDir = join(tempDir, "source with spaces", "borrow-fixture");
+    await mkdir(join(sourceDir, "scripts"), { recursive: true });
+    await mkdir(join(sourceDir, "assets"));
+    await mkdir(join(sourceDir, "templates"));
+    await writeFile(join(sourceDir, "SKILL.md"), body);
+    await writeFile(
+      join(sourceDir, "scripts", "run.sh"),
+      "#!/bin/sh\nprintf fixture\n",
+    );
+    await chmod(join(sourceDir, "scripts", "run.sh"), 0o755);
+    await writeFile(join(sourceDir, "assets", "data.bin"), binary);
+    await writeFile(join(sourceDir, "templates", "sample.txt"), "template");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("reads all files after get exits, then a second command removes only the borrow", async () => {
+    const got = await run("get", "--path", sourceDir);
+    expect(got.exitCode, got.stderr).toBe(0);
+    const path = got.stdout.trim();
+    expect(got.stdout).toBe(path + "\n");
+    expect(await realpath(path)).toBe(path);
+    expect(path).not.toBe(sourceDir);
+    expect(got.stderr).toContain("asm cleanup");
+    expect(got.stderr).toContain("(local)");
+    expect(await readFile(join(path, "SKILL.md"), "utf-8")).toBe(body);
+    expect(await readFile(join(path, "assets", "data.bin"))).toEqual(binary);
+    expect(await readFile(join(path, "templates", "sample.txt"), "utf-8")).toBe(
+      "template",
+    );
+    if (process.platform !== "win32")
+      expect((await lstat(join(path, "scripts", "run.sh"))).mode & 0o777).toBe(
+        0o755,
+      );
+    const sentinel = join(configDir, "unrelated.txt");
+    await writeFile(sentinel, "keep");
+    const cleaned = await run("cleanup", path);
+    expect(cleaned.exitCode, cleaned.stderr).toBe(0);
+    expect(cleaned.stdout).toContain("Removed borrowed skill");
+    await expect(lstat(path)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(join(sourceDir, "SKILL.md"), "utf-8")).toBe(body);
+    expect(await readFile(sentinel, "utf-8")).toBe("keep");
+    for (const dir of [
+      join(home, ".claude", "skills"),
+      join(configDir, "library"),
+    ]) {
+      await expect(lstat(dir)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+    const repeated = await run("cleanup", path, "--json");
+    expect(repeated.exitCode).toBe(0);
+    expect(JSON.parse(repeated.stdout)).toMatchObject({
+      path,
+      status: "not-found",
+      errors: [],
+    });
+  });
+
+  test.each([
+    ["before", "--json"],
+    ["after", "--json"],
+    ["before", "--machine"],
+    ["after", "--machine"],
+  ])("supports --path %s the target with %s", async (position, mode) => {
+    const got = await run(
+      "get",
+      ...(position === "before"
+        ? ["--path", sourceDir]
+        : [sourceDir, "--path"]),
+      mode,
+    );
+    expect(got.exitCode, got.stderr).toBe(0);
+    const payload = JSON.parse(got.stdout);
+    if (mode === "--machine")
+      expect(payload).toMatchObject({
+        command: "get",
+        status: "ok",
+        version: 1,
+      });
+    const result = mode === "--machine" ? payload.data : payload;
+    expect(result).toMatchObject({
+      name: "borrow-fixture",
+      tier: "local",
+      source: sourceDir,
+      security: null,
+      files: [
+        "SKILL.md",
+        "assets/data.bin",
+        "scripts/run.sh",
+        "templates/sample.txt",
+      ],
+      cleanup: { command: "asm", args: ["cleanup", result.path] },
+    });
+    expect(result).not.toHaveProperty("content");
+    expect(await readFile(join(result.path, "SKILL.md"), "utf-8")).toBe(body);
+    const cleaned = await run(...result.cleanup.args, mode);
+    expect(cleaned.exitCode, cleaned.stderr).toBe(0);
+    const cleanup = JSON.parse(cleaned.stdout);
+    expect(mode === "--machine" ? cleanup.data : cleanup).toMatchObject({
+      path: result.path,
+      status: "removed",
+      errors: [],
+    });
+  });
+
+  test("copies installed provider symlinks and leaves the provider and source intact", async () => {
+    const installed = join(home, ".claude", "skills", "borrow-fixture");
+    await mkdir(dirname(installed), { recursive: true });
+    await createDirSymlink(sourceDir, installed);
+    const got = await run("get", "borrow-fixture", "--path", "--json");
+    expect(got.exitCode, got.stderr).toBe(0);
+    const result = JSON.parse(got.stdout);
+    expect(result.tier).toBe("installed");
+    expect(result.files).toContain("assets/data.bin");
+    expect((await run("cleanup", result.path)).exitCode).toBe(0);
+    expect((await lstat(installed)).isSymbolicLink()).toBe(true);
+    expect(await readFile(join(installed, "SKILL.md"), "utf-8")).toBe(body);
+  });
+
+  test("borrows a deactivated library installation without removing the permanent install", async () => {
+    const installed = await run("install", sourceDir, "--library", "--yes");
+    expect(installed.exitCode, installed.stderr).toBe(0);
+    const got = await run("get", "borrow-fixture", "--path", "--json");
+    expect(got.exitCode, got.stderr).toBe(0);
+    const result = JSON.parse(got.stdout);
+    expect(result.tier).toBe("library");
+    expect(result.path).not.toBe(result.source);
+    expect((await run("cleanup", result.path)).exitCode).toBe(0);
+    const originalCleanup = await run("cleanup", result.source, "--json");
+    expect(JSON.parse(originalCleanup.stdout).status).toBe("not-found");
+    expect(await readFile(join(result.source, "SKILL.md"), "utf-8")).toBe(body);
+    expect(await readFile(join(sourceDir, "SKILL.md"), "utf-8")).toBe(body);
+  });
+
+  test("isolates concurrent subprocess borrows and serializes cross-process cleanup", async () => {
+    const gets = await Promise.all([
+      run("get", sourceDir, "--path"),
+      run("get", sourceDir, "--path"),
+    ]);
+    expect(gets.map((r) => r.exitCode)).toEqual([0, 0]);
+    const [one, two] = gets.map((r) => r.stdout.trim());
+    expect(one).not.toBe(two);
+    const cleanups = await Promise.all([
+      run("cleanup", one, "--json"),
+      run("cleanup", one, "--json"),
+    ]);
+    expect(cleanups.map((r) => r.exitCode)).toEqual([0, 0]);
+    expect(cleanups.map((r) => JSON.parse(r.stdout).status).sort()).toEqual([
+      "not-found",
+      "removed",
+    ]);
+    expect(await readFile(join(two, "SKILL.md"), "utf-8")).toBe(body);
+    expect((await run("cleanup", two)).exitCode).toBe(0);
+    expect(await readFile(join(sourceDir, "SKILL.md"), "utf-8")).toBe(body);
+  });
+
+  test("reports ownership refusal through a machine error without deleting content", async () => {
+    const got = await run("get", sourceDir, "--path");
+    const path = got.stdout.trim();
+    const marker = (await readdir(path)).find((name) =>
+      name.startsWith(".asm-owner-"),
+    )!;
+    await rm(join(path, marker));
+    const cleaned = await run("cleanup", path, "--machine");
+    expect(cleaned.exitCode).toBe(1);
+    expect(JSON.parse(cleaned.stdout)).toMatchObject({
+      command: "cleanup",
+      status: "error",
+      error: { details: { path, status: "refused" } },
+    });
+    const preserved = (await readdir(dirname(path))).find((name) =>
+      name.includes(".quarantine-"),
+    )!;
+    expect(
+      await readFile(join(dirname(path), preserved, "SKILL.md"), "utf-8"),
+    ).toBe(body);
+    expect(await readFile(join(sourceDir, "SKILL.md"), "utf-8")).toBe(body);
+  });
+
+  test("keeps shell metacharacters in config paths as data, not cleanup command syntax", async () => {
+    configDir = join(home, "config with $dollars `backticks` and 'quotes'");
+    const got = await run("get", sourceDir, "--path");
+    expect(got.exitCode, got.stderr).toBe(0);
+    const path = got.stdout.trim();
+    expect(path.startsWith(configDir)).toBe(true);
+    expect(got.stdout).toBe(path + "\n");
+    expect(got.stderr).toContain(
+      "run asm cleanup with the exact path printed to stdout.",
+    );
+    expect(got.stderr).not.toContain(path);
+    expect(await readFile(join(path, "SKILL.md"), "utf-8")).toBe(body);
+    expect((await run("cleanup", path)).exitCode).toBe(0);
+  });
+
+  test("documents borrows and cleanup in command and main help", async () => {
+    const get = await run("get", "--help");
+    expect(get.stdout).toContain("--path");
+    expect(get.stdout).toContain("survives");
+    const cleanup = await run("cleanup", "--help");
+    expect(cleanup.exitCode).toBe(0);
+    expect(cleanup.stdout).toContain("asm cleanup <borrowed-path>");
+    expect((await run("--help")).stdout).toContain("cleanup <path>");
+  });
+
+  test("validates missing/extra cleanup arguments and a missing get --path target", async () => {
+    expect((await run("get", "--path")).exitCode).toBe(2);
+    expect((await run("cleanup")).exitCode).toBe(2);
+    const extra = await run("cleanup", sourceDir, tempDir, "--machine");
+    expect(extra.exitCode).toBe(2);
+    expect(JSON.parse(extra.stdout)).toMatchObject({
+      status: "error",
+      error: { code: "INVALID_ARGUMENT" },
+    });
+  });
+});
+
 // ─── Caller-owned dependency leases (issue #621) ───────────────────────────
 
 describe("asm deps (issue #621)", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,8 @@ export interface ParsedArgs {
     name: string | null;
     force: boolean;
     path: string | null;
+    /** `asm get --path` borrows a full directory; install/init retain string path. */
+    getPath: boolean;
     all: boolean;
     library: boolean;
     verbose: boolean;
@@ -123,6 +125,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       name: null,
       force: false,
       path: null,
+      getPath: false,
       all: false,
       library: false,
       verbose: false,
@@ -212,8 +215,12 @@ export function parseArgs(argv: string[]): ParsedArgs {
     } else if (arg === "--force" || arg === "-f") {
       result.flags.force = true;
     } else if (arg === "--path") {
-      i++;
-      result.flags.path = args[i] || null;
+      if (result.command === "get") {
+        result.flags.getPath = true;
+      } else {
+        i++;
+        result.flags.path = args[i] || null;
+      }
     } else if (arg === "--all") {
       result.flags.all = true;
     } else if (arg === "--library") {
@@ -392,7 +399,8 @@ ${ansi.bold("Commands:")}
   search <query>         Search skills by name/description/tool
   tag add|remove         Edit local tags for an installed skill
   inspect <skill-name>   Show detailed info for a skill
-  get <skill>            Print a skill's SKILL.md body (installs nothing)
+  get <skill>            Print a skill body, or borrow its directory with --path
+  cleanup <path>         Remove an exact directory borrowed by get --path
   deps                   Manage caller-owned temporary dependency leases
   uninstall <skill-name> Remove a skill (with confirmation)
   disable <target>       Disable skill(s) without uninstalling
@@ -445,6 +453,7 @@ import { cmdSearch } from "./commands/search";
 import { cmdTag } from "./commands/tag";
 import { cmdInspect } from "./commands/inspect";
 import { cmdGet } from "./commands/get";
+import { cmdCleanup } from "./commands/cleanup";
 import { cmdDeps } from "./commands/deps";
 import { cmdUninstall } from "./commands/uninstall";
 import { cmdDisable, cmdEnable } from "./commands/toggle";
@@ -554,6 +563,9 @@ export async function runCLI(argv: string[]): Promise<void> {
     case "get":
       await cmdGet(args);
       break;
+    case "cleanup":
+      await cmdCleanup(args);
+      break;
     case "deps":
       await cmdDeps(args);
       break;
@@ -643,6 +655,7 @@ export function isCLIMode(argv: string[]): boolean {
     "tag",
     "inspect",
     "get",
+    "cleanup",
     "deps",
     "uninstall",
     "audit",

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -1,0 +1,61 @@
+import type { ParsedArgs } from "../cli";
+import { cleanupGetBorrow } from "../get-borrows";
+import {
+  formatCleanupHelp,
+  formatGetBorrowCleanup,
+  formatJSON,
+} from "../formatter";
+import {
+  ErrorCodes,
+  formatMachineError,
+  formatMachineOutput,
+} from "../utils/machine";
+import { error } from "./shared";
+
+export async function cmdCleanup(args: ParsedArgs): Promise<void> {
+  if (args.flags.help) {
+    console.log(formatCleanupHelp());
+    return;
+  }
+  const startTime = performance.now();
+  if (!args.subcommand || args.positional.length) {
+    const message =
+      "Expected exactly one argument: <borrowed-path>. Run asm cleanup --help for usage.";
+    if (args.flags.machine) {
+      console.log(
+        formatMachineError(
+          "cleanup",
+          ErrorCodes.INVALID_ARGUMENT,
+          message,
+          startTime,
+        ),
+      );
+    } else {
+      error(message);
+    }
+    process.exitCode = 2;
+    return;
+  }
+
+  const result = await cleanupGetBorrow(args.subcommand);
+  if (args.flags.machine) {
+    console.log(
+      result.status === "refused"
+        ? formatMachineError(
+            "cleanup",
+            ErrorCodes.INVALID_ARGUMENT,
+            formatGetBorrowCleanup(result),
+            startTime,
+            result,
+          )
+        : formatMachineOutput("cleanup", result, startTime),
+    );
+  } else if (args.flags.json) {
+    console.log(formatJSON(result));
+  } else if (result.status === "refused") {
+    error(formatGetBorrowCleanup(result));
+  } else {
+    console.log(formatGetBorrowCleanup(result));
+  }
+  if (result.status === "refused") process.exitCode = 1;
+}

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -18,6 +18,24 @@ export async function cmdCleanup(args: ParsedArgs): Promise<void> {
     return;
   }
   const startTime = performance.now();
+  if (args.flags.dryRun) {
+    const message =
+      "asm cleanup does not support --dry-run. Re-run without it to remove the borrow, or leave the directory in place.";
+    if (args.flags.machine) {
+      console.log(
+        formatMachineError(
+          "cleanup",
+          ErrorCodes.INVALID_ARGUMENT,
+          message,
+          startTime,
+        ),
+      );
+    } else {
+      error(message);
+    }
+    process.exitCode = 2;
+    return;
+  }
   if (!args.subcommand || args.positional.length) {
     const message =
       "Expected exactly one argument: <borrowed-path>. Run asm cleanup --help for usage.";

--- a/src/commands/get.test.ts
+++ b/src/commands/get.test.ts
@@ -1,0 +1,249 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseArgs } from "../cli";
+import { cmdGet } from "./get";
+import * as remote from "./eval";
+import * as scanner from "../scanner";
+import * as library from "../library";
+import * as index from "../skill-index";
+import * as registry from "../registry";
+import { cleanupGetBorrow } from "../get-borrows";
+import { getGetBorrowsDir } from "../config";
+import type { GetPathResult } from "../utils/types";
+
+let tempDir: string;
+let cloneDir: string;
+let selectedDir: string;
+let stdout: string;
+let stderr: string;
+const body =
+  "---\nname: helper\ndescription: Remote fixture\ndependencies: [other]\n---\n# Helper\nUse scripts/helper.sh and assets/data.bin.\n";
+const sha = "a".repeat(40);
+const source = `github:acme/skills#${sha}:skills/helper`;
+const indexedMatch: index.IndexedSkillMatch = {
+  repo: { owner: "acme", repo: "skills" },
+  skill: {
+    name: "helper",
+    description: "Remote fixture",
+    version: "1.0.0",
+    license: "MIT",
+    creator: "acme",
+    compatibility: "",
+    allowedTools: [],
+    installUrl: source,
+    relPath: "skills/helper",
+  },
+};
+
+beforeEach(async () => {
+  tempDir = await realpath(await mkdtemp(join(tmpdir(), "asm-get-command-")));
+  vi.stubEnv("ASM_CONFIG_DIR", join(tempDir, "config"));
+  vi.stubEnv("NO_COLOR", "1");
+  cloneDir = join(tempDir, "clone");
+  selectedDir = join(cloneDir, "skills", "helper");
+  await mkdir(join(selectedDir, "scripts"), { recursive: true });
+  await mkdir(join(selectedDir, "assets"));
+  await mkdir(join(selectedDir, ".git"));
+  await writeFile(join(selectedDir, "SKILL.md"), body);
+  await writeFile(
+    join(selectedDir, "scripts", "helper.sh"),
+    "#!/bin/sh\nprintf helper\n",
+    { mode: 0o755 },
+  );
+  await writeFile(
+    join(selectedDir, "assets", "data.bin"),
+    Buffer.from([0, 128, 255]),
+  );
+  await writeFile(join(selectedDir, ".git", "config"), "omit");
+  await writeFile(
+    join(cloneDir, "sibling.txt"),
+    "not part of the selected skill",
+  );
+  vi.spyOn(scanner, "scanAllSkills").mockResolvedValue([]);
+  vi.spyOn(library, "listLibrarySkills").mockResolvedValue([]);
+  vi.spyOn(index, "resolveIndexedSkillByName").mockResolvedValue({
+    status: "none",
+  });
+  vi.spyOn(registry, "resolveFromRegistry").mockResolvedValue({
+    resolved: null,
+    multipleMatches: [],
+    suggestions: [],
+  });
+  vi.spyOn(remote, "fetchRemoteSkillDir").mockResolvedValue({
+    rootDir: selectedDir,
+    tempDir: cloneDir,
+    sourceRef: source,
+    commitSha: sha,
+    cleanup: vi.fn(async () => {
+      await rm(cloneDir, { recursive: true, force: true });
+    }),
+  });
+  stdout = "";
+  stderr = "";
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    stdout += String(chunk);
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    stderr += String(chunk);
+    return true;
+  });
+});
+
+afterEach(async () => {
+  process.exitCode = 0;
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function run(...args: string[]) {
+  return cmdGet(parseArgs(["node", "asm", "get", ...args]));
+}
+
+describe("get path resolution and remote lifecycle", () => {
+  it.each(["remote", "index", "registry"] as const)(
+    "borrows the full selected %s skill before deleting its staging clone",
+    async (tier) => {
+      if (tier === "index")
+        vi.mocked(index.resolveIndexedSkillByName).mockResolvedValue({
+          status: "found",
+          match: indexedMatch,
+        });
+      if (tier === "registry")
+        vi.mocked(registry.resolveFromRegistry).mockResolvedValue({
+          resolved: {
+            source: "registry",
+            manifest: {
+              name: "helper",
+              author: "acme",
+              description: "Remote fixture",
+              repository: "https://github.com/acme/skills",
+              commit: sha,
+              skill_path: "skills/helper",
+              security_verdict: "pass",
+              published_at: "2026-01-01T00:00:00Z",
+            },
+          },
+          multipleMatches: [],
+          suggestions: [],
+        });
+      await run(
+        "--path",
+        tier === "remote" ? source : "helper",
+        "--json",
+        "--transport",
+        "https",
+        "--no-cache",
+      );
+      const result = JSON.parse(stdout) as GetPathResult;
+      expect(result).toMatchObject({
+        name: "helper",
+        tier,
+        source,
+        commit: sha,
+        dependencies: ["other"],
+        security: {
+          risk: expect.any(String),
+          warnings: expect.any(Number),
+          categories: expect.any(Array),
+        },
+        cleanup: { command: "asm", args: ["cleanup", result.path] },
+      });
+      expect(result.files).toEqual([
+        "SKILL.md",
+        "assets/data.bin",
+        "scripts/helper.sh",
+      ]);
+      expect(result).not.toHaveProperty("content");
+      expect(await readFile(join(result.path, "SKILL.md"), "utf-8")).toBe(body);
+      expect(await readFile(join(result.path, "assets", "data.bin"))).toEqual(
+        Buffer.from([0, 128, 255]),
+      );
+      await expect(readdir(cloneDir)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(remote.fetchRemoteSkillDir).toHaveBeenCalledWith(
+        source,
+        "https",
+        false,
+      );
+      if (tier === "registry")
+        expect(registry.resolveFromRegistry).toHaveBeenCalledWith("helper", {
+          noCache: true,
+        });
+      expect((await cleanupGetBorrow(result.path)).status).toBe("removed");
+    },
+  );
+
+  it("keeps default remote body output unchanged and retains no borrow", async () => {
+    await run(source);
+    expect(stdout).toBe(body);
+    expect(stderr).toContain("security:");
+    expect(stderr).not.toContain("cleanup:");
+    await expect(readdir(cloneDir)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readdir(getGetBorrowsDir())).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("still deletes remote staging on copy rejection without touching a symlink target", async () => {
+    const outside = join(tempDir, "outside.txt");
+    await writeFile(outside, "untouched");
+    await symlink(outside, join(selectedDir, "nested-link"), "file");
+    await run(source, "--path", "--machine");
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(stdout)).toMatchObject({
+      command: "get",
+      status: "error",
+      error: { message: expect.stringContaining("symbolic link") },
+    });
+    await expect(readdir(cloneDir)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(outside, "utf-8")).toBe("untouched");
+    await expect(
+      readdir(join(getGetBorrowsDir(), "artifacts")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("does not borrow or fetch when the indexed selection is ambiguous", async () => {
+    vi.mocked(index.resolveIndexedSkillByName).mockResolvedValue({
+      status: "ambiguous",
+      matches: [indexedMatch, indexedMatch],
+    });
+    await run("helper", "--path", "--machine");
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(stdout)).toMatchObject({
+      status: "error",
+      error: {
+        code: "INVALID_ARGUMENT",
+        details: { candidates: expect.any(Array) },
+      },
+    });
+    expect(remote.fetchRemoteSkillDir).not.toHaveBeenCalled();
+    await expect(readdir(getGetBorrowsDir())).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("makes no borrow for a missing target", async () => {
+    await run("NotARealSkill_654", "--path", "--machine");
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(stdout)).toMatchObject({
+      status: "error",
+      error: { code: "SKILL_NOT_FOUND" },
+    });
+    expect(remote.fetchRemoteSkillDir).not.toHaveBeenCalled();
+    await expect(readdir(getGetBorrowsDir())).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -5,7 +5,13 @@ import {
   resolveSkillDependencies,
 } from "../utils/frontmatter";
 import { readFile as fsReadFile } from "fs/promises";
-import { formatJSON, ansi } from "../formatter";
+import {
+  formatJSON,
+  ansi,
+  formatGetPath,
+  formatGetProvenance,
+} from "../formatter";
+import { borrowGetSkill } from "../get-borrows";
 import {
   parseSource,
   isLocalPath,
@@ -26,7 +32,7 @@ import {
   redirectConsoleToStderr,
 } from "../utils/machine";
 import { resolveIndexedSkillByName } from "../skill-index";
-import { estimateTokenCount, formatTokenCount } from "../utils/token-count";
+import { estimateTokenCount } from "../utils/token-count";
 import { findLibrarySkill, listLibrarySkills } from "../library";
 import { join as joinPath } from "path";
 import type { GetResult, GetSecurityVerdict, GetTier } from "../utils/types";
@@ -55,9 +61,16 @@ Index, registry and remote sources are fetched into a temp clone, scanned with
 the same pre-install security scan \`asm install\` runs, and deleted. The body
 goes to stdout; provenance and the security verdict go to stderr.
 
+With --path, copy the full selected directory (scripts, templates, assets, etc.)
+into an ASM-owned borrow and print its absolute path instead. The copy survives
+process exit. Later run asm cleanup <borrowed-path>; originals are never removed.
+No --keep is needed. Use asm install for permanent provider/library installation.
+
 ${ansi.bold("Options:")}
+  --path             Borrow the full skill directory, not just its body
   --json             Output {name, description, tier, source, commit,
-                     tokenCount, security, content} as a JSON object
+                     tokenCount, security, content} as a JSON object;
+                     --path returns path, sorted files and cleanup argv instead of content
   --machine          Stable machine-readable v1 envelope
   --audit            Also print the full security audit report (stderr),
                      for any resolved skill, not only fetched ones
@@ -72,41 +85,9 @@ ${ansi.bold("Examples:")}
   asm get code-review > SKILL.md           ${ansi.dim("Save it without installing")}
   asm get github:owner/repo:skills/review  ${ansi.dim("Fetch a remote skill")}
   asm get owner/review --audit             ${ansi.dim("Show the full security audit")}
-  asm get code-review --json               ${ansi.dim("Structured output")}`);
-}
-
-function getRiskLabel(risk: "high" | "medium" | "safe"): string {
-  if (risk === "high") return ansi.red("[!] High Risk");
-  if (risk === "medium") return ansi.yellow("[~] Medium Risk");
-  return ansi.green("[ok] Safe");
-}
-
-/**
- * Provenance block for the plain (non-JSON) path. Always stderr: stdout
- * carries the body and nothing else, so `asm get x > SKILL.md` and
- * `asm get x | agent` both stay clean.
- */
-
-function writeGetProvenance(result: GetResult): void {
-  const lines: string[] = [
-    `  ${ansi.bold(result.name)}  ${ansi.dim(formatTokenCount(result.tokenCount))}`,
-    `  ${ansi.dim("source:")} ${result.source}${
-      result.commit ? ` @ ${result.commit.slice(0, 7)}` : ""
-    } ${ansi.dim(`(${result.tier})`)}`,
-  ];
-  if (result.security) {
-    const { risk, warnings, categories } = result.security;
-    const detail = warnings
-      ? ansi.dim(
-          ` (${warnings} warning${warnings === 1 ? "" : "s"}: ${categories.join(", ")})`,
-        )
-      : "";
-    lines.push(`  ${ansi.dim("security:")} ${getRiskLabel(risk)}${detail}`);
-  }
-  lines.push(
-    `  ${ansi.dim("residency:")} ${ansi.dim("none — nothing was installed")}`,
-  );
-  process.stderr.write(lines.join("\n") + "\n\n");
+  asm get code-review --json               ${ansi.dim("Structured output")}
+  asm get --path code-review               ${ansi.dim("Borrow the full directory")}
+  asm cleanup /absolute/borrowed-path     ${ansi.dim("Remove only that borrow")}`);
 }
 
 /**
@@ -139,8 +120,8 @@ async function validateSkillForGet(
 /**
  * Clone a remote source into a temp dir, read its body, and run the same
  * pre-install security scan `asm install` runs. The verdict is *reported*, not
- * enforced — `asm get` writes nothing, so there is no install to block; the
- * user sees the risk before they feed the text to an agent.
+ * enforced — neither body output nor a borrowed copy installs the skill. The
+ * caller sees the risk before using the text or files; no skill code is run.
  */
 
 async function fetchGetFromRemote(
@@ -393,14 +374,20 @@ export async function cmdGet(args: ParsedArgs) {
       process.stderr.write(formatSecurityReport(report) + "\n");
     }
 
+    const output = args.flags.getPath
+      ? await borrowGetSkill(target, resolution.dir, result)
+      : result;
     if (args.flags.machine) {
       process.stdout.write(
-        formatMachineOutput("get", result, startTime) + "\n",
+        formatMachineOutput("get", output, startTime) + "\n",
       );
     } else if (args.flags.json) {
-      process.stdout.write(formatJSON(result) + "\n");
+      process.stdout.write(formatJSON(output) + "\n");
+    } else if ("path" in output) {
+      process.stderr.write(formatGetProvenance(output));
+      process.stdout.write(formatGetPath(output));
     } else {
-      writeGetProvenance(result);
+      process.stderr.write(formatGetProvenance(result));
       process.stdout.write(result.content);
       if (!result.content.endsWith("\n")) process.stdout.write("\n");
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -229,6 +229,11 @@ export function getDependencyLeasesDir(): string {
   return join(getConfigDir(), "dependency-leases");
 }
 
+/** Durable `get --path` copies, isolated from caller-session dependency leases. */
+export function getGetBorrowsDir(): string {
+  return join(getConfigDir(), "get-borrows");
+}
+
 export function getBundledIndexDir(): string {
   // In built dist/: __dirname is dist/, data/ is at ../data/
   // In dev (src/): __dirname is src/, data/ is at ../data/

--- a/src/dependency-leases.test.ts
+++ b/src/dependency-leases.test.ts
@@ -20,6 +20,7 @@ import {
   type DependencyLeasePaths,
   findAcquiredDependency,
   releaseDependencySession,
+  releaseDependencyByPath,
   withDependencyLeaseSession,
 } from "./dependency-leases";
 
@@ -629,6 +630,76 @@ describe("temporary dependency leases", () => {
     await expect(readFile(acquired.skillMdPath, "utf-8")).resolves.toContain(
       "# Helper",
     );
+  });
+
+  it("rechecks exact path ownership after acquiring the session lock", async () => {
+    const acquired = await acquire("run-path-lock", true);
+    let entered!: () => void;
+    const started = new Promise<void>((resolveStarted) => {
+      entered = resolveStarted;
+    });
+    let proceed!: () => void;
+    const gate = new Promise<void>((resolveGate) => {
+      proceed = resolveGate;
+    });
+    const holding = withDependencyLeaseSession(
+      "run-path-lock",
+      async () => {
+        entered();
+        await gate;
+        const path = statePath("run-path-lock");
+        const state = JSON.parse(await readFile(path, "utf-8"));
+        for (const key of Object.keys(state.acquisitions))
+          state.acquisitions[key].owned = false;
+        await writeFile(path, JSON.stringify(state));
+      },
+      { rootDir },
+    );
+    await started;
+    const releasing = releaseDependencyByPath(acquired.path, { rootDir });
+    proceed();
+    await holding;
+    await expect(releasing).rejects.toThrow("single owned acquisition");
+    await expect(readFile(acquired.skillMdPath, "utf-8")).resolves.toContain(
+      "# Helper",
+    );
+  });
+
+  it("does not release a registered session for a different artifact path", async () => {
+    const acquired = await acquire("run-exact-path", true);
+    await expect(
+      releaseDependencyByPath(
+        join(dirname(acquired.path), "another-artifact"),
+        { rootDir },
+      ),
+    ).resolves.toBeNull();
+    await expect(readFile(acquired.skillMdPath, "utf-8")).resolves.toContain(
+      "# Helper",
+    );
+  });
+
+  it("uses guarded quarantine for path cleanup during an artifact rename race", async () => {
+    const acquired = await acquire("run-path-race", true);
+    let quarantined = "";
+    const released = await releaseDependencyByPath(acquired.path, {
+      rootDir,
+      renameArtifact: async (from, to) => {
+        await rename(from, `${from}.original`);
+        await mkdir(from);
+        await writeFile(join(from, "sentinel"), "preserve replacement");
+        await rename(from, to);
+        quarantined = to;
+      },
+    });
+    expect(released?.errors).toEqual([
+      expect.stringContaining("without an ownership marker"),
+    ]);
+    await expect(
+      readFile(join(quarantined, "sentinel"), "utf-8"),
+    ).resolves.toBe("preserve replacement");
+    await expect(
+      readFile(join(sourceDir, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# Helper");
   });
 
   it("rejects session identities that could escape the lease root", async () => {

--- a/src/dependency-leases.ts
+++ b/src/dependency-leases.ts
@@ -1014,6 +1014,65 @@ export async function releaseDependencySession(
   );
 }
 
+/**
+ * Release an exact registered artifact from a single-acquisition session.
+ * The path only locates state: persisted acquisition identity plus the existing
+ * guarded release authorize deletion. Markers alone are never authorization.
+ */
+export async function releaseDependencyByPath(
+  artifactPath: string,
+  paths: DependencyLeasePaths = {},
+): Promise<DependencyReleaseResult | null> {
+  if (!isAbsolute(artifactPath) || resolve(artifactPath) !== artifactPath) {
+    return null;
+  }
+  const root = await canonicalLeasesRoot(paths, false);
+  if (!root) return null;
+  const segments = relative(root, artifactPath).split(/[\\/]+/);
+  if (
+    segments.length !== 3 ||
+    segments[0] !== "artifacts" ||
+    !/^[a-f0-9]{64}$/.test(segments[1]) ||
+    join(root, ...segments) !== artifactPath
+  ) {
+    return null;
+  }
+
+  const statePath = join(root, "sessions", `${segments[1]}.json`);
+  return withSessionMutationLock(
+    root,
+    statePath,
+    async () => {
+      let raw: string;
+      try {
+        raw = await readFile(statePath, "utf-8");
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT")
+          return null;
+        throw err;
+      }
+      const session = parseSession(raw);
+      if (sessionPath(root, session.sessionId) !== statePath) {
+        throw new Error("Dependency lease filename does not match session.");
+      }
+      const acquisitions = Object.values(session.acquisitions);
+      if (!acquisitions.some((entry) => entry?.path === artifactPath))
+        return null;
+      if (
+        acquisitions.length !== 1 ||
+        acquisitions[0].owned !== true ||
+        !acquisitions[0].artifactId
+      ) {
+        throw new Error(
+          "Refusing path cleanup without a single owned acquisition.",
+        );
+      }
+      return releaseDependencySessionUnlocked(root, session.sessionId, paths);
+    },
+    paths,
+  );
+}
+
 async function releaseDependencySessionUnlocked(
   root: string,
   sessionId: string,

--- a/src/formatter-core.ts
+++ b/src/formatter-core.ts
@@ -7,6 +7,9 @@ import type {
   DependencyAcquireResult,
   DependencyReleaseResult,
   DependencyStaleCleanupResult,
+  GetBorrowCleanupResult,
+  GetPathResult,
+  GetResult,
   SkillInfo,
 } from "./utils/types";
 
@@ -796,6 +799,71 @@ export function formatTagUpdates(
       return `${verb} ${ansi.bold(result.name)}: ${tags}${suffix}`;
     })
     .join("\n");
+}
+
+// ─── Reference-tier output ─────────────────────────────────────────────────
+
+export function formatGetProvenance(result: GetResult | GetPathResult): string {
+  const lines = [
+    `  ${ansi.bold(result.name)}  ${ansi.dim(formatTokenCount(result.tokenCount))}`,
+    `  ${ansi.dim("source:")} ${result.source}${result.commit ? ` @ ${result.commit.slice(0, 7)}` : ""} ${ansi.dim(`(${result.tier})`)}`,
+  ];
+  if (result.security) {
+    const { risk, warnings, categories } = result.security;
+    const label =
+      risk === "high"
+        ? ansi.red("[!] High Risk")
+        : risk === "medium"
+          ? ansi.yellow("[~] Medium Risk")
+          : ansi.green("[ok] Safe");
+    const detail = warnings
+      ? ansi.dim(
+          ` (${warnings} warning${warnings === 1 ? "" : "s"}: ${categories.join(", ")})`,
+        )
+      : "";
+    lines.push(`  ${ansi.dim("security:")} ${label}${detail}`);
+  }
+  lines.push(
+    `  ${ansi.dim("residency:")} ${ansi.dim("path" in result ? "none — borrowed copy is not installed" : "none — nothing was installed")}`,
+  );
+  if ("path" in result) {
+    lines.push(
+      `  ${ansi.dim("borrow:")} full copy retained until explicit cleanup`,
+    );
+    // Do not interpolate a filesystem path into pasteable shell syntax. Config
+    // roots may contain quotes, $ or backticks; structured output provides argv.
+    lines.push(
+      `  ${ansi.dim("cleanup:")} run asm cleanup with the exact path printed to stdout.`,
+    );
+  }
+  return lines.join("\n") + "\n\n";
+}
+
+export function formatGetPath(result: GetPathResult): string {
+  return result.path + "\n";
+}
+
+export function formatGetBorrowCleanup(result: GetBorrowCleanupResult): string {
+  switch (result.status) {
+    case "removed":
+      return `Removed borrowed skill: ${result.path}`;
+    case "missing":
+      return `Borrow was already missing: ${result.path}`;
+    case "not-found":
+      return `No registered borrow at this exact path (nothing removed): ${result.path}`;
+    case "refused":
+      return `Borrow cleanup refused: ${result.errors.join("; ")}`;
+  }
+}
+
+export function formatCleanupHelp(): string {
+  return `${ansi.bold("Usage:")} asm cleanup <borrowed-path> [--json | --machine]
+
+Remove only an exact ASM-owned directory returned by asm get --path.
+Original local, installed and library skills are never removed.
+Unknown or already cleaned paths are safe no-ops. Ownership mismatches are
+refused; unsafe replacements are preserved (possibly in quarantine).
+Use the absolute path exactly as returned, not a symlink or parent/child path.`;
 }
 
 // ─── Temporary dependency leases ───────────────────────────────────────────

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -32,6 +32,11 @@ export {
   // ── Tag editing ──
   formatTagUpdates,
   type TagUpdateResult,
+  // ── Reference-tier borrows ──
+  formatGetProvenance,
+  formatGetPath,
+  formatGetBorrowCleanup,
+  formatCleanupHelp,
   // ── Temporary dependency leases ──
   formatDependencyDiscovery,
   formatDependencyAcquisition,

--- a/src/get-borrows.test.ts
+++ b/src/get-borrows.test.ts
@@ -1,0 +1,405 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+  chmod,
+  stat,
+} from "fs/promises";
+import { basename, dirname, join } from "path";
+import { tmpdir } from "os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { borrowGetSkill, cleanupGetBorrow } from "./get-borrows";
+import { getDependencyLeasesDir, getGetBorrowsDir } from "./config";
+import { cleanupStaleDependencySessions } from "./dependency-leases";
+import type { DependencyLeaseSession, GetResult, GetTier } from "./utils/types";
+
+let tempDir: string;
+let sourceDir: string;
+const body = "---\nname: helper\ndescription: Borrow fixture\n---\n# Helper\n";
+const binary = Buffer.from([0, 255, 128, 13, 10, 1]);
+const dirLinkType = process.platform === "win32" ? "junction" : "dir";
+
+beforeEach(async () => {
+  tempDir = await realpath(await mkdtemp(join(tmpdir(), "asm-get-borrows-")));
+  vi.stubEnv("ASM_CONFIG_DIR", join(tempDir, "config"));
+  sourceDir = join(tempDir, "source");
+  await mkdir(sourceDir);
+  await writeFile(join(sourceDir, "SKILL.md"), body);
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function result(tier: GetTier = "local"): GetResult {
+  return {
+    name: "helper",
+    description: "Borrow fixture",
+    dependencies: ["another-skill"],
+    tier,
+    source: sourceDir,
+    commit: null,
+    tokenCount: 10,
+    security: null,
+    content: body,
+  };
+}
+
+const borrow = (tier: GetTier = "local", dir = sourceDir) =>
+  borrowGetSkill("helper", dir, result(tier));
+const statePath = (path: string) =>
+  join(getGetBorrowsDir(), "sessions", `${basename(dirname(path))}.json`);
+async function ownerMarker(path: string): Promise<string> {
+  return join(
+    path,
+    (await readdir(path)).find((name) => name.startsWith(".asm-owner-"))!,
+  );
+}
+async function expectSource(): Promise<void> {
+  expect(await readFile(join(sourceDir, "SKILL.md"), "utf-8")).toBe(body);
+}
+async function quarantine(path: string): Promise<string> {
+  const name = (await readdir(dirname(path))).find((entry) =>
+    entry.includes(".quarantine-"),
+  );
+  expect(name).toBeDefined();
+  return join(dirname(path), name!);
+}
+
+describe("durable full-directory get borrows", () => {
+  it("resolves the isolated namespace lazily and is not swept by dependency cleanup", async () => {
+    expect(getGetBorrowsDir()).toBe(join(tempDir, "config", "get-borrows"));
+    expect(getDependencyLeasesDir()).not.toBe(getGetBorrowsDir());
+    const acquired = await borrow();
+    await cleanupStaleDependencySessions(new Date("2999-01-01"), false);
+    expect(await readFile(join(acquired.path, "SKILL.md"), "utf-8")).toBe(body);
+    vi.stubEnv("ASM_CONFIG_DIR", join(tempDir, "other-config"));
+    expect(getGetBorrowsDir()).toBe(
+      join(tempDir, "other-config", "get-borrows"),
+    );
+    expect((await cleanupGetBorrow(acquired.path)).status).toBe("not-found");
+    await expectSource();
+  });
+
+  it.each<GetTier>([
+    "local",
+    "installed",
+    "library",
+    "index",
+    "registry",
+    "remote",
+  ])(
+    "copies every supporting file for %s and preserves the original after cleanup",
+    async (tier) => {
+      for (const dir of [
+        "scripts",
+        "templates",
+        "assets",
+        "references",
+        ".git",
+        "nested/.git",
+      ]) {
+        await mkdir(join(sourceDir, dir), { recursive: true });
+      }
+      await writeFile(
+        join(sourceDir, "scripts", "run.sh"),
+        "#!/bin/sh\nprintf helper\n",
+      );
+      await chmod(join(sourceDir, "scripts", "run.sh"), 0o755);
+      await writeFile(join(sourceDir, "templates", "sample.txt"), "template");
+      await writeFile(join(sourceDir, "assets", "image.bin"), binary);
+      await writeFile(join(sourceDir, "references", "guide.md"), "reference");
+      await writeFile(join(sourceDir, ".hidden"), "hidden support file");
+      await writeFile(join(sourceDir, ".git", "config"), "git internals");
+      await writeFile(
+        join(sourceDir, "nested", ".git", "config"),
+        "nested git internals",
+      );
+      await writeFile(join(sourceDir, ".asm-owner-unrelated.json"), "{}");
+
+      const acquired = await borrow(tier);
+      expect(acquired.path).not.toBe(sourceDir);
+      expect(await realpath(acquired.path)).toBe(acquired.path);
+      expect(acquired).toMatchObject({
+        tier,
+        source: sourceDir,
+        dependencies: ["another-skill"],
+        cleanup: { command: "asm", args: ["cleanup", acquired.path] },
+      });
+      expect(acquired).not.toHaveProperty("content");
+      expect(acquired.files).toEqual([
+        ".hidden",
+        "SKILL.md",
+        "assets/image.bin",
+        "references/guide.md",
+        "scripts/run.sh",
+        "templates/sample.txt",
+      ]);
+      expect(
+        await readFile(join(acquired.path, "assets", "image.bin")),
+      ).toEqual(binary);
+      if (process.platform !== "win32") {
+        expect(
+          (await stat(join(acquired.path, "scripts", "run.sh"))).mode & 0o777,
+        ).toBe(0o755);
+      }
+      await expect(stat(join(acquired.path, ".git"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(
+        stat(join(acquired.path, "nested", ".git")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      await writeFile(join(acquired.path, "SKILL.md"), "caller edits its copy");
+      expect((await cleanupGetBorrow(acquired.path)).status).toBe("removed");
+      await expect(stat(acquired.path)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expectSource();
+      expect(await readFile(join(sourceDir, "assets", "image.bin"))).toEqual(
+        binary,
+      );
+    },
+  );
+
+  it("canonicalizes a legitimate installed root symlink before copying", async () => {
+    const installed = join(tempDir, "installed-link");
+    await symlink(sourceDir, installed, dirLinkType);
+    const acquired = await borrow("installed", installed);
+    expect((await cleanupGetBorrow(acquired.path)).status).toBe("removed");
+    expect(await realpath(installed)).toBe(sourceDir);
+    await expectSource();
+  });
+
+  it.each(["file", "dir"] as const)(
+    "rejects nested source %s symlinks",
+    async (type) => {
+      const external = join(tempDir, "external");
+      await mkdir(external);
+      await writeFile(join(external, "sentinel"), "keep");
+      await symlink(
+        type === "file" ? join(external, "sentinel") : external,
+        join(sourceDir, "link"),
+        type === "file" ? "file" : dirLinkType,
+      );
+      await expect(borrow()).rejects.toThrow("symbolic link");
+      await expectSource();
+      expect(await readFile(join(external, "sentinel"), "utf-8")).toBe("keep");
+    },
+  );
+
+  it("rejects a symlink SKILL.md rather than copying its target", async () => {
+    const target = join(tempDir, "outside.md");
+    await rename(join(sourceDir, "SKILL.md"), target);
+    await symlink(target, join(sourceDir, "SKILL.md"), "file");
+    await expect(borrow()).rejects.toThrow("SKILL.md must be a real file");
+    expect(await readFile(target, "utf-8")).toBe(body);
+  });
+
+  it("isolates concurrent borrows of the same reference and serializes repeated cleanup", async () => {
+    const [one, two] = await Promise.all([borrow(), borrow()]);
+    expect(one.path).not.toBe(two.path);
+    const releases = await Promise.all([
+      cleanupGetBorrow(one.path),
+      cleanupGetBorrow(one.path),
+    ]);
+    expect(releases.map((r) => r.status).sort()).toEqual([
+      "not-found",
+      "removed",
+    ]);
+    expect(await readFile(join(two.path, "SKILL.md"), "utf-8")).toBe(body);
+    expect((await cleanupGetBorrow(one.path)).status).toBe("not-found");
+    expect((await cleanupGetBorrow(two.path)).status).toBe("removed");
+    await expectSource();
+  });
+
+  it("treats an already missing artifact as safe registered cleanup", async () => {
+    const acquired = await borrow();
+    await rm(acquired.path, { recursive: true });
+    expect((await cleanupGetBorrow(acquired.path)).status).toBe("missing");
+    expect((await cleanupGetBorrow(acquired.path)).status).toBe("not-found");
+    await expectSource();
+  });
+});
+
+describe("exact registered borrow cleanup boundary", () => {
+  it("refuses original/outside, parent, child, relative and symlink alias paths", async () => {
+    const acquired = await borrow();
+    const alias = join(tempDir, "alias");
+    await symlink(acquired.path, alias, dirLinkType);
+    const rootAlias = join(tempDir, "root-alias");
+    await symlink(getGetBorrowsDir(), rootAlias, dirLinkType);
+    for (const path of [
+      sourceDir,
+      tempDir,
+      getGetBorrowsDir(),
+      dirname(acquired.path),
+      join(acquired.path, "SKILL.md"),
+      "relative-path",
+      `${acquired.path}/../${basename(acquired.path)}`,
+      alias,
+      join(
+        rootAlias,
+        "artifacts",
+        basename(dirname(acquired.path)),
+        basename(acquired.path),
+      ),
+    ]) {
+      expect(await cleanupGetBorrow(path)).toMatchObject({
+        status: "not-found",
+        errors: [],
+      });
+    }
+    expect(await readFile(join(acquired.path, "SKILL.md"), "utf-8")).toBe(body);
+    await expectSource();
+  });
+
+  it("never authorizes cleanup from a marker without registered state", async () => {
+    const acquired = await borrow();
+    await rm(statePath(acquired.path));
+    expect((await cleanupGetBorrow(acquired.path)).status).toBe("not-found");
+    expect(await readFile(join(acquired.path, "SKILL.md"), "utf-8")).toBe(body);
+    await expectSource();
+  });
+
+  it.each(["missing", "forged", "invalid", "symlink"] as const)(
+    "preserves quarantined content with a %s ownership marker",
+    async (kind) => {
+      const acquired = await borrow();
+      const marker = await ownerMarker(acquired.path);
+      if (kind === "missing") await rm(marker);
+      if (kind === "forged")
+        await writeFile(
+          marker,
+          JSON.stringify({
+            version: 1,
+            sessionId: "wrong",
+            artifactId: "wrong",
+            path: acquired.path,
+          }),
+        );
+      if (kind === "invalid") await writeFile(marker, "not JSON");
+      if (kind === "symlink") {
+        const outside = join(tempDir, "outside-marker.json");
+        await rename(marker, outside);
+        await symlink(outside, marker, "file");
+      }
+      const cleaned = await cleanupGetBorrow(acquired.path);
+      expect(cleaned.status).toBe("refused");
+      expect(cleaned.errors).toHaveLength(1);
+      expect(
+        await readFile(
+          join(await quarantine(acquired.path), "SKILL.md"),
+          "utf-8",
+        ),
+      ).toBe(body);
+      await expectSource();
+    },
+  );
+
+  it("preserves the target of a swapped artifact root symlink", async () => {
+    const acquired = await borrow();
+    await rename(acquired.path, `${acquired.path}.original`);
+    await symlink(sourceDir, acquired.path, dirLinkType);
+    const cleaned = await cleanupGetBorrow(acquired.path);
+    expect(cleaned.status).toBe("refused");
+    expect(cleaned.errors.join()).toContain("symbolic-link artifact");
+    await expectSource();
+    expect(
+      await readFile(join(`${acquired.path}.original`, "SKILL.md"), "utf-8"),
+    ).toBe(body);
+  });
+
+  it("quarantines an unowned replacement directory without deleting it", async () => {
+    const acquired = await borrow();
+    await rename(acquired.path, `${acquired.path}.original`);
+    await mkdir(acquired.path);
+    await writeFile(join(acquired.path, "sentinel"), "replacement");
+    expect((await cleanupGetBorrow(acquired.path)).status).toBe("refused");
+    expect(
+      await readFile(
+        join(await quarantine(acquired.path), "sentinel"),
+        "utf-8",
+      ),
+    ).toBe("replacement");
+    await expectSource();
+  });
+
+  it("preserves a nested link introduced after acquisition and its target", async () => {
+    const acquired = await borrow();
+    await symlink(sourceDir, join(acquired.path, "link"), dirLinkType);
+    expect((await cleanupGetBorrow(acquired.path)).status).toBe("refused");
+    expect(
+      await readFile(
+        join(await quarantine(acquired.path), "SKILL.md"),
+        "utf-8",
+      ),
+    ).toBe(body);
+    await expectSource();
+  });
+
+  it("does not follow a swapped borrow namespace into outside content", async () => {
+    const acquired = await borrow();
+    const root = getGetBorrowsDir();
+    await rename(root, `${root}.original`);
+    await symlink(sourceDir, root, dirLinkType);
+    expect((await cleanupGetBorrow(acquired.path)).status).toBe("not-found");
+    await expectSource();
+    expect(await readdir(sourceDir)).toEqual(["SKILL.md"]);
+  });
+
+  it.each(["sessions", "artifacts"])(
+    "refuses a swapped managed %s parent",
+    async (parent) => {
+      const acquired = await borrow();
+      const managed = join(getGetBorrowsDir(), parent);
+      await rename(managed, `${managed}.original`);
+      await symlink(sourceDir, managed, dirLinkType);
+      expect((await cleanupGetBorrow(acquired.path)).status).toBe("refused");
+      await expectSource();
+      expect(await readdir(sourceDir)).toEqual(["SKILL.md"]);
+    },
+  );
+
+  it.each(["session", "multiple", "unowned", "identity", "corrupt"])(
+    "refuses %s persisted state without deleting the copy",
+    async (kind) => {
+      const acquired = await borrow();
+      const file = statePath(acquired.path);
+      const state = JSON.parse(
+        await readFile(file, "utf-8"),
+      ) as DependencyLeaseSession;
+      const acquisition = Object.values(state.acquisitions)[0];
+      if (kind === "session") state.sessionId = "different-session";
+      if (kind === "multiple")
+        state.acquisitions.other = { ...acquisition, path: sourceDir };
+      if (kind === "unowned") acquisition.owned = false;
+      if (kind === "identity") acquisition.artifactId = null;
+      await writeFile(
+        file,
+        kind === "corrupt" ? "not JSON" : JSON.stringify(state),
+      );
+      expect((await cleanupGetBorrow(acquired.path)).status).toBe("refused");
+      expect(await readFile(join(acquired.path, "SKILL.md"), "utf-8")).toBe(
+        body,
+      );
+      await expectSource();
+    },
+  );
+
+  it("does not accept a state symlink as a registration", async () => {
+    const acquired = await borrow();
+    const file = statePath(acquired.path);
+    await rename(file, `${file}.original`);
+    await symlink(`${file}.original`, file, "file");
+    expect((await cleanupGetBorrow(acquired.path)).status).toBe("refused");
+    expect(await readFile(join(acquired.path, "SKILL.md"), "utf-8")).toBe(body);
+    await expectSource();
+  });
+});

--- a/src/get-borrows.ts
+++ b/src/get-borrows.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "crypto";
+import { readdir, realpath } from "fs/promises";
+import { join } from "path";
+import { getGetBorrowsDir } from "./config";
+import {
+  acquireDependency,
+  releaseDependencyByPath,
+  releaseDependencySession,
+} from "./dependency-leases";
+import type {
+  GetBorrowCleanupResult,
+  GetPathResult,
+  GetResult,
+} from "./utils/types";
+
+async function listBorrowFiles(dir: string, prefix = ""): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.name === ".git" || /^\.asm-owner-.*\.json$/.test(entry.name))
+      continue;
+    const relativePath = `${prefix}${entry.name}`;
+    if (entry.isDirectory()) {
+      files.push(
+        ...(await listBorrowFiles(join(dir, entry.name), `${relativePath}/`)),
+      );
+    } else if (entry.isFile()) {
+      files.push(relativePath);
+    } else {
+      throw new Error(`Borrow contains an unsupported entry: ${relativePath}`);
+    }
+  }
+  return files.sort();
+}
+
+/** Every source tier is copied; a caller must never release the original. */
+export async function borrowGetSkill(
+  request: string,
+  sourceDir: string,
+  result: GetResult,
+): Promise<GetPathResult> {
+  const sessionId = randomUUID();
+  const paths = { rootDir: getGetBorrowsDir() };
+  const acquired = await acquireDependency(
+    {
+      sessionId,
+      request,
+      name: result.name,
+      // Installed roots may legitimately be provider/library symlinks. Only the
+      // root is canonicalized; the lease copy policy still rejects nested links.
+      sourceDir: await realpath(sourceDir),
+      tier: result.tier,
+      source: result.source,
+      commit: result.commit,
+      temporary: true,
+    },
+    paths,
+  );
+
+  try {
+    return {
+      name: result.name,
+      description: result.description,
+      dependencies: result.dependencies,
+      tier: result.tier,
+      source: result.source,
+      commit: result.commit,
+      tokenCount: result.tokenCount,
+      security: result.security,
+      path: acquired.path,
+      files: await listBorrowFiles(acquired.path),
+      cleanup: { command: "asm", args: ["cleanup", acquired.path] },
+    };
+  } catch (err) {
+    // Roll back a failed materialization only. Successful borrows have no
+    // process-exit handler and remain until explicit `asm cleanup <path>`.
+    const released = await releaseDependencySession(sessionId, paths);
+    if (released.errors.length) {
+      throw new Error(
+        `Borrow failed; ownership-safe cleanup refused: ${released.errors.join("; ")}`,
+        { cause: err },
+      );
+    }
+    throw err;
+  }
+}
+
+export async function cleanupGetBorrow(
+  path: string,
+): Promise<GetBorrowCleanupResult> {
+  try {
+    const released = await releaseDependencyByPath(path, {
+      rootDir: getGetBorrowsDir(),
+    });
+    return {
+      path,
+      status: !released
+        ? "not-found"
+        : released.errors.length
+          ? "refused"
+          : released.removed.length
+            ? "removed"
+            : "missing",
+      errors: released?.errors ?? [],
+    };
+  } catch (err) {
+    return {
+      path,
+      status: "refused",
+      errors: [err instanceof Error ? err.message : String(err)],
+    };
+  }
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -843,7 +843,7 @@ export type GetTier =
 /**
  * Security verdict attached to a remotely fetched body. This is the same scan
  * `asm install` runs before writing anything (`scanForWarnings`), reported
- * rather than enforced — `asm get` only prints text, it installs nothing.
+ * rather than enforced — `asm get` never installs or executes the skill.
  */
 export interface GetSecurityVerdict {
   /** `high` | `medium` | `safe` — same mapping the install preview uses. */
@@ -877,6 +877,22 @@ export interface GetResult {
   security: GetSecurityVerdict | null;
   /** The exact SKILL.md text. */
   content: string;
+}
+
+/** Full-directory reference; the default GetResult/body contract is unchanged. */
+export interface GetPathResult extends Omit<GetResult, "content"> {
+  /** Absolute, canonical ASM-owned copy, usable after `get` exits. */
+  path: string;
+  /** Sorted relative file paths using `/`, excluding ownership metadata/.git. */
+  files: string[];
+  /** Explicit cleanup instruction as argv (no shell interpolation required). */
+  cleanup: { command: "asm"; args: ["cleanup", string] };
+}
+
+export interface GetBorrowCleanupResult {
+  path: string;
+  status: "removed" | "missing" | "not-found" | "refused";
+  errors: string[];
 }
 
 // ─── Temporary Dependency Lease Types (issue #621) ───────────────────────


### PR DESCRIPTION
Closes #654

## Summary

Adds persistent full-directory borrowing to `asm get --path` so ephemeral callers receive supporting scripts, templates, references, and binary assets, plus an explicit `asm cleanup <borrowed-path>` command that only removes ASM-owned borrows.

## Approach

Thin borrowed-copy facade over the existing dependency-lease lifecycle (separate `get-borrows` namespace); copy every source tier and require exact registered-path cleanup.

## Decision Record

- **Root cause:** `asm get` resolved complete skill directories but only emitted `SKILL.md`, then deleted the remote staging clone, leaving callers without referenced supporting files.
- **Options considered:** Option 1 — Minimal fix: dependency-session borrowing; Option 2 — Balanced approach: dedicated get-borrows facade; Option 3 — Comprehensive refactor: shared owned-copy lifecycle
- **Options rejected:** Option 1 — Session-token cleanup exposes dependency internals and is awkward for an API whose primary result is a filesystem path; Option 3 — A shared lifecycle redesign is unnecessary for #654 because the existing lease engine already supplies the required capabilities
- **Selected option:** Option 2 — Balanced approach: dedicated get-borrows facade
- **Residual risk:** Windows runtime was not exercised; hard interruptions may leave quarantined artifacts for explicit inspection rather than silent removal.
- **Effort profile:** omitted
- **Design-confirm:** auto-selected Option 2 (complexity: XL)

Analyzed at: `feat/654-feature-asm-get-clone-full-skill @ 1fc84c0` (2026-09-09)

## Changes

| File | Change |
|------|--------|
| `README.md` | Documents persistent borrowing, exact-path cleanup, and permanent install workflow |
| `src/cli.ts` | Command-aware `get --path` parsing and `cleanup` routing/help |
| `src/cli.test.ts` | CLI lifecycle regression coverage, including dry-run rejection |
| `src/commands/cleanup.ts` | Exact-path cleanup handler; rejects unsupported `--dry-run` |
| `src/commands/get.ts` | Persistent full-directory borrow branch; preserves default output |
| `src/commands/get.test.ts` | Source staging lifecycle coverage |
| `src/config.ts` | Dedicated ASM-owned borrow root helper |
| `src/dependency-leases.ts` | Exact registered-path lease release |
| `src/dependency-leases.test.ts` | Path-release safety coverage |
| `src/formatter-core.ts` | Borrow/cleanup formatting |
| `src/formatter.ts` | Borrow/cleanup formatter surface |
| `src/get-borrows.ts` | Thin lease facade for borrow/copy/lookup/release |
| `src/get-borrows.test.ts` | Ownership, preservation, symlink, and concurrency coverage |
| `src/utils/types.ts` | Borrow/cleanup result contracts |

## Test Results

- Unit tests: 2793 passed
- Integration tests: included in unit suite where applicable
- E2e tests: push hooks passed
- Build: passed
- QA cycles: 2

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Borrow full skill directory with supporting files | pass | `src/get-borrows.test.ts` binary/executable preservation; CLI test reads all files after process exit |
| Provide explicit cleanup afterward | pass | `asm cleanup <borrowed-path>`; second-process removal test |
| Keep default `asm get` behavior unchanged | pass | default-output regression coverage |
| Use `asm install` for permanent retention | pass | README documents install workflow; no borrow retention operation |

<!-- gitissue:qa v1 head=1fc84c0d1e463aee5d651952ff2007d3846a193f profile=full cycles=2 review=clean tests=2793@1fc84c0d1e463aee5d651952ff2007d3846a193f ui=none:clean -->
