### PR TITLE
docs(env): refresh recorded environment facts (#657)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ M3's coverage target is bound to **`max(60%, baseline + 20pp)`**:
 - Lines: `max(60%, 80.61%)` = **80.61%**
 - Branches: `max(60%, 102.52%)` = **100%** (formula saturates at 100)
 
-Node and npm must satisfy `package.json` `engines` — node `">=18 <23"`, npm
+Node and npm must satisfy `package.json` `engines` — node `">=22 <27"`, npm
 `">=9"`. Mind the upper bound: `CONTRIBUTING.md` and `docs/DEVELOPMENT.md` still
 state a floor with no ceiling, and `engines` is the one that is correct.
 

--- a/docs/AGENT_ENVIRONMENT.md
+++ b/docs/AGENT_ENVIRONMENT.md
@@ -25,11 +25,10 @@ That is the authoritative range: Node **>= 22 and < 27**, npm **>= 9**. Note the
 
 - CI (`.github/workflows/ci.yml`) runs unit tests and both e2e jobs on a Node
   `22, 24` matrix; the `build` job pins Node `22`.
-- `docs/DEVELOPMENT.md` says "Node.js >= 18.0.0" with no upper bound. It is
-  out of step with `engines`; treat `engines` as correct.
-- **The measurements below were taken on Node `v26.7.0` / npm `11.19.0`** — above
-  the supported ceiling. They all passed, but any disagreement between these
-  numbers and a supported-Node run should be attributed to that first.
+- `docs/DEVELOPMENT.md` and `CONTRIBUTING.md` say "Node.js >= 22" with no
+  upper bound. They are out of step with `engines`; treat `engines` as correct.
+- **The measurements below were taken on Node `v26.7.0` / npm `11.19.0`** —
+  inside the declared range.
 
 ## Install
 


### PR DESCRIPTION
Closes #657

## Summary

Sprint Pre plan task **Pre.1**: refresh the recorded environment facts that drifted from `package.json` and `.pre-commit-config.yaml`. `CLAUDE.md` recorded node `">=18 <23"`; `engines` now declares `">=22 <27"` / npm `">=9"`. `docs/AGENT_ENVIRONMENT.md` quoted `engines` correctly but carried two stale claims — that `docs/DEVELOPMENT.md` says "Node.js >= 18.0.0" (it now says ">= 22", as does `CONTRIBUTING.md`) and that the recorded Node `v26.7.0` measurement sat "above the supported ceiling" (26.7.0 is inside `>=22 <27`).

**Verified fact list** (each checked against `package.json` `engines`/scripts and `.pre-commit-config.yaml` on this branch):

- Toolchain bounds: node `>=22 <27`, npm `>=9` — `package.json` `engines` (authoritative; `CONTRIBUTING.md`/`docs/DEVELOPMENT.md` state a `>= 22` floor with no ceiling)
- Install: `npm install` (`postinstall` → `scripts/postinstall.cjs`, no-ops when `CI` or `ASM_SKIP_POSTINSTALL` set), then `npm run build` (`tsx scripts/build.ts` → `dist/`, gitignored)
- Test command of record: `CI=true npm test` (`vitest run src/`); coverage: `npm run test:coverage` (`vitest run --coverage src/`, v8, no fail gate)
- Hook stages: `.pre-commit-config.yaml` sets neither `default_install_hook_types` nor `default_stages`, so the two-stage install is required: `pre-commit install --hook-type pre-commit --hook-type pre-push`
- Dev machine: node `v26.7.0`, npm `11.19.0` — both satisfy the documented bounds

## Approach

Correct drifted environment facts in place — direct minimal plan (light profile): fix the engines quote in `CLAUDE.md` and the two stale characterizations in `docs/AGENT_ENVIRONMENT.md`; leave the already-accurate command docs untouched.

## Decision Record

- **Root cause:** environment notes recorded node `">=18 <23"` (and stale derived claims) while `package.json` `engines` moved to `">=22 <27"`; the recorded facts were never re-verified.
- **Options considered:** Option 1 — Correct drifted environment facts in place
- **Options rejected:** n/a — trivial change, direct plan (light profile)
- **Selected option:** Option 1 — Correct drifted environment facts in place
- **Residual risk:** none identified
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/657-pre-1-refresh-recorded-environment @ cb65bfc` (2026-09-12)

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | engines note `node ">=18 <23"` → `">=22 <27"` (npm `">=9"` unchanged) |
| `docs/AGENT_ENVIRONMENT.md` | DEVELOPMENT.md quote `>= 18.0.0` → `>= 22` (also names CONTRIBUTING.md); v26.7.0 measurement recharacterized as inside the declared range |

## Test Results

- Unit tests: 2793 passed (89 files, `CI=true npm test`, run twice — QA cycle and final verify)
- Integration tests: n/a (unit suite is the command of record)
- E2e tests: passed (pre-push `e2e-node` hook)
- Build: passed (`npm run build` → 11 outputs; also pre-push `build` hook)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Written fact list names toolchain bounds, install/build/test commands, and hook stages — verified against `package.json` and `.pre-commit-config.yaml` | pass | Fact list above; `CLAUDE.md:43` now reads `">=22 <27"`; `docs/AGENT_ENVIRONMENT.md:14-31`; bounds match `package.json` `engines`, hook stages match `.pre-commit-config.yaml` (no `default_install_hook_types`/`default_stages`) |
| `node -v` and `npm -v` on the dev machine satisfy the documented bounds | pass | `node -v` → `v26.7.0` (∈ `>=22 <27`); `npm -v` → `11.19.0` (∈ `>=9`) |

<!-- gitissue:qa v1 head=083db6e8491b906dec3c66db1dbd2dd00395a36f profile=light cycles=1 review=clean ui=none -->