### PR TITLE
fix(ci): verify tool downloads in security workflow (#665)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,15 +27,21 @@ jobs:
       - name: Install gitleaks
         run: |
           GITLEAKS_VERSION=8.30.1
-          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | sudo tar -xz -C /usr/local/bin gitleaks
+          # SHA256 of gitleaks_8.30.1_linux_x64.tar.gz (from gitleaks_8.30.1_checksums.txt)
+          GITLEAKS_SHA256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+          curl -sSL -o /tmp/gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin -f /tmp/gitleaks.tar.gz gitleaks
           gitleaks version
 
       - name: Install trivy
         run: |
           TRIVY_VERSION=0.70.0
-          curl -sSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
-            | sudo tar -xz -C /usr/local/bin trivy
+          # SHA256 of trivy_0.70.0_Linux-64bit.tar.gz (from trivy_0.70.0_checksums.txt)
+          TRIVY_SHA256=8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9
+          curl -sSL -o /tmp/trivy.tar.gz "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          echo "${TRIVY_SHA256}  /tmp/trivy.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin -f /tmp/trivy.tar.gz trivy
           trivy --version
 
       - name: Compute trivy cache week stamp
@@ -56,7 +62,8 @@ jobs:
       - name: Install semgrep
         run: |
           python -m pip install --upgrade pip
-          python -m pip install semgrep
+          # renovate: datasource=pypi depName=semgrep
+          python -m pip install "semgrep==1.177.0"
           semgrep --version
 
       - name: Run local security checks

--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,16 @@
       "matchManagers": ["github-actions"],
       "pinDigests": true
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/security\\.yml$"],
+      "matchStrings": [
+        "# renovate: datasource=pypi depName=semgrep\\s+python -m pip install \"?semgrep==(?<currentValue>[^\"'\\s]+)"
+      ],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "semgrep"
+    }
   ]
 }


### PR DESCRIPTION
Closes #665

## Summary

The `security` CI leg installed gitleaks and trivy by piping `curl` output straight into `sudo tar -xz` with no integrity check, and installed semgrep unpinned — a tampered or corrupted release artifact would be extracted to `/usr/local/bin` and executed with no detection. Both tool tarballs now download to a file and pass a pinned SHA256 `sha256sum -c` gate before extraction, and semgrep is pinned to `==1.177.0` with a Renovate regex customManager wired to keep the pin bumpable.

## Approach

Option 2 — Pin-and-verify + Renovate bump path: pin `GITLEAKS_SHA256` / `TRIVY_SHA256` alongside each `*_VERSION`, verify the downloaded tarball with `sha256sum -c -` (fails the step before `tar` runs), and pin `semgrep==1.177.0` behind a `# renovate:` comment matched by a new regex `customManager` in `renovate.json`.

## Decision Record

- **Root cause:** `security.yml` fetched release tarballs and piped them directly into `tar` — the pipeline trusted whatever the network returned, and `pip install semgrep` floated to whatever PyPI resolved that day. No integrity anchor existed for any of the three tools (F-SEC-001/F-SEC-002).
- **Options considered:** Option 1 — Minimal (checksums only, no Renovate hookup); Option 2 — Pin-and-verify + Renovate bump path; Option 3 — Comprehensive (sigstore/cosign attestation verification)
- **Options rejected:** Option 1 — satisfies the letter of the AC but leaves "so Renovate can bump it" unrealized: no Renovate manager detects a bare `semgrep==` pin inside a workflow `run:` block without a customManager; Option 3 — trivy publishes sigstore bundles but gitleaks does not, so cosign adds asymmetric complexity well beyond a priority:low task; pinned SHA256 already covers the corruption/MITM threat model
- **Selected option:** Option 2 — Pin-and-verify + Renovate bump path
- **Residual risk:** gitleaks/trivy version bumps remain manual (version + SHA must be updated together — the pin comments name the `*_checksums.txt` source asset); the pinned SHA256 anchors integrity but not authenticity against a fully compromised upstream release — accepted, matches the issue scope
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle
- **Reproduction:** `grep -n "sha256\|SHA256\|semgrep==" .github/workflows/security.yml` confirmed red pre-fix (no matches — nothing was verified or pinned) → fixed → manual repro, no test seam (workflow YAML has no vitest harness; the `security` CI leg on this PR is the live check)

Analyzed at: `fix/665-1-4-verify-downloads-in-the-security @ 5e5bcd1` (2026-09-12)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/security.yml` | gitleaks + trivy steps now download the tarball to `/tmp`, verify a pinned `*_SHA256` with `sha256sum -c -` before `sudo tar -xz`; semgrep pinned to `==1.177.0` with a `# renovate: datasource=pypi depName=semgrep` marker |
| `renovate.json` | added a regex `customManager` scoped to `security.yml` so Renovate opens bump PRs for the `semgrep==` pin |

## Test Results

- Unit tests: 2800 passed
- Integration tests: skipped (no separate suite)
- E2e tests: passed (pre-push hook)
- Build: passed
- QA cycles: 1

Checksum provenance: both SHA256s were independently verified by downloading `gitleaks_8.30.1_linux_x64.tar.gz` and `trivy_0.70.0_Linux-64bit.tar.gz`, hashing them locally, and matching against the published `gitleaks_8.30.1_checksums.txt` / `trivy_0.70.0_checksums.txt` manifests. `sha256sum`/`shasum -a 256 -c` format verified against the real artifacts.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Both tarball downloads verify a pinned SHA256 before `tar` | pass | Verified red: `grep -n "sha256\|SHA256\|semgrep==" .github/workflows/security.yml` → no matches pre-fix → fixed → `security.yml:31-34` (gitleaks) and `:41-44` (trivy) run `sha256sum -c -` before extraction; manual repro, no test seam |
| `semgrep` install is version-pinned | pass | `security.yml:66` `python -m pip install "semgrep==1.177.0"` (latest stable on PyPI); `renovate.json` customManager regex verified to match and capture `1.177.0` |
| `CI=true npm test` passes at 2793/2793 (baseline-green holds) | pass | `CI=true npm test` → 2800/2800 at `5e5bcd1` (suite grew +7 on main since the issue was written; zero failures) |

<!-- gitissue:qa v1 head=5e5bcd134fb99a0a1e9267ab2c39df491b8c71d0 profile=light cycles=1 review=clean ui=none -->
