### PR TITLE
fix(evaluator): parse shellcheck json1 report from stdout (#663)

### DIFF
--- a/src/evaluator-pii-lint.test.ts
+++ b/src/evaluator-pii-lint.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runLinter } from "./evaluator-pii-lint";
+
+// Issue #663 — shellcheck --format=json1 emits its JSON report on stdout,
+// but runLinter parsed result.stderr (runCommand keeps the streams separate,
+// see src/utils/spawn.ts), so every linted shell script collapsed into the
+// generic "Linter exited with code" fallback instead of structured findings.
+// runCommand is stubbed so the stream the parser reads is asserted directly.
+
+const runCommandMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./utils/spawn", () => ({
+  runCommand: runCommandMock,
+}));
+
+const SH_FILE = "/tmp/skill/deploy.sh";
+
+describe("runLinter", () => {
+  beforeEach(() => {
+    runCommandMock.mockReset();
+  });
+
+  it("extracts file/line/severity/message from shellcheck JSON on stdout", async () => {
+    const payload = [
+      {
+        file: "deploy.sh",
+        line: 12,
+        endLine: 12,
+        column: 5,
+        endColumn: 9,
+        level: "error",
+        code: 2148,
+        message: "Tips depend on target shell and yours is unknown.",
+      },
+      {
+        file: "deploy.sh",
+        line: 20,
+        endLine: 20,
+        column: 10,
+        endColumn: 16,
+        level: "warning",
+        code: 2086,
+        message: "Double quote to prevent globbing and word splitting.",
+      },
+      {
+        file: "deploy.sh",
+        line: 30,
+        endLine: 30,
+        column: 1,
+        endColumn: 5,
+        level: "info",
+        code: 1091,
+        message: "Not following: file not specified.",
+      },
+    ];
+    runCommandMock.mockResolvedValue({
+      exitCode: 1,
+      stdout: JSON.stringify(payload),
+      stderr: "",
+    });
+
+    const findings = await runLinter(SH_FILE, ".sh");
+
+    expect(runCommandMock).toHaveBeenCalledWith([
+      "shellcheck",
+      "--format=json1",
+      SH_FILE,
+    ]);
+    expect(findings).toEqual([
+      {
+        file: SH_FILE,
+        line: 12,
+        severity: "error",
+        message: "Tips depend on target shell and yours is unknown.",
+      },
+      {
+        file: SH_FILE,
+        line: 20,
+        severity: "warning",
+        message: "Double quote to prevent globbing and word splitting.",
+      },
+      {
+        file: SH_FILE,
+        line: 30,
+        severity: "info",
+        message: "Not following: file not specified.",
+      },
+    ]);
+  });
+
+  it("maps short level codes the same as full names", async () => {
+    const payload = [
+      { line: 1, level: "e", message: "err" },
+      { line: 2, level: "w", message: "warn" },
+      { line: 3, level: "style", message: "style note" },
+    ];
+    runCommandMock.mockResolvedValue({
+      exitCode: 1,
+      stdout: JSON.stringify(payload),
+      stderr: "",
+    });
+
+    const findings = await runLinter(SH_FILE, ".sh");
+
+    expect(findings?.map((f) => f.severity)).toEqual([
+      "error",
+      "warning",
+      "info",
+    ]);
+  });
+
+  it("falls back to a single warning finding when stdout is not JSON", async () => {
+    runCommandMock.mockResolvedValue({
+      exitCode: 2,
+      stdout: "not json",
+      stderr: "",
+    });
+
+    const findings = await runLinter(SH_FILE, ".sh");
+
+    expect(findings).toHaveLength(1);
+    expect(findings?.[0].severity).toBe("warning");
+    expect(findings?.[0].message).toMatch(/Linter exited with code 2/);
+    expect(findings?.[0].message).toContain("not json");
+  });
+
+  it("returns no findings when the linter exits cleanly", async () => {
+    runCommandMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    expect(await runLinter(SH_FILE, ".sh")).toEqual([]);
+  });
+
+  it("returns null when the linter cannot be spawned", async () => {
+    runCommandMock.mockRejectedValue(
+      Object.assign(new Error("spawn shellcheck ENOENT"), { code: "ENOENT" }),
+    );
+
+    expect(await runLinter(SH_FILE, ".sh")).toBeNull();
+  });
+
+  it("returns null for extensions without a configured linter", async () => {
+    expect(await runLinter("/tmp/skill/app.js", ".js")).toBeNull();
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("still parses Python compile errors from stderr", async () => {
+    const pyFile = "/tmp/skill/broken.py";
+    runCommandMock.mockResolvedValue({
+      exitCode: 1,
+      stdout: "",
+      stderr: `  File "${pyFile}", line 3\n    def broken(\n             ^\nSyntaxError: invalid syntax\n`,
+    });
+
+    const findings = await runLinter(pyFile, ".py");
+
+    expect(runCommandMock).toHaveBeenCalledWith([
+      "python3",
+      "-m",
+      "py_compile",
+      pyFile,
+    ]);
+    expect(findings).toEqual([
+      {
+        file: pyFile,
+        line: 3,
+        severity: "error",
+        message: "SyntaxError: invalid syntax",
+      },
+    ]);
+  });
+});

--- a/src/evaluator-pii-lint.test.ts
+++ b/src/evaluator-pii-lint.test.ts
@@ -53,9 +53,11 @@ describe("runLinter", () => {
         message: "Not following: file not specified.",
       },
     ];
+    // shellcheck --format=json1 wraps the comments array in an object:
+    // {"comments": [...]} — a bare array is the legacy --format=json shape.
     runCommandMock.mockResolvedValue({
       exitCode: 1,
-      stdout: JSON.stringify(payload),
+      stdout: JSON.stringify({ comments: payload }),
       stderr: "",
     });
 
@@ -96,7 +98,7 @@ describe("runLinter", () => {
     ];
     runCommandMock.mockResolvedValue({
       exitCode: 1,
-      stdout: JSON.stringify(payload),
+      stdout: JSON.stringify({ comments: payload }),
       stderr: "",
     });
 

--- a/src/evaluator-pii-lint.ts
+++ b/src/evaluator-pii-lint.ts
@@ -239,7 +239,7 @@ interface LintFinding {
  * Run a linter on a single script file and return structured findings.
  * Returns null when the linter is unavailable.
  */
-async function runLinter(
+export async function runLinter(
   filePath: string,
   ext: string,
 ): Promise<LintFinding[] | null> {
@@ -283,9 +283,10 @@ async function runLinter(
         return findings;
       }
 
-      // Shellcheck JSON output
+      // Shellcheck JSON output — shellcheck --format=json1 emits the report
+      // on stdout; runCommand keeps stdout and stderr separate.
       try {
-        const issues = JSON.parse(result.stderr);
+        const issues = JSON.parse(result.stdout);
         const findings: LintFinding[] = [];
         if (Array.isArray(issues)) {
           for (const issue of issues) {
@@ -313,7 +314,7 @@ async function runLinter(
             file: filePath,
             line: 0,
             severity: "warning",
-            message: `Linter exited with code ${result.exitCode}: ${result.stderr.slice(0, 200)}`,
+            message: `Linter exited with code ${result.exitCode}: ${(result.stderr || result.stdout).slice(0, 200)}`,
           },
         ];
       }

--- a/src/evaluator-pii-lint.ts
+++ b/src/evaluator-pii-lint.ts
@@ -284,9 +284,13 @@ export async function runLinter(
       }
 
       // Shellcheck JSON output — shellcheck --format=json1 emits the report
-      // on stdout; runCommand keeps stdout and stderr separate.
+      // on stdout as {"comments": [...]} (the legacy json format is a bare
+      // array); runCommand keeps stdout and stderr separate.
       try {
-        const issues = JSON.parse(result.stdout);
+        const parsed: unknown = JSON.parse(result.stdout);
+        const issues = Array.isArray(parsed)
+          ? parsed
+          : (parsed as { comments?: unknown }).comments;
         const findings: LintFinding[] = [];
         if (Array.isArray(issues)) {
           for (const issue of issues) {


### PR DESCRIPTION
Closes #663

## Summary

`runLinter` in `src/evaluator-pii-lint.ts` parsed `result.stderr` for shellcheck's `--format=json1` report, but shellcheck writes that JSON to **stdout** and `runCommand` (`src/utils/spawn.ts`) keeps the streams separate — so `JSON.parse("")` always threw and every shell-script finding collapsed into the generic "Linter exited with code" warning, with file/line/severity/message never surfacing. The parse now reads `result.stdout`, the non-JSON fallback reports detail from stderr-or-stdout, and `runLinter` is exported and covered by a new sibling test that stubs `runCommand`.

## Approach

Option 2 — minimal fix + targeted regression coverage: change the parse source to `stdout` (the documented shellcheck json1 stream), export `runLinter`, and add `src/evaluator-pii-lint.test.ts` stubbing `runCommand` to return `{ exitCode: 1, stdout: <json1 payload>, stderr: "" }` and asserting structured findings.

## Decision Record

- **Root cause:** shellcheck `--format=json1` emits its report on stdout; `runLinter` parsed `result.stderr`, which is empty on a normal lint run, so `JSON.parse` threw and the code returned a single synthetic warning finding — real structured findings never surfaced.
- **Options considered:** Option 1 — try `stdout`, fall back to `stderr` on parse failure; Option 2 — parse `result.stdout` directly + regression test; Option 3 — refactor the linter abstraction behind an injectable runner.
- **Options rejected:** Option 1 — preserves dead-path ambiguity and masks the actual contract; Option 3 — out of scope for an S-effort bug fix.
- **Selected option:** Option 2 — minimal fix + targeted regression coverage
- **Residual risk:** `.py` linting still parses `stderr` (correct — `py_compile` reports there); non-JSON shellcheck stdout still degrades to the single-warning fallback, now reporting whichever stream carried output.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle
- **Reproduction:** `npx vitest run src/evaluator-pii-lint.test.ts` confirmed red (3 failures — structured findings lost to the `Linter exited with code 1:` fallback) → regression test `src/evaluator-pii-lint.test.ts`

Analyzed at: `fix/663-1-2-fix-the-shellcheck-stream-bug-cover @ 2a69ce6` (2026-09-12)

## Changes

| File | Change |
|------|--------|
| `src/evaluator-pii-lint.ts` | `runLinter` parses `result.stdout` for the shellcheck json1 report; non-JSON fallback detail reads `stderr \|\| stdout`; `runLinter` exported |
| `src/evaluator-pii-lint.test.ts` | new — stubs `runCommand`; covers stdout-JSON structured findings, severity mapping, non-JSON fallback, clean exit, ENOENT→null, unconfigured extension, and the unchanged `.py` stderr path |

## Test Results

- Unit tests: 2800 passed (90 files, `CI=true npm test`)
- Integration tests: skipped (none separate)
- E2e tests: skipped (`tests/e2e/` not covered by `npm test`)
- Build: passed (`npm run typecheck`, `npm run lint` clean)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `runLinter` extracts file/line/severity/message from a stubbed stdout-JSON shellcheck result | pass | Verified red: `npx vitest run src/evaluator-pii-lint.test.ts` → fixed → `src/evaluator-pii-lint.test.ts` › "extracts file/line/severity/message from shellcheck JSON on stdout" |
| `src/evaluator-pii-lint.test.ts` exists and passes | pass | `src/evaluator-pii-lint.test.ts` — 7/7 tests green |
| `CI=true npm test` passes at 2793/2793 (baseline-green holds) | pass | `CI=true npm test` → 2800/2800 (baseline 2793 + 7 new tests) |

<!-- gitissue:qa v1 head=c12e5f08491f0a8f11d2e08308900bce7cc4c052 profile=light cycles=1 review=clean tests=2800@c12e5f08491f0a8f11d2e08308900bce7cc4c052 ui=none:clean -->
