### PR TITLE
test(e2e): run orphaned e2e files in e2e-node CI leg (#660)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Node.js E2E tests
-        run: npx vitest run tests/e2e/node-e2e.test.ts tests/e2e/build-verification.test.ts
+        # registry-e2e resolves via an injected ASM_REGISTRY_CACHE (no network
+        # needed for resolution); the tui-* files render via ink-testing-library
+        # on virtual stdin/stdout, so no TTY is required (#660).
+        run: npx vitest run tests/e2e/node-e2e.test.ts tests/e2e/build-verification.test.ts tests/e2e/registry-e2e.test.ts tests/e2e/tui-smoke.test.tsx tests/e2e/tui-integration.test.tsx
 
   e2e-npm-install:
     needs: build


### PR DESCRIPTION
Closes #660

## Summary

Three e2e files under `tests/e2e/` were orphaned — no CI leg referenced them, so they only ran via local `npm run test:e2e`. This adds all three to the existing `e2e-node` leg, which already provides everything they need: the `dist/` artifact for `registry-e2e`, installed devDependencies (ink-testing-library, React) for the `tui-*` files, git, and the Node 22/24 matrix.

## Approach

Option 1 — add `registry-e2e.test.ts`, `tui-smoke.test.tsx`, and `tui-integration.test.tsx` to the `e2e-node` leg's single `vitest run` line. `registry-e2e` resolves the registry through an injected `ASM_REGISTRY_CACHE` file (non-network for resolution); both `tui-*` files render through ink-testing-library on virtual stdin/stdout, so no TTY is required and they run headless in CI — no local-only marker needed.

## Decision Record

- **Root cause:** the `e2e-node` leg ran only `node-e2e` + `build-verification` and `e2e-npm-install` ran only `npm-install-e2e`; the other three files in `tests/e2e/` were never wired into a leg.
- **Options considered:** Option 1 — all three join `e2e-node`; Option 2 — `registry-e2e` → `e2e-node`, `tui-*` → `unit-tests` leg; Option 3 — `registry-e2e` → `e2e-node`, `tui-*` carry a local-only marker.
- **Options rejected:** Option 2 — splits e2e files across two legs for no gain (same Node matrix, same runner); Option 3 — forfeits already-green headless coverage; the assumed TTY requirement does not apply since both files deliberately avoid a PTY via ink-testing-library.
- **Selected option:** Option 1 — all three join `e2e-node`.
- **Residual risk:** `registry-e2e`'s install cases exercise real github.com egress (CI runners have outbound network); the assertions target resolution output rather than install success, so a degraded-network flake would be limited to those cases.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle.

Analyzed at: `test/660-run-or-mark-orphaned-e2e-files @ 9997274` (2026-09-12)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | `e2e-node` leg now runs `registry-e2e.test.ts`, `tui-smoke.test.tsx`, and `tui-integration.test.tsx` alongside the existing files; comment documents the non-network / no-TTY rationale |

## Test Results

- Unit tests: 2793 passed (`CI=true npm test`, plus pre-push hook at HEAD)
- Integration tests: skipped — no dedicated integration suite
- E2e tests: 35 passed for the newly-added files (registry-e2e 22/22, tui-smoke 5/5, tui-integration 8/8 under `CI=true`); `node-e2e` green via pre-push hook. Local `build-verification` shows 2 pre-existing failures reading stale generated `website/` output — the leg regenerates the catalog via `npm run build:website` before tests, and that file is untouched here.
- Build: passed (pre-push hook)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `registry-e2e.test.ts` runs in the `e2e-node` CI leg on push/PR | pass | `.github/workflows/ci.yml:176` — leg triggers on push/PR to main |
| Each `tui-*` e2e file either runs in CI or carries a local-only marker | pass | Both run in `e2e-node` (`ci.yml:176`); verified headless: 13/13 pass under `CI=true` — no TTY needed, so no marker required |
| `CI=true npm test` passes at 2793/2793 | pass | `vitest run src/`: 89 files, 2793/2793 locally and via pre-push hook at HEAD |

<!-- gitissue:qa v1 head=d36fd5a79d6e6363cfc9da0a0a5c386725c1cfd9 profile=light cycles=1 review=clean tests=2793@d36fd5a79d6e6363cfc9da0a0a5c386725c1cfd9 ui=none:clean -->