### PR TITLE
test(evaluator): cover batch fix and detail failure paths (#674)

### DIFF
--- a/src/evaluator-batch.test.ts
+++ b/src/evaluator-batch.test.ts
@@ -1,0 +1,373 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildBatchMachineData,
+  buildEvalMachineData,
+  classifyEvalDirectory,
+  findChildSkillDirs,
+  formatBatchSummary,
+  resolveEvalInput,
+  runWithConcurrency,
+  summariseBatch,
+  type EvalBatchItem,
+} from "./evaluator-batch";
+import type { EvaluationReport, FixResult } from "./evaluator-core";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "fs/promises";
+import { basename, join, resolve } from "path";
+import { tmpdir } from "os";
+
+// Issue #674 — sibling coverage for evaluator-batch.ts. The happy paths are
+// exercised through the facade in evaluator.test.ts; this file pins down the
+// failure branches: unreadable children, remote-fetch cleanup on error, and
+// the all-failed aggregate rendering.
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "eval-batch-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+const MINI_SKILL = `---
+name: mini
+description: Do something specific when asked.
+---
+# mini
+
+## When to Use
+- something
+
+## Instructions
+1. do the thing
+`;
+
+async function writeSkillMd(dir: string, content = MINI_SKILL): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "SKILL.md"), content, "utf-8");
+}
+
+function mkReport(label: string, score: number): EvaluationReport {
+  return {
+    skillPath: `/virtual/${label}`,
+    skillMdPath: `/virtual/${label}/SKILL.md`,
+    evaluatedAt: "2026-01-01T00:00:00.000Z",
+    categories: [],
+    overallScore: score,
+    grade: "B",
+    topSuggestions: [],
+    frontmatter: {},
+  };
+}
+
+describe("findChildSkillDirs — child-entry failures", () => {
+  it("skips a plain file at the collection root", async () => {
+    const root = join(tempDir, "with-file");
+    await mkdir(root, { recursive: true });
+    await writeSkillMd(join(root, "real"));
+    // A regular file is not a directory — hits the !isDirectory continue.
+    await writeFile(join(root, "README.md"), "# readme\n", "utf-8");
+
+    const r = await findChildSkillDirs(root);
+    expect(r.map((d) => basename(d))).toEqual(["real"]);
+  });
+
+  it("skips a child directory that has no SKILL.md", async () => {
+    const root = join(tempDir, "with-empty-child");
+    await mkdir(root, { recursive: true });
+    await writeSkillMd(join(root, "real"));
+    // stat(SKILL.md) inside this child fails — caught and skipped.
+    await mkdir(join(root, "docs"), { recursive: true });
+
+    const r = await findChildSkillDirs(root);
+    expect(r.map((d) => basename(d))).toEqual(["real"]);
+  });
+
+  it("skips a child whose SKILL.md is a directory, not a file", async () => {
+    const root = join(tempDir, "with-dir-skillmd");
+    await mkdir(root, { recursive: true });
+    await writeSkillMd(join(root, "real"));
+    // stat succeeds but isFile() is false → not a valid skill child.
+    await mkdir(join(root, "weird", "SKILL.md"), { recursive: true });
+
+    const r = await findChildSkillDirs(root);
+    expect(r.map((d) => basename(d))).toEqual(["real"]);
+  });
+
+  it("skips a dangling symlink whose stat fails", async () => {
+    const root = join(tempDir, "with-dangling");
+    await mkdir(root, { recursive: true });
+    await writeSkillMd(join(root, "real"));
+    // stat() follows symlinks — a dangling target throws ENOENT, caught.
+    await symlink(join(root, "gone-target"), join(root, "dangling"));
+
+    const r = await findChildSkillDirs(root);
+    expect(r.map((d) => basename(d))).toEqual(["real"]);
+  });
+});
+
+describe("classifyEvalDirectory — root SKILL.md that is not a file", () => {
+  it("falls through to children when SKILL.md is a directory", async () => {
+    const root = join(tempDir, "weird-root");
+    // stat succeeds but isFile() is false → classify as collection/none.
+    await mkdir(join(root, "SKILL.md"), { recursive: true });
+    await writeSkillMd(join(root, "child-skill"));
+
+    const r = await classifyEvalDirectory(root);
+    expect(r.kind).toBe("collection");
+    expect(r.skillDirs.map((d) => basename(d))).toEqual(["child-skill"]);
+  });
+});
+
+describe("resolveEvalInput — error branches", () => {
+  it("rejects an empty input string", async () => {
+    await expect(resolveEvalInput("")).rejects.toThrow(/non-empty/);
+  });
+
+  it("cleans up and rethrows when classification of the remote root fails", async () => {
+    // A non-string rootDir makes classifyEvalDirectory throw synchronously
+    // inside the async fn (path.join requires strings) — the resolver must
+    // still run cleanup, and a failing cleanup must not mask the root error.
+    const cleanup = vi.fn(async () => {
+      throw new Error("cleanup exploded");
+    });
+    await expect(
+      resolveEvalInput("github:test/broken", {
+        fetchRemote: async () => ({
+          rootDir: 42 as unknown as string,
+          cleanup,
+          sourceRef: "github:test/broken",
+          commitSha: null,
+        }),
+      }),
+    ).rejects.toThrow(TypeError);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up and throws 'No SKILL.md' even when remote cleanup fails", async () => {
+    const emptyRepo = join(tempDir, "empty-remote");
+    await mkdir(emptyRepo, { recursive: true });
+    const cleanup = vi.fn(async () => {
+      throw new Error("cleanup exploded");
+    });
+
+    await expect(
+      resolveEvalInput("github:test/nothing", {
+        fetchRemote: async () => ({
+          rootDir: emptyRepo,
+          cleanup,
+          sourceRef: "github:test/nothing",
+          commitSha: null,
+        }),
+      }),
+    ).rejects.toThrow(/No SKILL\.md found/);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves a relative local path against the cwd", async () => {
+    await writeSkillMd(join(tempDir, "rel-skill"));
+    const prevCwd = process.cwd();
+    process.chdir(tempDir);
+    try {
+      const r = await resolveEvalInput("rel-skill");
+      expect(r.targets).toHaveLength(1);
+      // resolve() anchors on the chdir'd cwd (canonicalised on macOS).
+      expect(r.targets[0].skillPath).toBe(resolve("rel-skill"));
+      // Local directory inputs get a no-op cleanup — safe to call.
+      await expect(r.cleanup()).resolves.toBeUndefined();
+    } finally {
+      process.chdir(prevCwd);
+    }
+  });
+
+  it("keeps the full path as skillPath for a file not named SKILL.md", async () => {
+    const dir = join(tempDir, "odd-file");
+    await mkdir(dir, { recursive: true });
+    const alt = join(dir, "OTHER.md");
+    await writeFile(alt, MINI_SKILL, "utf-8");
+
+    const r = await resolveEvalInput(alt);
+    expect(r.targets).toHaveLength(1);
+    expect(r.targets[0].skillPath).toBe(alt);
+    expect(r.targets[0].skillMdPath).toBe(alt);
+    expect(r.targets[0].label).toBe("OTHER.md");
+    // Local inputs get a no-op cleanup — it must be safe to call.
+    await expect(r.cleanup()).resolves.toBeUndefined();
+  });
+
+  it("rejects a path that is neither a file nor a directory", async () => {
+    // /dev/null stats successfully but is a character device.
+    await expect(resolveEvalInput("/dev/null")).rejects.toThrow(
+      /not a directory or file/,
+    );
+  });
+});
+
+describe("runWithConcurrency — failure window", () => {
+  it("rethrows the first error when multiple workers fail", async () => {
+    // With limit 2 both workers claim an index and reject; the second
+    // observes `failure` already set — the first error wins.
+    const calls: number[] = [];
+    await expect(
+      runWithConcurrency([1, 2, 3, 4], 2, async (n) => {
+        calls.push(n);
+        if (n === 1) throw new Error("boom-1");
+        if (n === 2) throw new Error("boom-2");
+        return n;
+      }),
+    ).rejects.toThrow("boom-1");
+    // Workers stop claiming new indexes once failure is observed.
+    expect(calls).toEqual([1, 2]);
+  });
+});
+
+describe("batch reporting — failure aggregates", () => {
+  const allFailed: EvalBatchItem[] = [
+    {
+      label: "a",
+      skillPath: "/virtual/a",
+      report: null,
+      error: "SKILL.md not found",
+    },
+    {
+      label: "b",
+      skillPath: "/virtual/b",
+      report: null,
+      error: "parse exploded",
+    },
+  ];
+
+  it("summariseBatch reports only failures", () => {
+    const agg = summariseBatch(allFailed);
+    expect(agg).toEqual({
+      total: 2,
+      succeeded: 0,
+      failed: 2,
+      meanScore: null,
+      top: null,
+      bottom: null,
+    });
+  });
+
+  it("formatBatchSummary shows the failed count and no score lines", () => {
+    const out = formatBatchSummary({
+      provenance: { input: "./skills", remote: false, sourceRef: null },
+      aggregate: summariseBatch(allFailed),
+      results: allFailed,
+    });
+    expect(out).toContain("Skills evaluated:      0/2  (2 failed)");
+    expect(out).not.toContain("Mean score:");
+    expect(out).not.toContain("Top:");
+    expect(out).not.toContain("Bottom:");
+  });
+
+  it("formatBatchSummary omits provenance lines the remote left unset", () => {
+    const out = formatBatchSummary({
+      provenance: {
+        input: "github:a/b",
+        remote: true,
+        sourceRef: null,
+        commitSha: null,
+        tempPath: null,
+      },
+      aggregate: {
+        total: 1,
+        succeeded: 1,
+        failed: 0,
+        meanScore: 88,
+        top: { label: "a", score: 88 },
+        bottom: { label: "a", score: 88 },
+      },
+      results: [],
+    });
+    expect(out).not.toContain("Source:");
+    expect(out).not.toContain("Commit:");
+    expect(out).not.toContain("Fetched to:");
+  });
+
+  it("buildBatchMachineData keeps a failed item's error and null report", () => {
+    const data = buildBatchMachineData({
+      provenance: { input: "./skills", remote: false, sourceRef: null },
+      aggregate: summariseBatch(allFailed),
+      results: allFailed,
+    });
+    expect(data.aggregate.failed).toBe(2);
+    expect(data.results[0].report).toBeNull();
+    expect(data.results[0].error).toBe("SKILL.md not found");
+  });
+});
+
+describe("buildEvalMachineData — provider payload", () => {
+  it("serialises extra providers with their categories and findings", () => {
+    const report = {
+      ...mkReport("x", 70),
+      providers: [
+        {
+          id: "skill-best-practice",
+          version: "1.0.0",
+          schemaVersion: 1,
+          score: 88,
+          passed: true,
+          categories: [
+            {
+              id: "validation",
+              name: "Deterministic validation",
+              score: 7,
+              max: 7,
+              findings: [],
+              suggestions: [],
+            },
+            // No `findings` key — the `?? []` fallback must kick in.
+            {
+              id: "other",
+              name: "Other",
+              score: 1,
+              max: 3,
+            } as never,
+          ],
+          findings: [
+            {
+              severity: "warning" as const,
+              message: "Missing negative-trigger clause.",
+            },
+          ],
+        },
+      ],
+    };
+    const data = buildEvalMachineData(report);
+    expect(data.providers).toHaveLength(1);
+    expect(data.providers[0]).toMatchObject({
+      id: "skill-best-practice",
+      score: 88,
+      passed: true,
+    });
+    expect(data.providers[0].categories[0].id).toBe("validation");
+    expect(data.providers[0].categories[1].findings).toEqual([]);
+    expect(data.providers[0].findings).toEqual([
+      { severity: "warning", message: "Missing negative-trigger clause." },
+    ]);
+  });
+});
+
+describe("buildEvalMachineData — fix payload", () => {
+  it("serialises the fix block when a FixResult is supplied", () => {
+    const fix: FixResult = {
+      report: mkReport("x", 70),
+      applied: [{ id: "add-missing-version", description: "Add `version`." }],
+      skipped: [{ id: "missing-description", description: "Left to author." }],
+      diff: "--- a/SKILL.md\n+++ b/SKILL.md\n@@ -1,1 +1,2 @@\n+version: 0.1.0",
+      dryRun: false,
+      backupPath: "/virtual/x/SKILL.md.bak",
+      skillMdPath: "/virtual/x/SKILL.md",
+    };
+    const data = buildEvalMachineData(mkReport("x", 70), fix);
+    expect(data.fix).toEqual({
+      dry_run: false,
+      applied: fix.applied,
+      skipped: fix.skipped,
+      backup_path: "/virtual/x/SKILL.md.bak",
+      diff: fix.diff,
+    });
+  });
+});

--- a/src/evaluator-fix.test.ts
+++ b/src/evaluator-fix.test.ts
@@ -1,0 +1,784 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyFix,
+  buildFixPlan,
+  detectGitAuthor,
+  evaluateSkill,
+  evaluateSkillContent,
+  evaluateSkillContentSync,
+  formatFixPreview,
+  formatReport,
+} from "./evaluator-fix";
+import { ROOT_README_SUGGESTION } from "./evaluator-core";
+import type { EvaluationReport } from "./evaluator-core";
+import type { ProviderEvalReport } from "./eval/summary";
+import { mkdtemp, mkdir, rm, writeFile, readFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Issue #674 — sibling coverage for evaluator-fix.ts. evaluator.test.ts
+// exercises the happy paths through the evaluator.ts facade; this file pins
+// the failure branches: unreadable inputs, fixer edge cases, malformed
+// provider payloads, and the detectGitAuthor fallbacks.
+
+const runCommandMock = vi.hoisted(() => vi.fn());
+const fsCtl = vi.hoisted(() => ({
+  /** Absolute paths for which the mocked readdir must reject. */
+  readdirFailures: new Set<string>(),
+  realReaddir: null as unknown as (
+    path: string,
+    options?: unknown,
+  ) => Promise<unknown>,
+}));
+
+vi.mock("./utils/spawn", () => ({
+  runCommand: runCommandMock,
+}));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  fsCtl.realReaddir = actual.readdir as typeof fsCtl.realReaddir;
+  return {
+    ...actual,
+    readdir: (path: string, options?: unknown) => {
+      if (fsCtl.readdirFailures.has(String(path))) {
+        return Promise.reject(
+          Object.assign(new Error("EACCES: permission denied"), {
+            code: "EACCES",
+          }),
+        );
+      }
+      return fsCtl.realReaddir(path, options);
+    },
+  };
+});
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "eval-fix-test-"));
+  runCommandMock.mockReset();
+  // Default: any subprocess (e.g. a linter probe) exits cleanly.
+  runCommandMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+  fsCtl.readdirFailures.clear();
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+const HIGH_SKILL = `---
+name: code-review
+description: Review pull request diffs for code smells, style issues, and safety problems before merging.
+version: 1.0.0
+license: MIT
+creator: Test Author
+compatibility: Claude Code
+allowed-tools: Read Grep
+effort: medium
+---
+
+# Code review
+
+## When to Use
+
+- When the user asks to "review this PR" or "check the diff"
+- Before merging any change larger than 10 lines
+
+## Prerequisites
+
+- A git repository with the target branch checked out
+- Read access to the files being reviewed
+
+## Instructions
+
+1. Run \`git diff main...HEAD\` to list files
+2. Read each file and check for common smells
+3. Emit a markdown report summarising findings
+
+## Example
+
+\`\`\`bash
+$ asm eval ./code-review
+Overall score: 95/100
+\`\`\`
+
+## Acceptance Criteria
+
+- Produces a markdown report with sections per file
+- Flags any use of \`eval()\` or \`exec\` as dangerous
+- Does not modify the working tree
+
+## Edge cases
+
+- Empty diffs: emit a short "no changes" note
+- Binary files: skip and mention the filename in the report
+
+## Safety
+
+See \`references/safety.md\` for error handling rules.
+Always confirm before writing. Never run destructive commands without a dry-run.
+`;
+
+// Complete skill minus `author`, with a README at the root: structure scores
+// 9/10 so it sorts first in the suggestion loop, and its suggestions are
+// [add-author, ROOT_README_SUGGESTION] — the promoted README then hits the
+// `includes` dedup guard instead of being pushed a second time.
+const ALMOST_PERFECT_SKILL = `---
+name: code-review
+description: Review pull request diffs for code smells, style issues, and safety problems before merging.
+version: 1.0.0
+license: MIT
+compatibility: Claude Code
+allowed-tools: Read Grep
+effort: medium
+---
+
+# Code review
+
+## When to Use
+
+- When the user asks to "review this PR" or "check the diff"
+- Before merging any change larger than 10 lines
+
+## Prerequisites
+
+- A git repository with the target branch checked out
+- Read access to the files being reviewed
+
+## Instructions
+
+1. Run \`git diff main...HEAD\` to list files
+2. Read each file and check for common smells
+3. Emit a markdown report summarising findings
+
+## Example
+
+\`\`\`bash
+$ asm eval ./code-review
+Overall score: 95/100
+\`\`\`
+
+## Acceptance Criteria
+
+- Produces a markdown report with sections per file
+- Flags any use of \`eval()\` or \`exec\` as dangerous
+- Does not modify the working tree
+
+## Expected output
+
+Emit a markdown report; verify every file appears once. The expected output
+must fit within the agent's token budget for the context window.
+
+## Edge cases
+
+- Empty diffs: emit a short "no changes" note
+- Binary files: skip and mention the filename in the report
+
+## Safety
+
+See \`references/safety.md\` for error handling rules.
+Always confirm before writing. Never run destructive commands without a dry-run.
+`;
+
+const MID_SKILL = `---
+name: mid-skill
+description: Generate reports when asked to summarise things.
+version: 1.0.0
+license: MIT
+---
+
+# mid
+
+## When to Use
+- thing
+
+## Instructions
+1. do it
+`;
+
+async function writeSkillMd(dir: string, content: string): Promise<string> {
+  await mkdir(dir, { recursive: true });
+  const p = join(dir, "SKILL.md");
+  await writeFile(p, content, "utf-8");
+  return p;
+}
+
+function mkReport(
+  overrides: Partial<EvaluationReport> & {
+    providers?: ProviderEvalReport[];
+  } = {},
+): EvaluationReport & { providers?: ProviderEvalReport[] } {
+  return {
+    skillPath: "/virtual/x",
+    skillMdPath: "/virtual/x/SKILL.md",
+    evaluatedAt: "2026-01-01T00:00:00.000Z",
+    categories: [
+      {
+        id: "structure",
+        name: "Structure & completeness",
+        score: 9,
+        max: 10,
+        findings: [],
+        suggestions: [],
+      },
+    ],
+    overallScore: 90,
+    grade: "A",
+    topSuggestions: [],
+    frontmatter: {},
+    ...overrides,
+  };
+}
+
+function mkProvider(
+  overrides: Partial<ProviderEvalReport> = {},
+): ProviderEvalReport {
+  return {
+    id: "extra-provider",
+    version: "1.0.0",
+    schemaVersion: 1,
+    score: 42,
+    passed: true,
+    categories: [],
+    findings: [],
+    ...overrides,
+  };
+}
+
+describe("evaluateSkillContent — grade boundaries and promotions", () => {
+  const LICENSE_AT_ROOT = ["SKILL.md", "LICENSE"];
+
+  it("grades a near-perfect skill A (async path)", async () => {
+    const report = await evaluateSkillContent({
+      content: HIGH_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+      rootEntries: LICENSE_AT_ROOT,
+    });
+    expect(report.overallScore).toBeGreaterThanOrEqual(90);
+    expect(report.grade).toBe("A");
+  });
+
+  it("grades a mid-range skill C (async path)", async () => {
+    const report = await evaluateSkillContent({
+      content: MID_SKILL,
+      skillPath: "/virtual/mid-skill",
+      skillMdPath: "/virtual/mid-skill/SKILL.md",
+      rootEntries: LICENSE_AT_ROOT,
+    });
+    expect(report.overallScore).toBeGreaterThanOrEqual(65);
+    expect(report.overallScore).toBeLessThan(80);
+    expect(report.grade).toBe("C");
+  });
+
+  it("grades a weak-but-passing skill D (async path)", async () => {
+    const report = await evaluateSkillContent({
+      content: MID_SKILL,
+      skillPath: "/virtual/mid-skill",
+      skillMdPath: "/virtual/mid-skill/SKILL.md",
+    });
+    expect(report.overallScore).toBeGreaterThanOrEqual(50);
+    expect(report.overallScore).toBeLessThan(65);
+    expect(report.grade).toBe("D");
+  });
+
+  it("grades the same bands in the sync path", () => {
+    const a = evaluateSkillContentSync({
+      content: HIGH_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+      rootEntries: LICENSE_AT_ROOT,
+    });
+    expect(a.grade).toBe("A");
+    const c = evaluateSkillContentSync({
+      content: MID_SKILL,
+      skillPath: "/virtual/mid-skill",
+      skillMdPath: "/virtual/mid-skill/SKILL.md",
+      rootEntries: LICENSE_AT_ROOT,
+    });
+    expect(c.grade).toBe("C");
+  });
+
+  it("awards the naming bonus when the directory matches frontmatter name", async () => {
+    const report = await evaluateSkillContent({
+      content:
+        "---\nname: my-skill\ndescription: Do a thing when triggered.\nversion: 1.0.0\n---\nbody\n",
+      skillPath: "/virtual/my-skill",
+      skillMdPath: "/virtual/my-skill/SKILL.md",
+    });
+    const naming = report.categories.find((c) => c.id === "naming")!;
+    expect(naming.findings.some((f) => /Directory name matches/.test(f))).toBe(
+      true,
+    );
+  });
+
+  it("promotes the README-at-root suggestion once, ahead of score order", async () => {
+    const report = await evaluateSkillContent({
+      content: HIGH_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+      rootEntries: ["SKILL.md", "README.md"],
+    });
+    expect(report.topSuggestions[0]).toBe(ROOT_README_SUGGESTION);
+    // The dedup guard must keep it to a single entry even though the
+    // structure category still carries the same suggestion.
+    expect(
+      report.topSuggestions.filter((s) => s === ROOT_README_SUGGESTION),
+    ).toHaveLength(1);
+  });
+
+  it("promotes the README-at-root suggestion in the sync path too", () => {
+    const report = evaluateSkillContentSync({
+      content: HIGH_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+      rootEntries: ["SKILL.md", "README.md"],
+    });
+    expect(report.topSuggestions[0]).toBe(ROOT_README_SUGGESTION);
+  });
+
+  it("deduplicates the promoted suggestion when structure is scored early", async () => {
+    const report = await evaluateSkillContent({
+      content: ALMOST_PERFECT_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+      rootEntries: ["SKILL.md", "LICENSE", "README.md"],
+    });
+    expect(report.topSuggestions[0]).toBe(ROOT_README_SUGGESTION);
+    expect(
+      report.topSuggestions.filter((s) => s === ROOT_README_SUGGESTION),
+    ).toHaveLength(1);
+  });
+
+  it("deduplicates the promoted suggestion in the sync path", () => {
+    const report = evaluateSkillContentSync({
+      content: ALMOST_PERFECT_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+      rootEntries: ["SKILL.md", "LICENSE", "README.md"],
+    });
+    expect(
+      report.topSuggestions.filter((s) => s === ROOT_README_SUGGESTION),
+    ).toHaveLength(1);
+  });
+});
+
+describe("evaluateSkill — filesystem error branches", () => {
+  it("resolves a relative skill path against the cwd", async () => {
+    await writeSkillMd(join(tempDir, "rel"), HIGH_SKILL);
+    const prevCwd = process.cwd();
+    process.chdir(tempDir);
+    try {
+      const report = await evaluateSkill("rel");
+      expect(report.skillPath).toBe(join(process.cwd(), "rel"));
+    } finally {
+      process.chdir(prevCwd);
+    }
+  });
+
+  it("keeps the full path as skillPath for a file not named SKILL.md", async () => {
+    const dir = join(tempDir, "alt-file");
+    await mkdir(dir, { recursive: true });
+    const alt = join(dir, "OTHER.md");
+    await writeFile(alt, HIGH_SKILL, "utf-8");
+
+    const report = await evaluateSkill(alt);
+    expect(report.skillPath).toBe(alt);
+    expect(report.skillMdPath).toBe(alt);
+  });
+
+  it("rejects a path that is neither a file nor a directory", async () => {
+    await expect(evaluateSkill("/dev/null")).rejects.toThrow(
+      /not a directory or file/,
+    );
+  });
+
+  it("still evaluates when the skill root cannot be readdir'd", async () => {
+    const dir = join(tempDir, "unreadable-root");
+    await writeSkillMd(dir, HIGH_SKILL);
+    // A README sits at the root, but with readdir failing the evaluator
+    // must degrade to "no rootEntries" instead of crashing.
+    await writeFile(join(dir, "README.md"), "# readme\n", "utf-8");
+    fsCtl.readdirFailures.add(dir);
+
+    const report = await evaluateSkill(dir);
+    expect(report.skillPath).toBe(dir);
+    const structure = report.categories.find((c) => c.id === "structure")!;
+    expect(structure.findings.some((f) => /skill root/i.test(f))).toBe(false);
+    expect(report.topSuggestions).not.toContain(ROOT_README_SUGGESTION);
+  });
+});
+
+describe("buildFixPlan — uncovered planner branches", () => {
+  it("infers effort: high for bodies between 81 and 250 lines", () => {
+    const body = Array.from({ length: 100 }, (_, i) => `line ${i}`).join("\n");
+    const plan = buildFixPlan(
+      `---\nname: x\ndescription: do a thing\n---\n\n${body}\n`,
+    );
+    expect(plan.newContent).toContain("effort: high");
+  });
+
+  it("infers effort: max for bodies over 250 lines", () => {
+    const body = Array.from({ length: 300 }, (_, i) => `line ${i}`).join("\n");
+    const plan = buildFixPlan(
+      `---\nname: x\ndescription: do a thing\n---\n\n${body}\n`,
+    );
+    expect(plan.newContent).toContain("effort: max");
+  });
+
+  it("refuses to reorder frontmatter containing a non key-value line", () => {
+    const plan = buildFixPlan(
+      "---\nversion: 1.0.0\nname: x\n- a stray list line\ndescription: do a thing\n---\n\nbody\n",
+    );
+    expect(plan.applied.some((a) => a.id === "reorder-frontmatter")).toBe(
+      false,
+    );
+    // The raw block is preserved verbatim — unsafe to touch.
+    expect(plan.newContent).toContain("- a stray list line");
+  });
+
+  it("keeps a nested block intact when it contains a blank line", () => {
+    const plan = buildFixPlan(
+      "---\ncreator: Alice\nname: x\ndescription: do a thing\nversion: 1.0.0\nmetadata:\n  author: Jane\n\n  reviewer: Bob\n---\n\nbody\n",
+    );
+    // Simple keys reorder; the nested metadata block (blank line included)
+    // stays verbatim at the end.
+    expect(plan.newContent.indexOf("name: x")).toBeLessThan(
+      plan.newContent.indexOf("description:"),
+    );
+    expect(plan.newContent).toContain(
+      "metadata:\n  author: Jane\n\n  reviewer: Bob",
+    );
+  });
+
+  it("keeps original order between two non-canonical keys when reordering", () => {
+    const plan = buildFixPlan(
+      "---\nzzz-custom: 1\naaa-custom: 2\nname: x\ndescription: do a thing\nversion: 1.0.0\n---\n\nbody\n",
+    );
+    expect(plan.applied.some((a) => a.id === "reorder-frontmatter")).toBe(true);
+    const out = plan.newContent;
+    // Canonical keys move first; unknown keys keep their relative order.
+    expect(out.indexOf("name: x")).toBeLessThan(out.indexOf("zzz-custom"));
+    expect(out.indexOf("zzz-custom")).toBeLessThan(out.indexOf("aaa-custom"));
+  });
+
+  it("appends a trailing newline when the fixed content lacks one", () => {
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\nversion: 1.0.0\n---\n\nbody without newline",
+    );
+    expect(plan.newContent.endsWith("\n")).toBe(true);
+  });
+
+  it("does not duplicate an `effort:` line whose value is empty", () => {
+    // fm.effort is falsy so the planner tries to infer one, but the raw
+    // block already has an `effort:` key — appendFrontmatterKey must bail.
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\nversion: 1.0.0\neffort:\n---\n\nbody\n",
+    );
+    expect(plan.newContent.match(/^effort:/gm)).toHaveLength(1);
+  });
+
+  it("treats metadata.version as a declared version", () => {
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\nmetadata:\n  version: 2.0.0\n---\n\nbody\n",
+    );
+    expect(plan.applied.some((a) => a.id === "add-missing-version")).toBe(
+      false,
+    );
+  });
+
+  it("treats metadata.creator as a declared authorship", () => {
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\nversion: 1.0.0\nmetadata:\n  creator: Jane Doe\n---\n\nbody\n",
+      { gitAuthor: "Git Name" },
+    );
+    expect(plan.applied.some((a) => a.id === "add-missing-author")).toBe(false);
+  });
+
+  it("quotes an author value containing YAML-special characters", () => {
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\nversion: 1.0.0\n---\n\nbody\n",
+      { gitAuthor: "Jane: Doe" },
+    );
+    expect(plan.newContent).toContain('author: "Jane: Doe"');
+  });
+
+  it("skips the author fix when gitAuthor is only whitespace", () => {
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\nversion: 1.0.0\n---\n\nbody\n",
+      { gitAuthor: "   " },
+    );
+    expect(plan.skipped.some((s) => s.id === "add-missing-author")).toBe(true);
+  });
+});
+
+describe("applyFix — error branches", () => {
+  it("rejects when the skill path does not exist", async () => {
+    await expect(
+      applyFix(join(tempDir, "missing"), { dryRun: true }),
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  it("rejects a path that is neither a file nor a directory", async () => {
+    await expect(applyFix("/dev/null", { dryRun: true })).rejects.toThrow(
+      /not a directory or file/,
+    );
+  });
+
+  it("rejects when the directory has no SKILL.md", async () => {
+    const dir = join(tempDir, "no-skillmd");
+    await mkdir(dir, { recursive: true });
+    await expect(applyFix(dir, { dryRun: true })).rejects.toThrow(
+      /SKILL\.md not found at/,
+    );
+  });
+
+  it("resolves a relative skill path against the cwd", async () => {
+    await writeSkillMd(
+      join(tempDir, "rel-fix"),
+      "---\nname: rel-fix\ndescription: does a thing\n---\n\nbody\n",
+    );
+    const prevCwd = process.cwd();
+    process.chdir(tempDir);
+    try {
+      const r = await applyFix("rel-fix", { dryRun: true });
+      expect(r.skillMdPath).toBe(join(process.cwd(), "rel-fix", "SKILL.md"));
+    } finally {
+      process.chdir(prevCwd);
+    }
+  });
+
+  it("accepts a direct SKILL.md file path and writes a .bak next to it", async () => {
+    const dir = join(tempDir, "direct");
+    const skillMd = await writeSkillMd(
+      dir,
+      "---\nname: direct\ndescription: does a thing\n---\n\nbody\n",
+    );
+    const r = await applyFix(skillMd, { dryRun: false, gitAuthor: "Al" });
+    expect(r.backupPath).toBe(`${skillMd}.bak`);
+    const backup = await readFile(r.backupPath!, "utf-8");
+    expect(backup).toContain("name: direct");
+    expect(backup).not.toContain("version:");
+  });
+});
+
+describe("detectGitAuthor — git config fallbacks", () => {
+  it("returns null when git exits non-zero", async () => {
+    runCommandMock.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "" });
+    expect(await detectGitAuthor()).toBeNull();
+  });
+
+  it("returns null when user.name is empty", async () => {
+    runCommandMock.mockResolvedValue({
+      exitCode: 0,
+      stdout: "   \n",
+      stderr: "",
+    });
+    expect(await detectGitAuthor()).toBeNull();
+  });
+
+  it("returns null when git cannot be spawned", async () => {
+    runCommandMock.mockRejectedValue(new Error("spawn git ENOENT"));
+    expect(await detectGitAuthor()).toBeNull();
+  });
+
+  it("returns the trimmed user.name on success", async () => {
+    runCommandMock.mockResolvedValue({
+      exitCode: 0,
+      stdout: "  Jane Doe\n",
+      stderr: "",
+    });
+    expect(await detectGitAuthor()).toBe("Jane Doe");
+    expect(runCommandMock).toHaveBeenCalledWith([
+      "git",
+      "config",
+      "--global",
+      "--get",
+      "user.name",
+    ]);
+  });
+});
+
+describe("formatReport — provider failure branches", () => {
+  it("renders the clean-state line when there are no suggestions", () => {
+    const text = formatReport(mkReport({ topSuggestions: [] }));
+    expect(text).toContain("No suggestions — skill looks great.");
+  });
+
+  it("marks a failing provider verdict in the headline", () => {
+    const text = formatReport(
+      mkReport({
+        providers: [
+          mkProvider({ id: "quality", passed: true }),
+          mkProvider({ id: "strict-lint", passed: false, score: 12 }),
+        ],
+      }),
+    );
+    expect(text).toContain("strict-lint@1.0.0:  12/100  fail");
+  });
+
+  it("omits the findings block for a provider with nothing to say", () => {
+    const text = formatReport(
+      mkReport({
+        providers: [mkProvider({ findings: [] })],
+      }),
+    );
+    expect(text).toContain("extra-provider@1.0.0:  42/100  pass");
+    expect(text).not.toContain("extra-provider@1.0.0 findings:");
+    expect(text).not.toContain("extra-provider@1.0.0 breakdown:");
+  });
+
+  it("falls back to findings when raw.checks is not an array", () => {
+    const text = formatReport(
+      mkReport({
+        providers: [
+          mkProvider({
+            raw: { checks: "not-an-array" },
+            findings: [{ severity: "error" as const, message: "lint blew up" }],
+          }),
+        ],
+      }),
+    );
+    expect(text).toContain("extra-provider@1.0.0 findings:");
+    expect(text).toContain("[error] lint blew up");
+  });
+
+  it("falls back to findings when a check entry is not an object", () => {
+    const text = formatReport(
+      mkReport({
+        providers: [
+          mkProvider({
+            raw: { checks: [null, 42] },
+            findings: [
+              { severity: "warning" as const, message: "partial payload" },
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(text).toContain("[warning] partial payload");
+  });
+
+  it("falls back to findings when a check entry has wrong field types", () => {
+    const text = formatReport(
+      mkReport({
+        providers: [
+          mkProvider({
+            raw: {
+              checks: [
+                {
+                  id: 7,
+                  label: "bad id type",
+                  passed: true,
+                  severity: "error",
+                  message: "m",
+                },
+              ],
+            },
+            findings: [
+              { severity: "error" as const, message: "schema mismatch" },
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(text).toContain("[error] schema mismatch");
+  });
+
+  it("renders the checks breakdown with pass/warning/error marks", () => {
+    const text = formatReport(
+      mkReport({
+        providers: [
+          mkProvider({
+            raw: {
+              checks: [
+                {
+                  id: "ok",
+                  label: "passing check",
+                  passed: true,
+                  severity: "error",
+                  message: "unused",
+                },
+                {
+                  id: "warn",
+                  label: "soft check",
+                  passed: false,
+                  severity: "warning",
+                  message: "could be better",
+                },
+                {
+                  id: "bad",
+                  label: "hard check",
+                  passed: false,
+                  severity: "error",
+                  message: "is broken",
+                },
+              ],
+            },
+          }),
+        ],
+      }),
+    );
+    expect(text).toContain("extra-provider@1.0.0 breakdown:");
+    expect(text).toContain("√ passing check");
+    expect(text).toContain("⚠ soft check");
+    expect(text).toContain("[warning] could be better");
+    expect(text).toContain("× hard check");
+    expect(text).toContain("[error] is broken");
+  });
+});
+
+describe("formatFixPreview — empty and partial results", () => {
+  const base = mkReport();
+
+  it("reports a clean skill when nothing applied and nothing skipped", () => {
+    const preview = formatFixPreview({
+      report: base,
+      applied: [],
+      skipped: [],
+      diff: "",
+      dryRun: false,
+      backupPath: null,
+      skillMdPath: "/virtual/x/SKILL.md",
+    });
+    expect(preview).toBe("No fixes needed — SKILL.md is already clean.");
+  });
+
+  it("uses 'Applied' wording and the Backup line for a real fix run", () => {
+    const preview = formatFixPreview({
+      report: base,
+      applied: [{ id: "add-missing-version", description: "Add `version`." }],
+      skipped: [],
+      diff: "--- a/SKILL.md\n+++ b/SKILL.md\n@@ -1,1 +1,2 @@\n+version: 0.1.0",
+      dryRun: false,
+      backupPath: "/virtual/x/SKILL.md.bak",
+      skillMdPath: "/virtual/x/SKILL.md",
+    });
+    expect(preview).toContain("Applied 1 fix(es):");
+    expect(preview).not.toContain("Skipped");
+    expect(preview).toContain("Diff:");
+    expect(preview).toContain("+version: 0.1.0");
+    expect(preview).toContain("Backup: /virtual/x/SKILL.md.bak");
+  });
+
+  it("renders only the skipped block when nothing was auto-fixable", () => {
+    const preview = formatFixPreview({
+      report: base,
+      applied: [],
+      skipped: [
+        {
+          id: "missing-description",
+          description: "Missing `description` — left to the author.",
+        },
+      ],
+      diff: "",
+      dryRun: true,
+      backupPath: null,
+      skillMdPath: "/virtual/x/SKILL.md",
+    });
+    expect(preview).not.toContain("fix(es):");
+    expect(preview).toContain("Skipped 1 issue(s) (not auto-fixable):");
+    expect(preview).toContain("Missing `description`");
+  });
+});

--- a/src/formatter-detail.test.ts
+++ b/src/formatter-detail.test.ts
@@ -1,0 +1,431 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  colorEvalScore,
+  formatSkillDetail,
+  formatSkillInspect,
+} from "./formatter-detail";
+import type { SkillInfo } from "./utils/types";
+
+// Issue #674 — sibling coverage for formatter-detail.ts. formatter.test.ts
+// exercises the renderers through the formatter.ts facade; this file pins the
+// branches the facade tests never reach: the allowed-tools warning block,
+// provider-keyed eval summary ordering/fallbacks, and the colour paths.
+
+function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    name: "test-skill",
+    version: "1.0.0",
+    description: "A test skill",
+    creator: "",
+    license: "",
+    compatibility: "",
+    allowedTools: [],
+    dirName: "test-skill",
+    path: "/home/user/.claude/skills/test-skill",
+    originalPath: "~/.claude/skills/test-skill",
+    location: "global-claude",
+    scope: "global",
+    provider: "claude",
+    providerLabel: "Claude Code",
+    isSymlink: false,
+    symlinkTarget: null,
+    realPath: "/home/user/.claude/skills/test-skill",
+    fileCount: 3,
+    effort: undefined,
+    ...overrides,
+  };
+}
+
+function makeEvalSummary(
+  overrides: Partial<NonNullable<SkillInfo["evalSummary"]>> = {},
+): NonNullable<SkillInfo["evalSummary"]> {
+  return {
+    overallScore: 87,
+    grade: "B",
+    categories: [{ id: "structure", name: "Structure", score: 9, max: 10 }],
+    evaluatedAt: "2026-04-20T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("formatSkillDetail — allowed tools and warnings", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("renders the risk warning for high-risk tools", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({ allowedTools: ["Bash", "Read"] }),
+    );
+    expect(output).toContain("Allowed Tools:");
+    expect(output).toContain("Bash");
+    expect(output).toContain("! This skill can execute shell commands");
+  });
+
+  test("lists tools without a warning for low-risk tools", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({ allowedTools: ["Read", "Grep"] }),
+    );
+    expect(output).toContain("Allowed Tools:");
+    expect(output).toContain("Read");
+    expect(output).not.toContain("This skill can");
+  });
+
+  test("falls back to countFiles and renders token count when set", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({
+        fileCount: undefined,
+        path: "/nonexistent/skill/dir",
+        tokenCount: 512,
+      }),
+    );
+    // countFiles swallows readdir failures → 0.
+    expect(output).toContain("File Count: 0");
+    expect(output).toContain("Est. Tokens: ~512 tokens");
+  });
+
+  test("renders the warnings block for skill warnings", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({
+        warnings: [
+          { category: "missing-version", message: "No version field" },
+        ],
+      }),
+    );
+    expect(output).toContain("Warnings:");
+    expect(output).toContain("[missing-version] No version field");
+  });
+});
+
+describe("formatSkillDetail — eval summary fallbacks", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("falls back to evalSummary when evalSummaries is an empty map", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({
+        evalSummary: makeEvalSummary(),
+        evalSummaries: {},
+      }),
+    );
+    expect(output).toContain("Overall: 87 / 100");
+  });
+
+  test("omits the categories block when a summary has none", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({ evalSummary: makeEvalSummary({ categories: [] }) }),
+    );
+    expect(output).toContain("Overall: 87 / 100");
+    expect(output).not.toContain("Categories:");
+  });
+
+  test("omits the version suffix when evaluatedVersion is unset", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({ evalSummary: makeEvalSummary() }),
+    );
+    expect(output).toContain("Evaluated: 2026-04-20T10:00:00.000Z");
+    expect(output).not.toContain("— version");
+  });
+
+  test("orders provider summaries quality-first, then alphabetical", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({
+        evalSummaries: {
+          "zeta-provider": makeEvalSummary({
+            providerId: "zeta-provider",
+            providerVersion: "2.0.0",
+          }),
+          // Inserted last in the record but must sort first.
+          quality: makeEvalSummary({
+            providerId: "quality",
+            providerVersion: "1.0.0",
+          }),
+          "alpha-provider": makeEvalSummary({
+            providerId: "alpha-provider",
+            providerVersion: "0.1.0",
+          }),
+        },
+      }),
+    );
+    const q = output.indexOf("quality@1.0.0");
+    const a = output.indexOf("alpha-provider@0.1.0");
+    const z = output.indexOf("zeta-provider@2.0.0");
+    expect(q).toBeGreaterThanOrEqual(0);
+    expect(q).toBeLessThan(a);
+    expect(a).toBeLessThan(z);
+  });
+
+  test("falls back to '?' for a provider id without a version", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({
+        evalSummaries: {
+          quality: makeEvalSummary({
+            providerId: "quality",
+            providerVersion: "1.0.0",
+          }),
+          other: makeEvalSummary({
+            providerId: "unversioned",
+            providerVersion: undefined,
+          }),
+        },
+      }),
+    );
+    expect(output).toContain("unversioned@?");
+  });
+
+  test("sorts two provider-less summaries by their quality label", async () => {
+    // Both entries lack providerId — the comparator's `?? "quality"`
+    // fallback fires on both sides of the comparison.
+    const output = await formatSkillDetail(
+      makeSkill({
+        evalSummaries: {
+          second: makeEvalSummary({ overallScore: 50, grade: "D" }),
+          first: makeEvalSummary({ overallScore: 90, grade: "A" }),
+        },
+      }),
+    );
+    expect(output.match(/quality: \d+ \/ 100/g)?.length).toBe(2);
+  });
+
+  test("labels a provider-less summary as quality in multi-provider mode", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({
+        evalSummaries: {
+          // No providerId/providerVersion → label "quality", version "?".
+          bare: makeEvalSummary({ overallScore: 55, grade: "D" }),
+          other: makeEvalSummary({
+            providerId: "other",
+            providerVersion: "3.0.0",
+            overallScore: 99,
+            grade: "A",
+          }),
+        },
+      }),
+    );
+    expect(output).toContain("quality: 55 / 100  (D)");
+    expect(output).toContain("other@3.0.0: 99 / 100  (A)");
+    // Multi-provider mode prefixes the categories heading with the label.
+    expect(output).toContain("Categories (quality):");
+  });
+});
+
+describe("formatSkillInspect — shared-field branches", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  function makePair(refOverrides: Partial<SkillInfo>): SkillInfo[] {
+    return [
+      makeSkill(refOverrides),
+      makeSkill({
+        providerLabel: "Codex",
+        provider: "codex",
+        path: "/home/user/.codex/skills/test-skill",
+      }),
+    ];
+  }
+
+  test("renders compatibility, effort and token count when set", async () => {
+    const output = await formatSkillInspect(
+      makePair({
+        compatibility: "Claude Code >= 1.0",
+        effort: "high",
+        tokenCount: 2048,
+      }),
+    );
+    expect(output).toContain("Compatibility: Claude Code >= 1.0");
+    expect(output).toContain("Effort: high");
+    expect(output).toContain("Est. Tokens: ~2k tokens");
+  });
+
+  test("falls back to countFiles when fileCount is unset", async () => {
+    const output = await formatSkillInspect(
+      makePair({ fileCount: undefined, path: "/nonexistent/skill/dir" }),
+    );
+    // countFiles swallows readdir failures → 0.
+    expect(output).toContain("File Count: 0");
+  });
+
+  test("renders the multi-provider eval block for the reference skill", async () => {
+    const output = await formatSkillInspect(
+      makePair({
+        evalSummaries: {
+          quality: makeEvalSummary({
+            providerId: "quality",
+            providerVersion: "1.0.0",
+            evaluatedVersion: "0.9.0",
+          }),
+          "best-practice": makeEvalSummary({
+            providerId: "best-practice",
+            providerVersion: "2.1.0",
+            overallScore: 64,
+            grade: "D",
+          }),
+        },
+      }),
+    );
+    expect(output).toContain("quality@1.0.0: 87 / 100  (B)");
+    expect(output).toContain("— version 0.9.0");
+    expect(output).toContain("best-practice@2.1.0: 64 / 100  (D)");
+    expect(output).toContain("Structure");
+  });
+
+  test("renders a single eval summary without provider prefix", async () => {
+    const output = await formatSkillInspect(
+      makePair({ evalSummary: makeEvalSummary({ categories: [] }) }),
+    );
+    expect(output).toContain("Overall: 87 / 100  (B)");
+    expect(output).not.toContain("quality@");
+  });
+
+  test("renders the empty-eval state when no summary exists", async () => {
+    const output = await formatSkillInspect(makePair({}));
+    expect(output).toContain("Not available — run `asm eval");
+  });
+
+  test("falls back to '?' for an eval summary without providerVersion", async () => {
+    const output = await formatSkillInspect(
+      makePair({
+        evalSummaries: {
+          quality: makeEvalSummary({ providerId: "quality" }),
+          other: makeEvalSummary({ providerId: "unversioned" }),
+        },
+      }),
+    );
+    expect(output).toContain("quality@?");
+    expect(output).toContain("unversioned@?");
+  });
+
+  test("renders the allowed-tools block and warning for the reference skill", async () => {
+    const output = await formatSkillInspect(
+      makePair({ allowedTools: ["Bash", "Write"] }),
+    );
+    expect(output).toContain("Allowed Tools:");
+    expect(output).toContain(
+      "! This skill can execute shell commands and modify files",
+    );
+  });
+
+  test("lists allowed tools without a warning for low-risk tools", async () => {
+    const output = await formatSkillInspect(
+      makePair({ allowedTools: ["Read", "Grep"] }),
+    );
+    expect(output).toContain("Allowed Tools:");
+    expect(output).not.toContain("This skill can");
+  });
+});
+
+describe("colourised output", () => {
+  const origIsTTY = process.stdout.isTTY;
+  const origNoColor = process.env.NO_COLOR;
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: origIsTTY,
+      configurable: true,
+    });
+    if (origNoColor === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = origNoColor;
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  function forceColor(): void {
+    delete process.env.NO_COLOR;
+    delete (globalThis as any).__CLI_NO_COLOR;
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+  }
+
+  test("formatSkillDetail emits ANSI escapes when colour is on", async () => {
+    forceColor();
+    const output = await formatSkillDetail(
+      makeSkill({
+        allowedTools: ["Bash"],
+        warnings: [{ category: "empty-body", message: "No body" }],
+        evalSummaries: {
+          quality: makeEvalSummary({
+            providerId: "quality",
+            providerVersion: "1.0.0",
+          }),
+          other: makeEvalSummary({ providerId: "other" }),
+        },
+      }),
+    );
+    expect(output).toContain("\x1b[");
+    // Colour on → the warning icon is wrapped, not a bare "!".
+    expect(output).toContain("\x1b[33m!\x1b[0m");
+    // Multi-provider categories heading is dimmed when coloured.
+    expect(output).toContain("\x1b[2m");
+  });
+
+  test("formatSkillDetail dims the single-provider categories heading", async () => {
+    forceColor();
+    const output = await formatSkillDetail(
+      makeSkill({ evalSummary: makeEvalSummary() }),
+    );
+    expect(output).toContain("\x1b[2m  Categories:");
+  });
+
+  test("formatSkillDetail dims the empty-eval hint when colour is on", async () => {
+    forceColor();
+    const output = await formatSkillDetail(makeSkill());
+    expect(output).toContain("\x1b[2m");
+    expect(output).toContain("Not available");
+  });
+
+  test("formatSkillInspect emits ANSI escapes when colour is on", async () => {
+    forceColor();
+    const output = await formatSkillInspect([
+      makeSkill({
+        allowedTools: ["Write"],
+        warnings: [{ category: "empty-body", message: "No body" }],
+        evalSummary: makeEvalSummary(),
+      }),
+      makeSkill({
+        providerLabel: "Codex",
+        provider: "codex",
+        path: "/home/user/.codex/skills/test-skill",
+        isSymlink: true,
+        symlinkTarget: "/opt/target",
+        warnings: [{ category: "missing-version", message: "No version" }],
+      }),
+    ]);
+    expect(output).toContain("\x1b[");
+    expect(output).toContain("\x1b[34;1m"); // blueBold title
+    // Aggregated warnings render with the yellow icon when coloured.
+    expect(output).toContain("\x1b[33m!\x1b[0m");
+    // The eval block's "Evaluated:" label is dimmed when coloured.
+    expect(output).toContain("\x1b[2mEvaluated:");
+
+    // A reference skill with no eval gets the dimmed hint instead.
+    const noEval = await formatSkillInspect([makeSkill(), makeSkill()]);
+    expect(noEval).toContain("Not available");
+    expect(noEval).toContain("\x1b[2m");
+  });
+
+  test("colorEvalScore tiers map to green/cyan/yellow/red", () => {
+    forceColor();
+    expect(colorEvalScore(95)).toBe("\x1b[32m95\x1b[0m");
+    expect(colorEvalScore(85)).toBe("\x1b[36m85\x1b[0m");
+    expect(colorEvalScore(70)).toBe("\x1b[33m70\x1b[0m");
+    expect(colorEvalScore(40)).toBe("\x1b[31m40\x1b[0m");
+  });
+
+  test("colorEvalScore returns the bare number when colour is off", () => {
+    // Force the no-colour path explicitly so the assertion is TTY-agnostic.
+    (globalThis as any).__CLI_NO_COLOR = true;
+    expect(colorEvalScore(95)).toBe("95");
+  });
+});


### PR DESCRIPTION
Closes #674

## Summary

Adds dedicated sibling test files for the three remaining under-tested modules from epic #656 / F-TEST-003 — `src/evaluator-batch.ts`, `src/evaluator-fix.ts`, and `src/formatter-detail.ts` — with the emphasis the issue asked for on error and failure branches rather than line-count coverage. 86 new tests exercise local/GitHub input resolution failures, missing-skill and missing-file errors, git-author detection failure, applyFix dry-run/backup/write paths, suggestion deduplication, provider-less and unversioned summary fallbacks, empty states, warning rendering, and color/no-color output tiers. All three modules now sit at 100% statement coverage; the only residual branch misses are defensive guards unreachable through the public API and one V8 implicit-else instrumentation artifact.

## Approach

Option 2 — dedicated sibling test files per module, in the established `vi.hoisted`/`vi.mock` style of `src/evaluator-pii-lint.test.ts`, using real temp-directory fixtures for filesystem-dependent behavior and dependency mocks only for external command/FS failure seams.

## Decision Record

- **Root cause:** The three modules were exercised only indirectly through the `src/evaluator.test.ts` / `src/formatter.test.ts` facade suites, which cover the happy paths but never drive the failure branches — input resolution errors, missing skills/files, git-author failure, provider-less formatting fallbacks, and warning/empty-state rendering were all uncovered.
- **Options considered:** Option 1 — extend the existing facade test files in place; Option 2 — dedicated sibling test files per module; Option 3 — snapshot-level coverage via the public facades only.
- **Options rejected:** Option 1 — the facade files are already large and facade-level inputs cannot reach several failure branches (e.g., `resolveBatchInputs` cleanup no-ops, formatter's provider-less sort) without contorting public API calls; Option 3 — snapshots would raise line counts without asserting the failure-branch behavior the issue targets.
- **Selected option:** Option 2 — dedicated sibling test files.
- **Residual risk:** Three residual uncovered branches are accepted as unreachable: `evaluator-fix.ts:83,177` (defensive aggregation/suggestion guards — scores are capped before these branches, so they cannot fire on valid scorer output) and `formatter-detail.ts:213` (a V8 implicit-else instrumentation artifact verified exercised via an in-repo probe). The CLAUDE.md coverage baseline text is unchanged; real coverage moved to 83.2% lines / 75.26% branches, above the recorded 82.69%/73.74% floor — a re-baseline note can ride a later doc change.
- **Effort profile:** full (issue Effort M — adaptive effort kept the full pipeline).

Analyzed at: `refactor/674-4-2-test-the-three-remaining @ 2d2a846` (2026-09-12)

## Changes

| File | Change |
|------|--------|
| `src/evaluator-batch.test.ts` | New — 18 tests: local relative-path resolution after `chdir`, directory/missing-input errors, child-skill discovery, cleanup no-ops, concurrency, per-skill error aggregation, human and machine output builders (incl. missing-`findings` fallback) |
| `src/evaluator-fix.test.ts` | New — 43 tests: `evaluateSkillContent` async/sync, missing metadata and suggestion deduplication, root-README promotion, missing skill path/file errors, `detectGitAuthor` success/failure via mocked `runCommand`, `applyFix` dry-run/backup/write/report paths |
| `src/formatter-detail.test.ts` | New — 25 tests: provider-less summary labels and sorting, missing provider version (`@?`), empty states, allowed-tools and high-risk warnings vs low-risk silence, forced-TTY color output, `__CLI_NO_COLOR` no-color output, `colorEvalScore` tiers, multi/single-provider category rendering |

## Test Results

- Unit tests: 2886 passed (93 files; +86 over the 2800-test baseline)
- Integration tests: skipped (no separate integration leg)
- E2e tests: passed (pre-push `tests/e2e/node-e2e.test.ts`)
- Build: passed (pre-push `npm run build`)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Each of the three modules gains a sibling test file covering its error branches | pass | `src/evaluator-batch.test.ts`, `src/evaluator-fix.test.ts`, `src/formatter-detail.test.ts` — all import the target module directly; coverage run shows 100% statements on all three (residual branches documented above as unreachable) |
| `CI=true npm test` passes at 2793/2793 (baseline-green holds) | pass | `CI=true npm test` → 93 files / 2886 tests, 0 failures. Note: the issue's 2793 figure predates dependency #673/#695, which grew the baseline to 2800; this change adds 86 more, and baseline-green holds |

<!-- gitissue:qa v1 head=8ae042b9c09b02b5a1238f7abc255e5219c0355a profile=full cycles=1 review=clean tests=2886@8ae042b9c09b02b5a1238f7abc255e5219c0355a ui=none -->
