### PR TITLE
docs(agent-docs): correct stale cli.ts and engines claims (#658)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,11 +48,12 @@ description: Reviews changes to the CLI command surface and its output
 tools: Read, Grep, Glob
 ---
 
-You own `bin/agent-skill-manager.ts` and `src/cli.ts` — roughly thirty `cmd*`
-handlers. Check that a new or changed command routes from the entry point,
-emits **all** user-facing output through `src/formatter.ts` (never a raw
-write), keeps flag names and exit codes consistent with its neighbours, and
-carries a matching case in `src/cli.test.ts`.
+You own `bin/agent-skill-manager.ts`, `src/cli.ts` (the argv dispatcher), and
+`src/commands/` — one `cmd*` handler module per command. Check that a new or
+changed command routes from the entry point through the dispatcher, emits
+**all** user-facing output through `src/formatter.ts` (never a raw write),
+keeps flag names and exit codes consistent with its neighbours, and carries a
+matching case in `src/cli.test.ts` or its own `src/commands/*.test.ts`.
 Boundary: do not touch `src/views/` or `src/index.tsx` — argv goes to the CLI,
 no argv goes to the TUI. Report, do not refactor.
 Output: blocking issues first, each with `path:line` and a concrete fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,13 +41,13 @@ M3's coverage target is bound to **`max(60%, baseline + 20pp)`**:
 - Branches: `max(60%, 102.52%)` = **100%** (formula saturates at 100)
 
 Node and npm must satisfy `package.json` `engines` — node `">=22 <27"`, npm
-`">=9"`. Mind the upper bound: `CONTRIBUTING.md` and `docs/DEVELOPMENT.md` still
-state a floor with no ceiling, and `engines` is the one that is correct.
+`">=9"`.
 
 ## Architecture map
 
 - `bin/agent-skill-manager.ts` — entry point: args go to `src/cli.ts`, none to the TUI.
-- `src/cli.ts` — ~30 `cmd*` handlers, all output through `src/formatter.ts`.
+- `src/cli.ts` — argv dispatcher routing to the `cmd*` handler modules in
+  `src/commands/`; all output through `src/formatter.ts`.
 - `src/index.tsx` + `src/views/` — the ink/React TUI.
 - `src/*.ts` — one module per domain (scanner, installer, auditor, skill-index, …),
   each with its `*.test.ts` beside it.


### PR DESCRIPTION
Closes #658
Closes #659

## Summary

Sprint Pre plan tasks **Pre.2** and **Pre.3** — batched because they share one
root cause: after the `src/commands/` split, `CLAUDE.md` and `AGENTS.md` still
described `src/cli.ts` as the home of "~30 / roughly thirty `cmd*` handlers",
and `CLAUDE.md` still warned that `CONTRIBUTING.md` / `docs/DEVELOPMENT.md`
"state a floor with no ceiling" against `engines`. PR #682 (#657) had already
corrected the quoted `engines` range to `">=22 <27"`; this PR removes the two
remaining stale `CLAUDE.md` claims and repoints `AGENTS.md`'s
`cli-surface-reviewer` at `src/commands/`, naming `cli.ts`'s dispatcher role.

## Approach

Minimal targeted doc edits: delete the stale no-ceiling sentence, rewrite the
`cli.ts` architecture-map bullet as an argv dispatcher over `src/commands/`,
and update the `cli-surface-reviewer` definition to own `bin/`,
`src/cli.ts` (dispatcher) and `src/commands/` (one `cmd*` module per command).

## Decision Record

- **Root cause:** the `commands/` split moved every `cmd*` handler out of
  `src/cli.ts` (now a 696-line argv dispatcher that imports them), and the
  Pre.1 engines refresh aligned `CONTRIBUTING.md`/`docs/DEVELOPMENT.md` on the
  `>= 22` floor — but both agent-facing docs kept the pre-split wording.
- **Options considered:** Option 1 — minimal targeted edits; Option 2 — full
  `/agent-config update` regeneration of both files; Option 3 — targeted edits
  plus checking off `MODERNIZATION_PLAN.md` task checkboxes.
- **Options rejected:** Option 2 — wider churn than the issues scope; the
  issues name specific stale claims, and regeneration was not required to
  satisfy the acceptance criteria. Option 3 — the plan file carries no `- [x]`
  marks anywhere and merged sibling Pre.1 (#682) left its boxes unchecked, so
  the file's own convention is not to mark completed tasks in place.
- **Selected option:** Option 1 — minimal targeted edits.
- **Residual risk:** none identified — docs-only diff, every rewritten claim
  verified against `package.json` and the `src/` tree.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/658-pre-2-3-update-agent-docs @ 3b5b7e5` (2026-09-12)

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | Removed stale "floor with no ceiling" claim about CONTRIBUTING/DEVELOPMENT; `cli.ts` bullet now reads "argv dispatcher routing to the `cmd*` handler modules in `src/commands/`" |
| `AGENTS.md` | `cli-surface-reviewer` now owns `bin/agent-skill-manager.ts`, `src/cli.ts` (the argv dispatcher) and `src/commands/`; test-pointer updated to `src/cli.test.ts` or the handler's own `src/commands/*.test.ts` |

## Test Results

- Unit tests: 2793 passed (`CI=true npm test`, 89 files)
- Integration tests: skipped (none separate)
- E2e tests: passed via pre-push hook (`e2e-node`); not part of `npm test`
- Build: passed (pre-push `build` hook)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| #658: `CLAUDE.md` states `engines` `>=22 <27` and describes `cli.ts` as a dispatcher over `src/commands/` | pass | `CLAUDE.md:43` (`node ">=22 <27"`, npm `">=9"`); `CLAUDE.md:49-50` |
| #658: No claim in `CLAUDE.md` contradicts `package.json` or the `src/` layout | pass | `engines` quote matches `package.json:69-71`; every documented npm command verified against `scripts`; `src/cli.ts` imports all `cmd*` from `./commands/` (0 local definitions) |
| #658: `CI=true npm test` passes at 2793/2793 (baseline-green holds) | pass | 2793/2793 @ `3b5b7e5`, twice (QA cycle + final run) |
| #659: `AGENTS.md`'s cli-surface-reviewer owns `src/commands/` and names cli.ts's dispatcher role | pass | `AGENTS.md:51-53` |
| #659: `CI=true npm test` passes at 2793/2793 (baseline-green holds) | pass | 2793/2793 @ `3b5b7e5` |

<!-- gitissue:qa v1 head=3b5b7e56bdc72f48aa6046ebef0fc698b871fa93 profile=light cycles=1 review=clean tests=2793@3b5b7e56bdc72f48aa6046ebef0fc698b871fa93 ui=none -->
