### PR TITLE
docs(architecture): align ARCHITECTURE.md with the commands/ layout (#681)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing! This guide will help you get started.
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) >= 22 (with npm >= 9)
+- [Node.js](https://nodejs.org/) >= 22 and < 27 (with npm >= 9)
 - [Git](https://git-scm.com/)
 
 ### Development Setup

--- a/docs/AGENT_ENVIRONMENT.md
+++ b/docs/AGENT_ENVIRONMENT.md
@@ -25,8 +25,8 @@ That is the authoritative range: Node **>= 22 and < 27**, npm **>= 9**. Note the
 
 - CI (`.github/workflows/ci.yml`) runs unit tests and both e2e jobs on a Node
   `22, 24` matrix; the `build` job pins Node `22`.
-- `docs/DEVELOPMENT.md` and `CONTRIBUTING.md` say "Node.js >= 22" with no
-  upper bound. They are out of step with `engines`; treat `engines` as correct.
+- `docs/DEVELOPMENT.md` and `CONTRIBUTING.md` state the same bounded range.
+  If they ever diverge from `engines`, treat `engines` as correct.
 - **The measurements below were taken on Node `v26.7.0` / npm `11.19.0`** —
   inside the declared range.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ agent-skill-manager is a dual-interface application (interactive TUI + non-inter
 graph TD
     A[bin/agent-skill-manager.ts] --> B{CLI mode?}
     B -->|Yes| C[cli.ts - Command Dispatcher]
-    B -->|No| D[index.ts - TUI Bootstrap]
+    B -->|No| D[index.tsx - TUI Bootstrap]
     C --> E[Core Modules]
     D --> E
     E --> F[config.ts]
@@ -24,17 +24,28 @@ graph TD
 **`bin/agent-skill-manager.ts`** — Determines the execution mode:
 
 - If CLI arguments are present (commands or flags), delegates to `cli.ts`
-- If no arguments, launches the interactive TUI via `index.ts`
+- If no arguments, launches the interactive TUI via `index.tsx`
 
 ## CLI Mode (`src/cli.ts`)
 
-Parses arguments and dispatches to command handlers:
+`cli.ts` is a thin argv dispatcher — parsing and routing only, no command
+logic:
 
-Dispatches to ~47 command handlers (`cmd*` functions) covering discovery
-(`list`, `search`, `inspect`, `tag`), lifecycle (`install`, `uninstall`,
-`disable`/`enable`, `update`, `outdated`), authoring (`init`, `link`, `eval`,
-`publish`), and organization (`audit`, `bundle`, `deps`, `library`, `stats`,
-`doctor`, `config`, `import`/`export`, `index`). See
+- `parseArgs()` (`src/cli.ts:109`) normalizes argv into a `ParsedArgs` struct
+  (command, subcommand, positionals, flags).
+- `isCLIMode()` (`src/cli.ts:647`) decides whether the invocation runs the
+  CLI or falls through to the TUI.
+- `runCLI()` (`src/cli.ts:482`) switches on the parsed command and delegates
+  to the matching `cmd*` handler.
+
+The handlers live one-per-command under `src/commands/` — `cmdList` in
+`commands/list.ts`, `cmdInstall` in `commands/install.ts`, and so on — with
+shared helpers in `src/commands/shared.ts`. They cover discovery (`list`,
+`search`, `inspect`, `tag`, `get`, `cleanup`), lifecycle (`install`,
+`uninstall`, `disable`/`enable`, `activate`/`deactivate`, `update`,
+`outdated`), authoring (`init`, `link`, `eval`/`eval-providers`, `publish`),
+and organization (`audit`, `bundle`, `deps`, `library`, `stats`, `doctor`,
+`config`, `import`/`export`, `index`). See
 [README § CLI Commands](../README.md#cli-commands) for the full, current
 reference with flags and examples.
 
@@ -111,14 +122,16 @@ Each view is an ink/React component:
 
 `asm eval` evaluates a skill and produces a scored report. Internally it is a **provider framework** — individual evaluators plug into a common `EvalResult` shape through the `EvalProvider` contract, so static linters, runtime LLM-judge tools, and future domain-specific evaluators all flow through the same CLI surface.
 
-| File                         | Responsibility                                                           |
-| ---------------------------- | ------------------------------------------------------------------------ |
-| `eval/types.ts`              | Contract types: `EvalProvider`, `EvalResult`, `SkillContext`, `EvalOpts` |
-| `eval/registry.ts`           | `register()`, `resolve(id, semverRange)`, `list()`; minimal semver impl  |
-| `eval/runner.ts`             | Timing, error normalization, timeout enforcement around `provider.run()` |
-| `eval/config.ts`             | Reads the `eval` section of `~/.asm/config.yml` with typed defaults      |
-| `eval/providers/index.ts`    | Calls `register()` for every built-in provider                           |
-| `eval/providers/quality/v1/` | Static SKILL.md linter — adapter over `src/evaluator.ts`                 |
+| File                                     | Responsibility                                                             |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| `eval/types.ts`                          | Contract types: `EvalProvider`, `EvalResult`, `SkillContext`, `EvalOpts`   |
+| `eval/registry.ts`                       | `register()`, `resolve(id, semverRange)`, `list()`; minimal semver impl    |
+| `eval/runner.ts`                         | Timing, error normalization, timeout enforcement around `provider.run()`   |
+| `eval/summary.ts`                        | Score→grade mapping and per-provider report shaping                        |
+| `eval/builtins.ts`                       | `ensureEvalBuiltins()` + registry accessors consumed by `commands/eval.ts` |
+| `eval/providers/index.ts`                | `registerBuiltins()` calls `register()` for every built-in provider        |
+| `eval/providers/quality/v1/`             | Static SKILL.md linter — adapter over `src/evaluator.ts`                   |
+| `eval/providers/skill-best-practice/v1/` | Frontmatter best-practice checks (allowed properties, effort values, …)    |
 
 ### Provider contract
 
@@ -142,7 +155,7 @@ See [`docs/eval-providers.md`](./eval-providers.md) for the user-facing workflow
 | File             | Purpose                                                                |
 | ---------------- | ---------------------------------------------------------------------- |
 | `types.ts`       | Shared TypeScript interfaces (`SkillInfo`, `AppConfig`, `Scope`, etc.) |
-| `colors.ts`      | Neon green color palette for the TUI                                   |
+| `colors.ts`      | `theme` color-token palette for the TUI                                |
 | `version.ts`     | Version constant used across CLI and TUI                               |
 | `frontmatter.ts` | YAML-like frontmatter parser for SKILL.md files                        |
 
@@ -165,7 +178,7 @@ flowchart LR
 
 ## State Management
 
-Application state is held in module-level variables in `src/index.ts`:
+Application state is held in module-level variables in `src/index.tsx`:
 
 - `allSkills` / `filteredSkills` — current skill data
 - `currentScope` / `currentSort` / `searchQuery` — filter state

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,13 +178,16 @@ flowchart LR
 
 ## State Management
 
-Application state is held in module-level variables in `src/index.tsx`:
+Application state lives in React hooks inside the root component in
+`src/index.tsx` (`useState`, with `filteredSkills` derived via `useMemo`):
 
 - `allSkills` / `filteredSkills` — current skill data
-- `currentScope` / `currentSort` / `searchQuery` — filter state
-- `viewState` — which overlay is active (`dashboard`, `detail`, `confirm`, `config`, `help`, `duplicates`)
+- `scope` / `sort` / `searchQuery` — filter state
+- `view` — the active overlay (`ViewState`: `dashboard`, `detail`, `confirm`,
+  `help`, `config`, `audit`; the `audit` state renders `duplicates.tsx`)
 
-State transitions are driven by keyboard events and propagated to views via update functions.
+State transitions are driven by keyboard events (`useInput`) and propagated to
+views via props and callback setters.
 
 ## Duplicate Detection (`src/auditor.ts`)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) >= 22 (with npm >= 9) (`package.json:engines`)
+- [Node.js](https://nodejs.org/) >= 22 and < 27 (with npm >= 9) (`package.json:engines`)
 - [Git](https://git-scm.com/)
 - [pre-commit](https://pre-commit.com/) (optional, for git hooks)
 
@@ -44,8 +44,8 @@ traps (scripts that rewrite tracked files; the unit suite writing to your real
 `~/.config/agent-skill-manager/`) are recorded in
 [AGENT_ENVIRONMENT.md](AGENT_ENVIRONMENT.md).
 
-Test files are co-located with source files using the `*.test.ts` convention.
-50 `*.test.ts` files live under `src/`, one per module — e.g. `cli.test.ts`,
+Test files are co-located with source files using the `*.test.ts` convention
+(`*.test.tsx` for views), one per module — e.g. `cli.test.ts`,
 `scanner.test.ts`, `installer.test.ts`, `eval/*.test.ts`. Run `npm test` for
 the full, current list.
 

--- a/docs/eval-providers.md
+++ b/docs/eval-providers.md
@@ -5,7 +5,7 @@
 This doc covers:
 
 - How providers work and why they're versioned on two axes
-- How to pin a provider version
+- How `asm eval` selects providers
 - A checklist for adding a new provider
 
 ## How providers work
@@ -66,22 +66,16 @@ asm eval-providers list
 
 Shows id, version, schemaVersion, description, and any `requires` tags. `--json` emits a machine-readable array of the same records.
 
-## Pinning a provider version
+## Provider selection
 
-Via `~/.asm/config.yml`:
+`asm eval` is zero-config: it runs every registered provider whose
+`applicable()` check passes (`src/commands/eval.ts`). No config file or CLI
+flag selects or pins a subset.
 
-```yaml
-eval:
-  defaults:
-    threshold: 70
-    timeoutMs: 60000
-  providers:
-    quality:
-      version: "^1.0.0" # pin the range
-      threshold: 80
-```
-
-The `version` key is a semver range that future CLI upgrades honor. Today `asm eval` picks the highest version in range; explicit pinning is what keeps CI stable when a new provider version ships.
+Version _resolution_ still lives in the registry — `resolve(id, semverRange)`
+returns the highest registered version matching a range
+(`src/eval/registry.ts:200`) — so multiple versions of a provider can coexist
+and programmatic consumers can ask for a range.
 
 ### Output modes
 


### PR DESCRIPTION
Closes #681

## Summary

`docs/ARCHITECTURE.md` still described `src/cli.ts` as containing "~47 command handlers (`cmd*` functions)". Since the command-handler extraction, `cli.ts` is a thin argv dispatcher (`parseArgs` / `isCLIMode` / `runCLI`) routing to one `cmd*` handler module per command under `src/commands/`. This PR rewrites the CLI-mode section accordingly, then applies a doc-manager reconcile pass over the rest of `docs/` (plus the repo-root `CONTRIBUTING.md` it cross-references), clearing every contradiction found against the current code.

## Approach

Balanced — fix the flagged line, then run the drift pass the issue asks for instead of stopping at the single line.

## Decision Record

- **Root cause:** docs drifted behind two refactors: the cli.ts → `src/commands/` handler split (stale `~47 cmd*` claim) and the eval zero-config rework in #182 (stale `eval/config.ts` row and `~/.asm/config.yml` pinning section). Smaller stale claims accumulated alongside: `index.ts` vs the actual `index.tsx`, a "50 test files" count now at 73, the `colors.ts` "Neon green" description vs the current `theme` token palette, and the Node `>= 22` prerequisite missing the `< 27` upper bound that `package.json` `engines` declares (a divergence `AGENT_ENVIRONMENT.md` itself flagged).
- **Options considered:** Option 1 — fix only `ARCHITECTURE.md:33`; Option 2 — fix the flagged section plus a reconcile pass over `docs/`; Option 3 — full doc regeneration with new citations throughout.
- **Options rejected:** Option 1 — fails the "drift pass reports zero unresolved contradictions" criterion; Option 3 — churns stable, accurate docs for no correctness gain.
- **Selected option:** Option 2 — matches the issue scope exactly.
- **Residual risk:** point-in-time records (`docs/archive/`, `docs/superpowers/` plans/specs, `IMPLEMENTATION_PLAN.md`, `EPIC-WEBSITE-CATALOG-FIXES.md`, audit reports under `docs/security/`) intentionally left as dated snapshots — their `index.ts`/`cli.ts` references are historical, not current-state claims.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle.

Analyzed at: `docs/681-6-3-align-architecture-md-with-the @ 8cb2b69` (2026-09-12)

## Changes

| File | Change |
|------|--------|
| `docs/ARCHITECTURE.md` | CLI-mode section rewritten for the dispatcher + `src/commands/` split; `index.ts` → `index.tsx` (mermaid, entry point, state mgmt); eval table drops removed `eval/config.ts`, adds `eval/summary.ts`, `eval/builtins.ts`, `eval/providers/skill-best-practice/v1/`; `colors.ts` row describes the `theme` token palette |
| `docs/eval-providers.md` | Replaced the stale "Pinning a provider version via `~/.asm/config.yml`" section with the actual zero-config provider selection (`src/commands/eval.ts`, `src/eval/registry.ts:200`) |
| `docs/DEVELOPMENT.md` | Node `>= 22 and < 27` per `engines`; dropped the stale "50 `*.test.ts` files" count (73 test files today, incl. `.tsx`) |
| `CONTRIBUTING.md` | Node `>= 22 and < 27` per `engines` |
| `docs/AGENT_ENVIRONMENT.md` | Updated the engines-divergence note now that both docs carry the bounded range |

## Test Results

- Unit tests: 2793 passed (`CI=true npm test`, 89 files)
- Integration tests: skipped (none separate from the unit suite)
- E2e tests: passed (pre-push `e2e-node` hook)
- Build: passed (`npm run build` → 11 outputs in `dist/`)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `ARCHITECTURE.md` names `src/commands/` and drops the `cmd*`-in-cli.ts claim | pass | `docs/ARCHITECTURE.md:29-50` — dispatcher + `src/commands/` wording; `grep -n "cmd\*"` now matches only the corrected handler-description line |
| `doc-manager`'s drift pass reports zero unresolved contradictions in `docs/` | pass | Reconcile pass over living docs fixed all contradictions found (eval config, index.tsx, test count, colors.ts, engines bound); `docs/archive`, `superpowers/`, plan/audit snapshots excluded as dated records; zero `FLAG:` markers remain |
| `CI=true npm test` passes at 2793/2793 | pass | `CI=true npm test` → Test Files 89 passed, Tests 2793 passed |

<!-- gitissue:qa v1 head=8cb2b693aab79270ea8d86d7dde44f2af8900433 profile=light cycles=1 review=clean tests=2793@8cb2b693aab79270ea8d86d7dde44f2af8900433 ui=none:clean -->
