### PR TITLE
docs(ci): document moderate-advisory policy (#661)

### DIFF
--- a/docs/security/moderate-advisory-policy.md
+++ b/docs/security/moderate-advisory-policy.md
@@ -1,0 +1,49 @@
+# Moderate-Advisory Policy
+
+**Decision (2026-09-12, #661):** moderate (and low) npm advisories are owned
+by **Renovate `osvVulnerabilityAlerts`**, not by a dedicated CI job.
+`scripts/ci-npm-audit.ts` continues to gate merges on **high/critical only**.
+
+## Context
+
+`scripts/ci-npm-audit.ts` invokes `npm audit --audit-level=high --json` from
+the `audit` job in `.github/workflows/ci.yml`. That floor is correct — a
+moderate advisory should not block a release — but before this decision no
+mechanism tracked moderates at all, so they lingered unnoticed (a live
+`vitest` moderate advisory was the trigger for this review, epic #656 /
+F-CI-002).
+
+## Options considered
+
+| Option                                                              | Verdict                                                             |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Scheduled (weekly) non-gating CI job reporting moderate advisories  | Rejected — a new workflow, more CI surface, and reports nobody owns |
+| Documented policy: Renovate `osvVulnerabilityAlerts` owns moderates | **Chosen** — zero new infrastructure; the mechanism already exists  |
+
+## Why Renovate
+
+`renovate.json` already sets:
+
+```json
+"osvVulnerabilityAlerts": true,
+"vulnerabilityAlerts": {
+  "minimumReleaseAge": "0 days",
+  "labels": ["security"]
+}
+```
+
+OSV vulnerability alerts are not severity-filtered: Renovate raises an update
+PR for every advisory OSV reports — moderate and low included — bypassing the
+repo's usual 7-day `minimumReleaseAge` and tagging the PR `security`. A
+moderate advisory therefore already produces a visible, actionable, reviewable
+PR instead of a CI line nobody reads. The weekly-report option would have
+duplicated that signal at the cost of a new workflow file and its maintenance.
+
+## Consequences
+
+- `npm audit` below `--audit-level=high` is never run in CI; the `audit` job
+  stays high/critical-only in both its `--omit=dev` and full passes.
+- Moderate advisories are triaged through the Renovate `security`-labeled PR
+  queue. If Renovate alerts are ever disabled, this policy must be revisited.
+- The script header comment in `scripts/ci-npm-audit.ts` names the same owner
+  so the two documents cannot silently disagree.

--- a/scripts/ci-npm-audit.ts
+++ b/scripts/ci-npm-audit.ts
@@ -11,6 +11,13 @@
  * ASM_AUDIT_ALLOWLIST_EXPIRES) may suppress specific GHSA ids. After the
  * expiry date (UTC, inclusive) the allowlist is ignored. An allowlist
  * without an expiry is never honoured.
+ *
+ * The severity floor is deliberate: this gate covers high/critical only.
+ * Moderate and low advisories are owned by Renovate — `renovate.json`
+ * sets `osvVulnerabilityAlerts: true`, so OSV alerts raise
+ * `security`-labeled update PRs at every severity — and are never
+ * tracked or gated here. Decision record:
+ * `docs/security/moderate-advisory-policy.md` (#661).
  */
 
 import { spawnSync } from "node:child_process";


### PR DESCRIPTION
Closes #661

## Summary

`scripts/ci-npm-audit.ts` gates CI on high/critical npm advisories only — correct — but moderate advisories had no tracking mechanism and lingered unnoticed (a live `vitest` moderate was the trigger). This PR picks one of the two options the issue offered: moderate (and low) advisories are owned by Renovate `osvVulnerabilityAlerts`, which `renovate.json` already enables. The decision is recorded in two places that cannot silently disagree: the script's header comment and a new decision record at `docs/security/moderate-advisory-policy.md`.

## Approach

Option 2 — documented policy: Renovate `osvVulnerabilityAlerts` owns moderates. No new CI job is added; the existing `osvVulnerabilityAlerts: true` + `vulnerabilityAlerts` config (labels `security`, `minimumReleaseAge: 0 days`) already raises a reviewable `security`-labeled PR for every OSV advisory at every severity.

## Decision Record

- **Root cause:** the CI audit floor (`--audit-level=high`) left moderates with no owner — nothing tracked them, so they accumulated silently (F-CI-002, epic #656).
- **Options considered:** Option 1 — scheduled (weekly) non-gating CI job reporting moderate advisories; Option 2 — documented policy naming Renovate `osvVulnerabilityAlerts` as the owner of moderates.
- **Options rejected:** Option 1 — a new workflow file plus ongoing maintenance to produce a report nobody owns, duplicating a signal Renovate already emits as actionable PRs.
- **Selected option:** Option 2 — documented Renovate `osvVulnerabilityAlerts` policy.
- **Residual risk:** Renovate alert noise for unfixable transitive moderates is triaged in the PR queue; if Renovate alerts are ever disabled the policy must be revisited (noted in the doc).
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/661-0-2-decide-and-document-the @ 96641ce` (2026-09-12)

## Changes

| File | Change |
|------|--------|
| `scripts/ci-npm-audit.ts` | Header comment documents the deliberate high/critical-only floor and names Renovate `osvVulnerabilityAlerts` as the owner of moderate/low advisories |
| `docs/security/moderate-advisory-policy.md` | New decision record: context, options considered, rationale, consequences |

## Test Results

- Unit tests: 2793 passed
- Integration tests: skipped (none defined separately)
- E2e tests: passed (pre-push hook)
- Build: passed (pre-push hook)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| The chosen mechanism exists (scheduled workflow file, or doc comment + doc note naming Renovate as the owner) | pass | `scripts/ci-npm-audit.ts:15-20` header comment + `docs/security/moderate-advisory-policy.md` name Renovate `osvVulnerabilityAlerts` as the owner; `renovate.json` already sets it true |
| `CI=true npm test` passes at 2793/2793 (baseline-green holds) | pass | `CI=true npm test` → 89 files / 2793 tests, 0 failures at 96641ce |

<!-- gitissue:qa v1 head=96641cea0aec599ca9f7cbada05543e19b520769 profile=light cycles=1 review=clean tests=2793@96641cea0aec599ca9f7cbada05543e19b520769 ui=none -->