### PR TITLE
fix(types): eliminate any in product source (#675)

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -6,6 +6,7 @@ import { getConfigDir } from "./config";
 import { readLock } from "./utils/lock";
 import { loadAllIndices } from "./skill-index";
 import { repoBundlesForIndex } from "./repo-bundles";
+import { errorMessage } from "./utils/errors";
 import type {
   BundleManifest,
   BundleSkillRef,
@@ -190,11 +191,11 @@ export async function readBundleFile(
   let raw: string;
   try {
     raw = await readFile(filePath, "utf-8");
-  } catch (err: any) {
-    if (err?.code === "ENOENT") {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       throw new Error(`Bundle file not found: ${filePath}`, { cause: err });
     }
-    throw new Error(`Failed to read bundle file: ${err.message}`, {
+    throw new Error(`Failed to read bundle file: ${errorMessage(err)}`, {
       cause: err,
     });
   }
@@ -236,14 +237,14 @@ export async function loadBundle(nameOrPath: string): Promise<BundleManifest> {
 
   try {
     return await readBundleFile(filePath);
-  } catch (err: any) {
+  } catch (err) {
     // If not found in user dir, fall back to predefined (shipped) bundles
-    if (err?.message?.includes("Bundle file not found")) {
+    if (errorMessage(err).includes("Bundle file not found")) {
       const predefinedPath = join(PREDEFINED_BUNDLE_DIR, filename);
       try {
         return await readBundleFile(predefinedPath);
-      } catch (predefinedErr: any) {
-        if (predefinedErr?.message?.includes("Bundle file not found")) {
+      } catch (predefinedErr) {
+        if (errorMessage(predefinedErr).includes("Bundle file not found")) {
           const repoBundle = await findRepoIndexBundle(nameOrPath);
           if (repoBundle) return repoBundle;
           throw new Error(`Bundle file not found: ${filePath}`, {
@@ -366,8 +367,8 @@ export async function removeBundle(name: string): Promise<boolean> {
     await rm(filePath);
     debug(`bundle: removed ${filePath}`);
     return true;
-  } catch (err: any) {
-    if (err?.code === "ENOENT") {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       return false;
     }
     throw err;

--- a/src/commands/activate.ts
+++ b/src/commands/activate.ts
@@ -139,7 +139,7 @@ export async function cmdDeactivate(args: ParsedArgs) {
     provider = (
       await resolveProvider(config, args.flags.provider, process.stdin.isTTY)
     ).provider;
-  } catch (err: any) {
+  } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     error(message);
     process.exit(2);
@@ -164,7 +164,7 @@ export async function cmdDeactivate(args: ParsedArgs) {
     console.log(
       `${ansi.green("✓")} deactivated ${result.name} (${result.provider}/${result.scope}) -> ${result.target}`,
     );
-  } catch (err: any) {
+  } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (args.flags.json) {
       console.log(JSON.stringify({ error: message }, null, 2));

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -37,6 +37,7 @@ import {
   formatOverlapReport,
   formatOverlapReportJSON,
 } from "../installed-overlap";
+import { errorMessage } from "../utils/errors";
 
 import { formatAuditMachineData, error } from "./shared";
 import type { ParsedArgs } from "../cli";
@@ -443,19 +444,20 @@ export async function cmdAuditSecuritySource(
     } else {
       console.log(formatSecurityReport(report));
     }
-  } catch (err: any) {
+  } catch (err) {
+    const message = errorMessage(err);
     if (args.flags.machine) {
       console.log(
         formatMachineError(
           "audit security",
           ErrorCodes.AUDIT_FAILED,
-          err.message,
+          message,
           startTime,
         ),
       );
       process.exit(1);
     }
-    error(err.message);
+    error(message);
     process.exit(1);
   } finally {
     if (tempDir) {

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -27,6 +27,7 @@ import {
   removeBundle,
 } from "../bundler";
 import type { BundleSkillRef } from "../utils/types";
+import { errorMessage } from "../utils/errors";
 import { join as joinPath } from "path";
 
 import { error, readLine } from "./shared";
@@ -221,8 +222,8 @@ export async function cmdBundle(args: ParsedArgs) {
       let bundle;
       try {
         bundle = await loadBundle(nameOrPath);
-      } catch (err: any) {
-        error(err.message);
+      } catch (err) {
+        error(errorMessage(err));
         process.exit(1);
       }
 
@@ -289,8 +290,8 @@ export async function cmdBundle(args: ParsedArgs) {
           isTTY: !!process.stdin.isTTY,
           yes: !!args.flags.yes,
         });
-      } catch (err: any) {
-        error(err.message);
+      } catch (err) {
+        error(errorMessage(err));
         process.exit(1);
       }
 
@@ -372,8 +373,8 @@ export async function cmdBundle(args: ParsedArgs) {
             // Check if skill already exists; skip unless --force
             try {
               await checkConflict(plan.targetDir, plan.force);
-            } catch (conflictErr: any) {
-              if (conflictErr.message?.includes("--force")) {
+            } catch (conflictErr) {
+              if (errorMessage(conflictErr).includes("--force")) {
                 results.push({
                   name: skill.name,
                   status: "skipped",
@@ -399,13 +400,14 @@ export async function cmdBundle(args: ParsedArgs) {
               await cleanupTemp(tempDir);
             }
           }
-        } catch (err: any) {
+        } catch (err) {
+          const reason = errorMessage(err);
           results.push({
             name: skill.name,
             status: "failed",
-            reason: err.message,
+            reason,
           });
-          console.error(`    ${ansi.red("!!!")} ${skill.name}: ${err.message}`);
+          console.error(`    ${ansi.red("!!!")} ${skill.name}: ${reason}`);
         }
       }
 
@@ -537,8 +539,8 @@ export async function cmdBundle(args: ParsedArgs) {
       let bundle;
       try {
         bundle = await loadBundle(nameOrPath);
-      } catch (err: any) {
-        error(err.message);
+      } catch (err) {
+        error(errorMessage(err));
         process.exit(1);
       }
 
@@ -593,8 +595,8 @@ export async function cmdBundle(args: ParsedArgs) {
       let removed: boolean;
       try {
         removed = await removeBundle(bundleName);
-      } catch (err: any) {
-        error(err.message);
+      } catch (err) {
+        error(errorMessage(err));
         process.exit(1);
       }
 
@@ -620,8 +622,8 @@ export async function cmdBundle(args: ParsedArgs) {
       let bundle: import("../utils/types").BundleManifest;
       try {
         bundle = await loadBundle(bundleName);
-      } catch (err: any) {
-        error(err.message);
+      } catch (err) {
+        error(errorMessage(err));
         process.exit(1);
       }
 
@@ -772,8 +774,8 @@ export async function cmdBundle(args: ParsedArgs) {
       let bundle: import("../utils/types").BundleManifest;
       try {
         bundle = await loadBundle(bundleName);
-      } catch (err: any) {
-        error(err.message);
+      } catch (err) {
+        error(errorMessage(err));
         process.exit(1);
       }
 

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -41,6 +41,7 @@ import {
   ErrorCodes,
   redirectConsoleToStderr,
 } from "../utils/machine";
+import { errorMessage } from "../utils/errors";
 import { join as joinPath } from "path";
 import type { TransportMode } from "../utils/types";
 
@@ -216,8 +217,8 @@ async function runSingleEval(target: EvalTarget): Promise<{
       },
       error: null,
     };
-  } catch (err: any) {
-    return { report: null, error: err?.message ?? String(err) };
+  } catch (err) {
+    return { report: null, error: errorMessage(err) };
   }
 }
 
@@ -321,20 +322,20 @@ export async function cmdEval(args: ParsedArgs) {
       console.log("");
       console.log(formatFixPreview(fix));
       return;
-    } catch (err: any) {
+    } catch (err) {
       if (args.flags.machine) {
         restoreConsole?.();
         console.log(
           formatMachineError(
             "eval",
             ErrorCodes.SKILL_NOT_FOUND,
-            err?.message ?? String(err),
+            errorMessage(err),
             startTime,
           ),
         );
         process.exit(1);
       }
-      error(err?.message ?? String(err));
+      error(errorMessage(err));
       process.exit(1);
     }
     return;
@@ -348,20 +349,20 @@ export async function cmdEval(args: ParsedArgs) {
       fetchRemote: (input: string) =>
         fetchRemoteSkillDir(input, args.flags.transport, args.flags.keep),
     });
-  } catch (err: any) {
+  } catch (err) {
     if (args.flags.machine) {
       restoreConsole?.();
       console.log(
         formatMachineError(
           "eval",
           ErrorCodes.SKILL_NOT_FOUND,
-          err?.message ?? String(err),
+          errorMessage(err),
           startTime,
         ),
       );
       process.exit(1);
     }
-    error(err?.message ?? String(err));
+    error(errorMessage(err));
     process.exit(1);
   }
 
@@ -502,20 +503,20 @@ export async function cmdEval(args: ParsedArgs) {
       // formatBatchSummary already prints provenance for remote inputs, so
       // we deliberately skip the extra print here to avoid duplication.
     }
-  } catch (err: any) {
+  } catch (err) {
     if (args.flags.machine) {
       restoreConsole?.();
       console.log(
         formatMachineError(
           "eval",
           ErrorCodes.SKILL_NOT_FOUND,
-          err?.message ?? String(err),
+          errorMessage(err),
           startTime,
         ),
       );
       process.exit(1);
     }
-    error(err?.message ?? String(err));
+    error(errorMessage(err));
     process.exit(1);
   } finally {
     if (resolved) {

--- a/src/commands/export-import.ts
+++ b/src/commands/export-import.ts
@@ -14,6 +14,7 @@ import type {
 } from "../utils/types";
 
 import { error, readLine } from "./shared";
+import { errorMessage } from "../utils/errors";
 import type { ParsedArgs } from "../cli";
 
 function printExportHelp() {
@@ -182,8 +183,8 @@ export async function cmdImport(args: ParsedArgs) {
   let manifest;
   try {
     manifest = await readManifestFile(absPath);
-  } catch (err: any) {
-    error(err.message);
+  } catch (err) {
+    error(errorMessage(err));
     process.exit(1);
   }
 

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -36,6 +36,7 @@ import { estimateTokenCount } from "../utils/token-count";
 import { findLibrarySkill, listLibrarySkills } from "../library";
 import { join as joinPath } from "path";
 import type { GetResult, GetSecurityVerdict, GetTier } from "../utils/types";
+import { errorMessage } from "../utils/errors";
 
 import { error } from "./shared";
 import type { ParsedArgs } from "../cli";
@@ -391,8 +392,8 @@ export async function cmdGet(args: ParsedArgs) {
       process.stdout.write(result.content);
       if (!result.content.endsWith("\n")) process.stdout.write("\n");
     }
-  } catch (err: any) {
-    const message = err?.message || String(err);
+  } catch (err) {
+    const message = errorMessage(err) || String(err);
     const candidates =
       err instanceof AmbiguousGetError ? err.candidates : undefined;
     if (args.flags.machine) {

--- a/src/commands/install-run.ts
+++ b/src/commands/install-run.ts
@@ -46,6 +46,7 @@ import {
 } from "../utils/machine";
 import { relative as relativePath } from "path";
 import { toPortableRelativePath } from "../utils/fs";
+import { errorMessage } from "../utils/errors";
 import { error, readLine } from "./shared";
 import type { ParsedArgs } from "../cli";
 import { promptInstallScope } from "./install-prompts";
@@ -232,8 +233,8 @@ export async function cmdInstall(args: ParsedArgs) {
         if (!stats.isDirectory()) {
           throw new Error(`Path is not a directory: ${localPath}`);
         }
-      } catch (err: any) {
-        if (err.code === "ENOENT") {
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
           throw new Error(`Path does not exist: ${localPath}`, { cause: err });
         }
         throw err;
@@ -403,8 +404,8 @@ export async function cmdInstall(args: ParsedArgs) {
               `No SKILL.md found at path "${effectivePath}" in the repository.`,
             );
           }
-        } catch (statErr: any) {
-          if (statErr && statErr.code === "ENOENT") {
+        } catch (statErr) {
+          if ((statErr as NodeJS.ErrnoException | null)?.code === "ENOENT") {
             throw new Error(
               `No SKILL.md found at path "${effectivePath}" in the repository.`,
               { cause: statErr },
@@ -796,13 +797,14 @@ export async function cmdInstall(args: ParsedArgs) {
           } catch {
             // Lock write failure is non-fatal
           }
-        } catch (linkErr: any) {
+        } catch (linkErr) {
+          const linkMessage = errorMessage(linkErr);
           failures.push({
             name: inspection.metadata.name,
-            error: linkErr.message,
+            error: linkMessage,
           });
           console.error(
-            `${progress}${ansi.red("✗")} ${ansi.bold(inspection.metadata.name)} — ${ansi.red(linkErr.message)}`,
+            `${progress}${ansi.red("✗")} ${ansi.bold(inspection.metadata.name)} — ${ansi.red(linkMessage)}`,
           );
         }
         continue;
@@ -862,13 +864,14 @@ export async function cmdInstall(args: ParsedArgs) {
             // Lock write failure is non-fatal
           }
         }
-      } catch (installErr: any) {
+      } catch (installErr) {
+        const installMessage = errorMessage(installErr);
         failures.push({
           name: inspection.metadata.name,
-          error: installErr.message,
+          error: installMessage,
         });
         console.error(
-          `${progress}${ansi.red("✗")} ${ansi.bold(inspection.metadata.name)} — ${ansi.red(installErr.message)}`,
+          `${progress}${ansi.red("✗")} ${ansi.bold(inspection.metadata.name)} — ${ansi.red(installMessage)}`,
         );
       }
     }
@@ -926,10 +929,13 @@ export async function cmdInstall(args: ParsedArgs) {
         `\n${ansi.green(`Done! Installed ${results.length} skill(s) successfully.`)}`,
       );
     }
-  } catch (err: any) {
+  } catch (err) {
     // Remove signal handlers
     process.removeListener("SIGINT", cleanup);
     process.removeListener("SIGTERM", cleanup);
+
+    const message = errorMessage(err);
+    const duplicates = (err as { duplicates?: unknown } | null)?.duplicates;
 
     if (args.flags.machine) {
       restoreConsole?.();
@@ -937,22 +943,22 @@ export async function cmdInstall(args: ParsedArgs) {
         formatMachineError(
           "install",
           ErrorCodes.INSTALL_FAILED,
-          err.message,
+          message,
           startTime,
-          err?.duplicates ? { duplicates: err.duplicates } : undefined,
+          duplicates ? { duplicates } : undefined,
         ),
       );
     } else if (args.flags.json) {
       const payload: Record<string, unknown> = {
         success: false,
-        error: err.message,
+        error: message,
       };
-      if (err?.duplicates) {
-        payload.duplicates = err.duplicates;
+      if (duplicates) {
+        payload.duplicates = duplicates;
       }
       console.log(JSON.stringify(payload, null, 2));
     } else {
-      error(err.message);
+      error(message);
     }
     process.exit(1);
   } finally {

--- a/src/commands/outdated-update.ts
+++ b/src/commands/outdated-update.ts
@@ -14,6 +14,7 @@ import {
 } from "../utils/machine";
 
 import { error } from "./shared";
+import { errorMessage } from "../utils/errors";
 import type { ParsedArgs } from "../cli";
 
 function printOutdatedHelp() {
@@ -72,20 +73,21 @@ export async function cmdOutdated(args: ParsedArgs) {
     if (summary.outdatedCount > 0) {
       process.exitCode = 1;
     }
-  } catch (err: any) {
+  } catch (err) {
+    const message = errorMessage(err);
     if (args.flags.machine) {
       restoreConsole?.();
       console.log(
         formatMachineError(
           "outdated",
           ErrorCodes.UNKNOWN_ERROR,
-          err.message,
+          message,
           startTime,
         ),
       );
       process.exit(1);
     }
-    error(err.message);
+    error(message);
     process.exit(1);
   }
 }
@@ -218,20 +220,21 @@ export async function cmdUpdate(args: ParsedArgs) {
     if (summary.failedCount > 0) {
       process.exitCode = 1;
     }
-  } catch (err: any) {
+  } catch (err) {
+    const message = errorMessage(err);
     if (args.flags.machine) {
       restoreConsole?.();
       console.log(
         formatMachineError(
           "update",
           ErrorCodes.UNKNOWN_ERROR,
-          err.message,
+          message,
           startTime,
         ),
       );
       process.exit(1);
     }
-    error(err.message);
+    error(message);
     process.exit(1);
   }
 }

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -8,6 +8,7 @@ import {
 } from "../utils/machine";
 
 import { error } from "./shared";
+import { errorMessage } from "../utils/errors";
 import type { ParsedArgs } from "../cli";
 
 function printPublishHelp() {
@@ -146,14 +147,15 @@ export async function cmdPublish(args: ParsedArgs) {
         ansi.dim("The registry maintainers will review your submission."),
       );
     }
-  } catch (err: any) {
+  } catch (err) {
+    const message = errorMessage(err);
     if (args.flags.machine) {
       restoreConsole?.();
       console.log(
         formatMachineError(
           "publish",
           ErrorCodes.PUBLISH_FAILED,
-          err.message,
+          message,
           startTime,
         ),
       );
@@ -166,7 +168,7 @@ export async function cmdPublish(args: ParsedArgs) {
             success: false,
             manifest: null,
             pr_url: null,
-            error: err.message,
+            error: message,
             security_verdict: null,
           },
           null,
@@ -175,7 +177,7 @@ export async function cmdPublish(args: ParsedArgs) {
       );
       process.exit(1);
     }
-    error(err.message);
+    error(message);
     process.exit(1);
   }
 }

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -13,6 +13,7 @@ import { resolve } from "path";
 import type { Scope } from "../utils/types";
 
 import { error, readLine } from "./shared";
+import { errorMessage } from "../utils/errors";
 import type { ParsedArgs } from "../cli";
 
 function printUninstallHelp() {
@@ -118,16 +119,17 @@ export async function cmdUninstall(args: ParsedArgs) {
       undefined,
       relocationInfo?.needed ? relocationInfo : undefined,
     );
-  } catch (err: any) {
+  } catch (err) {
     // executeRemoval throws when a relocation rename/EXDEV-fallback fails.
     // Surface any partial log entries (including the failure message it
     // pushed before throwing) so the user sees what happened, then exit
     // non-zero — don't print "Done." for a half-finished uninstall.
-    const partialLog: string[] = Array.isArray(err?.log) ? err.log : [];
+    const rawLog = (err as { log?: unknown } | null)?.log;
+    const partialLog: string[] = Array.isArray(rawLog) ? rawLog : [];
     for (const entry of partialLog) {
       console.error(entry);
     }
-    error(err?.message || "Uninstall failed.");
+    error(errorMessage(err) || "Uninstall failed.");
     process.exit(1);
   }
   for (const entry of log) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -330,8 +330,8 @@ export async function loadConfig(): Promise<AppConfig> {
   let raw: string;
   try {
     raw = await readFile(configPath, "utf-8");
-  } catch (err: any) {
-    if (err?.code === "ENOENT") {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       // Config doesn't exist — silently use defaults
       debug("config: using defaults (file not found)");
       const config = getDefaultConfig();

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -21,6 +21,7 @@ import { readLock } from "./utils/lock";
 import { REGISTRY_INDEX_URL } from "./registry";
 import { buildShadowingReport } from "./utils/path-shadowing";
 import type { AppConfig, LockFile } from "./utils/types";
+import { errorMessage } from "./utils/errors";
 
 const execFileAsync = promisify(execFile);
 
@@ -153,9 +154,10 @@ export async function checkGhAuthenticated(
       status: "pass",
       message: user,
     };
-  } catch (err: any) {
+  } catch (err) {
     // gh auth status outputs to stderr on failure
-    const stderr = err?.stderr ?? "";
+    const rawStderr = (err as { stderr?: unknown } | null)?.stderr;
+    const stderr = typeof rawStderr === "string" ? rawStderr : "";
     const userMatch = stderr.match(/Logged in to .+ account (\S+)/);
     if (userMatch) {
       return {
@@ -291,8 +293,8 @@ export async function checkConfigValid(): Promise<CheckResult> {
       status: "pass",
       message: "OK",
     };
-  } catch (err: any) {
-    if (err?.code === "ENOENT") {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       return {
         name: "Config file valid",
         status: "pass",
@@ -356,8 +358,8 @@ export async function checkLockFileIntegrity(): Promise<CheckResult> {
       status: "pass",
       message: `${entries.length} skills tracked`,
     };
-  } catch (err: any) {
-    if (err?.code === "ENOENT") {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       return {
         name: "Lock file integrity",
         status: "pass",
@@ -591,11 +593,11 @@ export async function checkNoPathShadowing(): Promise<CheckResult> {
       message: `resolved ${resolved.path}, shadowed ${firstShadow}${extra}`,
       fix: `Remove the shadowed install at ${firstShadow} (e.g. \`npm uninstall -g agent-skill-manager\`) and keep ${resolved.path}.`,
     };
-  } catch (err: any) {
+  } catch (err) {
     return {
       name: "No PATH shadowing",
       status: "warn",
-      message: `Could not scan PATH: ${err?.message ?? err}`,
+      message: `Could not scan PATH: ${errorMessage(err)}`,
     };
   }
 }

--- a/src/eval/providers/skill-best-practice/v1/index.ts
+++ b/src/eval/providers/skill-best-practice/v1/index.ts
@@ -9,6 +9,7 @@ import type {
   Finding,
   SkillContext,
 } from "../../../types";
+import { errorMessage } from "../../../../utils/errors";
 
 const PROVIDER_ID = "skill-best-practice";
 const PROVIDER_VERSION = "1.2.0";
@@ -142,14 +143,14 @@ async function validate(ctx: SkillContext): Promise<{
   let parsed: unknown;
   try {
     parsed = parseYaml(frontmatterBlock);
-  } catch (err: any) {
+  } catch (err) {
     pushCheck(
       checks,
       "invalid-yaml",
       "Frontmatter parses as YAML",
       false,
       "error",
-      `Invalid YAML in frontmatter: ${err?.message ?? String(err)}`,
+      `Invalid YAML in frontmatter: ${errorMessage(err)}`,
     );
     const raw = buildRaw(ctx, checks, null);
     return {

--- a/src/health.ts
+++ b/src/health.ts
@@ -2,6 +2,7 @@ import { readFile } from "fs/promises";
 import { join } from "path";
 import { parse as parseYaml } from "yaml";
 import type { SkillInfo, SkillWarning } from "./utils/types";
+import { errorMessage } from "./utils/errors";
 
 const HIGH_FILE_COUNT_THRESHOLD = 500;
 
@@ -48,8 +49,8 @@ function validateYamlFrontmatter(content: string): string | null {
   try {
     parseYaml(raw);
     return null;
-  } catch (err: any) {
-    return err.message || "invalid YAML";
+  } catch (err) {
+    return errorMessage(err) || "invalid YAML";
   }
 }
 

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -15,6 +15,7 @@ import { scanAllSkills } from "./scanner";
 import { unifiedDiff } from "./evaluator";
 import { BINARY_EXTENSIONS, MAX_FILE_SIZE, createDirSymlink } from "./utils/fs";
 import { debug } from "./logger";
+import { errorMessage } from "./utils/errors";
 import type {
   ExportManifest,
   ExportedSkill,
@@ -91,11 +92,11 @@ export async function readManifestFile(
   let raw: string;
   try {
     raw = await readFile(filePath, "utf-8");
-  } catch (err: any) {
-    if (err?.code === "ENOENT") {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       throw new Error(`Manifest file not found: ${filePath}`, { cause: err });
     }
-    throw new Error(`Failed to read manifest file: ${err.message}`, {
+    throw new Error(`Failed to read manifest file: ${errorMessage(err)}`, {
       cause: err,
     });
   }
@@ -554,13 +555,13 @@ export async function importSkills(
             path: targetDir,
             conflict,
           });
-        } catch (err: any) {
+        } catch (err) {
           results.push({
             skillName: skill.name,
             provider: skill.provider,
             scope: skill.scope,
             status: "failed",
-            reason: `Copy failed: ${err.message}`,
+            reason: `Copy failed: ${errorMessage(err)}`,
             conflict,
           });
         }
@@ -684,13 +685,13 @@ export async function importSkills(
         status: "installed",
         path: targetDir,
       });
-    } catch (err: any) {
+    } catch (err) {
       results.push({
         skillName: skill.name,
         provider: skill.provider,
         scope: skill.scope,
         status: "failed",
-        reason: `Copy failed: ${err.message}`,
+        reason: `Copy failed: ${errorMessage(err)}`,
       });
     }
   }

--- a/src/ingester.ts
+++ b/src/ingester.ts
@@ -19,6 +19,7 @@ import {
   mergeRepoBundles,
 } from "./repo-bundles";
 import { estimateTokenCount } from "./utils/token-count";
+import { errorMessage } from "./utils/errors";
 import { evaluateSkillContent, runWithConcurrency } from "./evaluator";
 import { getEvalProviders } from "./eval/builtins";
 import { runProvider } from "./eval/runner";
@@ -57,8 +58,8 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
   let source: ParsedSource;
   try {
     source = parseSource(sourceInput);
-  } catch (err: any) {
-    return { success: false, repoIndex: null, error: err.message };
+  } catch (err) {
+    return { success: false, repoIndex: null, error: errorMessage(err) };
   }
 
   if (source.isLocal) {
@@ -72,8 +73,8 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
 
   try {
     assertNoParentSegments(source, sourceInput);
-  } catch (err: any) {
-    return { success: false, repoIndex: null, error: err.message };
+  } catch (err) {
+    return { success: false, repoIndex: null, error: errorMessage(err) };
   }
 
   debug(`ingester: cloning ${source.owner}/${source.repo}`);
@@ -251,8 +252,8 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
     debug(`ingester: wrote index to ${outputFile}`);
 
     return { success: true, repoIndex };
-  } catch (err: any) {
-    return { success: false, repoIndex: null, error: err.message };
+  } catch (err) {
+    return { success: false, repoIndex: null, error: errorMessage(err) };
   } finally {
     if (tempDir) {
       await cleanupTemp(tempDir);

--- a/src/repo-bundles.ts
+++ b/src/repo-bundles.ts
@@ -359,7 +359,7 @@ function normalizeExplicitBundle(
   relPath: string,
 ): RepoBundleManifest | null {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
-  const obj = raw as Record<string, any>;
+  const obj = raw as Record<string, unknown>;
   const rawSkills = Array.isArray(obj.skills) ? obj.skills : [];
   if (rawSkills.length === 0) return null;
 
@@ -373,7 +373,7 @@ function normalizeExplicitBundle(
         }
         if (!entry || typeof entry !== "object" || Array.isArray(entry))
           return null;
-        const skill = entry as Record<string, any>;
+        const skill = entry as Record<string, unknown>;
         const name = typeof skill.name === "string" ? skill.name : "";
         if (!name) return null;
         const match = byName.get(name);
@@ -507,8 +507,10 @@ export async function discoverExplicitRepoBundles(
   const candidates = await readBundleCandidates(repoRoot);
 
   for (const candidate of candidates) {
-    const data = candidate.data as any;
-    const bundleInputs = Array.isArray(data?.bundles) ? data.bundles : [data];
+    const data = candidate.data as { bundles?: unknown } | null;
+    const bundleInputs: unknown[] = Array.isArray(data?.bundles)
+      ? data.bundles
+      : [data];
     for (const input of bundleInputs) {
       const bundle = normalizeExplicitBundle(
         input,

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -244,7 +244,7 @@ function buildScanLocations(config: AppConfig, scope: Scope): ScanLocation[] {
 
 export async function countFiles(dir: string): Promise<number> {
   try {
-    const entries = await readdir(dir, { recursive: true } as any);
+    const entries = await readdir(dir, { recursive: true });
     return entries.length;
   } catch {
     return 0;

--- a/src/security-auditor.ts
+++ b/src/security-auditor.ts
@@ -10,6 +10,7 @@ import type {
   SecurityAuditReport,
   SecurityVerdict,
 } from "./utils/types";
+import { errorMessage } from "./utils/errors";
 
 // ─── Code Scan Patterns ─────────────────────────────────────────────────────
 
@@ -318,8 +319,8 @@ export async function analyzeSource(
     debug(
       `security-audit: source analysis for ${owner} -> repos=${result.publicRepos}, org=${result.isOrganization}, age=${result.accountAge}`,
     );
-  } catch (err: any) {
-    result.fetchError = err.message || "Failed to fetch GitHub profile";
+  } catch (err) {
+    result.fetchError = errorMessage(err) || "Failed to fetch GitHub profile";
     debug(`security-audit: source analysis failed -> ${result.fetchError}`);
   }
 

--- a/src/skill-state.ts
+++ b/src/skill-state.ts
@@ -41,8 +41,8 @@ export async function loadSkillState(path?: string): Promise<SkillStateFile> {
   let raw: string;
   try {
     raw = await readFile(statePath, "utf-8");
-  } catch (err: any) {
-    if (err?.code === "ENOENT") {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       debug("skill-state: file not found, returning empty state");
       return emptyState();
     }

--- a/src/skill-tags.ts
+++ b/src/skill-tags.ts
@@ -39,8 +39,9 @@ export async function loadSkillTagState(
   let raw: string;
   try {
     raw = await readFile(statePath, "utf-8");
-  } catch (error: any) {
-    if (error?.code === "ENOENT") return emptySkillTagState();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT")
+      return emptySkillTagState();
     throw error;
   }
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -22,7 +22,7 @@ import type {
 export async function dirSize(dirPath: string): Promise<number> {
   let total = 0;
   try {
-    const entries = await readdir(dirPath, { recursive: true } as any);
+    const entries = await readdir(dirPath, { recursive: true });
     const statPromises = entries.map(async (entry) => {
       try {
         const s = await stat(join(dirPath, entry));

--- a/src/utils/checkbox-picker.ts
+++ b/src/utils/checkbox-picker.ts
@@ -260,7 +260,7 @@ export async function checkboxPicker(
 
   const output = process.stderr;
   const input = process.stdin;
-  const width = (output as any).columns || 80;
+  const width = output.columns || 80;
 
   // Enable raw mode
   if (typeof input.setRawMode === "function") {

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "vitest";
+
+import { errorMessage } from "./errors";
+
+describe("errorMessage", () => {
+  test("returns .message for Error instances", () => {
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  test("returns .message for error subclasses", () => {
+    expect(errorMessage(new TypeError("bad type"))).toBe("bad type");
+  });
+
+  test("reads .message off error-like plain objects", () => {
+    expect(errorMessage({ message: "oops", code: "ENOENT" })).toBe("oops");
+  });
+
+  test("stringifies a thrown string as itself", () => {
+    expect(errorMessage("plain failure")).toBe("plain failure");
+  });
+
+  test("falls back to String(err) when .message is missing", () => {
+    expect(errorMessage({ code: "ENOENT" })).toBe("[object Object]");
+  });
+
+  test("stringifies nullish thrown values", () => {
+    expect(errorMessage(null)).toBe("null");
+    expect(errorMessage(undefined)).toBe("undefined");
+  });
+
+  test("stringifies a non-string .message like err?.message in a template", () => {
+    expect(errorMessage({ message: 42 })).toBe("42");
+  });
+
+  test("keeps an empty-string .message verbatim", () => {
+    expect(errorMessage(new Error())).toBe("");
+  });
+});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,10 @@
+/**
+ * Extract a display message from a thrown value of unknown shape — the typed
+ * equivalent of `err?.message ?? String(err)`: a `.message` property is used
+ * verbatim (Error instance or error-like object); anything else falls back to
+ * stringifying the value itself.
+ */
+export function errorMessage(err: unknown): string {
+  const message = (err as { message?: unknown } | null)?.message;
+  return message == null ? String(err) : String(message);
+}

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -83,8 +83,8 @@ async function readLockFile(lockPath: string): Promise<LockFile> {
   let raw: string;
   try {
     raw = await readFile(lockPath, "utf-8");
-  } catch (err: any) {
-    if (err?.code === "ENOENT") {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       debug("lock: file not found, returning empty lock");
       return createEmptyLock();
     }


### PR DESCRIPTION
Closes #675

## Summary

Eliminates every `any` type annotation/assertion in product source under `src/` — all 51 sites matched by the acceptance-criteria grep plus 2 additional `Record<string, any>` sites in `src/repo-bundles.ts` (53 total across 26 files). The overwhelming pattern was `catch (err: any)`; under `strict` mode a bare `catch (err)` binds `unknown`, so each site now narrows explicitly. A new shared `errorMessage(err: unknown)` helper in `src/utils/errors.ts` preserves the exact `err?.message ?? String(err)` semantics (reads `.message` off Error or error-like objects, stringifies everything else); ENOENT checks use the repo's existing `(err as NodeJS.ErrnoException | null)?.code` idiom; `readdir({ recursive: true })` and `process.stderr.columns` needed no cast at all under `@types/node` 26.

## Approach

Option 2 — Balanced: replace all 53 sites (the 51-site AC floor plus the 2 `Record<string, any>` sites the floor regex misses), one shared helper for the dominant `.message` pattern, existing repo idioms elsewhere, runtime behavior preserved.

## Decision Record

- **Root cause:** `catch (err: any)` annotations and a handful of `as any` casts accumulated before/around `useUnknownInCatchVariables` adoption, erasing type safety on error paths and JSON parsing.
- **Options considered:** Option 1 — Minimal (AC floor only, leave `Record<string, any>`); Option 2 — Balanced (all 53 sites, shared `errorMessage` helper, existing idioms); Option 3 — Comprehensive (also sweep ~150 `as any` sites in test files).
- **Options rejected:** Option 1 — leaves `any` in product source, contrary to issue intent; Option 3 — test-file casts are out of scope and legitimately needed for mocks.
- **Selected option:** Option 2 — Balanced.
- **Residual risk:** `errorMessage` widens tolerance marginally at two `.includes()` checks (`bundler.ts` fallback, `bundle.ts` `--force` conflict): a raw string throw containing the needle now matches, where `(<string>).message` was `undefined`. Direction is toward the intended graceful branch; object-with-`message` tolerance is preserved exactly. A nullish throw into a catch that previously re-threw `TypeError` on `err.message` now produces `"null"`/`"undefined"` — strictly more tolerant, no crashes removed from real paths.
- **Design-confirm:** auto-selected Option 2 (complexity: medium).
- **Reproduction:** `grep -rE ': any|as any|<any>' src/ --include='*.ts' --include='*.tsx' | grep -v '.test.'` confirmed red (51 matches) → fixed → now 0 matches; `tsc --noEmit` (strict) is the standing regression gate, and `src/utils/errors.test.ts` locks the new helper's semantics.

Analyzed at: `fix/675-4-3-eliminate-any-in-product-source @ f05480b` (2026-09-12)

## Changes

| File | Change |
|------|--------|
| `src/utils/errors.ts` | new shared `errorMessage(err: unknown)` helper |
| `src/utils/errors.test.ts` | new — 8 unit tests covering Error, error-like objects, strings, nullish, non-string messages |
| `src/commands/bundle.ts` | 8 `any` sites → `unknown` catches + `errorMessage` |
| `src/commands/install-run.ts` | 5 sites → `unknown` catches; `ErrnoException` casts for `code`; `duplicates` prop narrowed |
| `src/doctor.ts` | 4 sites → `unknown` catches; `stderr` narrowed via typeof; `ErrnoException` casts |
| `src/commands/eval.ts` | 4 sites → `errorMessage` |
| `src/bundler.ts` | 4 sites → `ErrnoException` casts + `errorMessage().includes()` |
| `src/ingester.ts` | 3 sites → `errorMessage` |
| `src/importer.ts` | 3 sites → `ErrnoException` cast + `errorMessage` |
| `src/repo-bundles.ts` | `Record<string, any>` → `Record<string, unknown>` (×2); `data as any` → `{ bundles?: unknown } \| null` |
| `src/stats.ts`, `src/scanner.ts` | `readdir({ recursive: true })` cast removed — typed by `@types/node` |
| `src/utils/checkbox-picker.ts` | `(output as any).columns` → `output.columns` (`tty.WriteStream`) |
| `src/commands/uninstall.ts` | `err?.log` narrowed via `{ log?: unknown }`; `errorMessage` |
| `src/commands/get.ts` | `err?.message \|\| String(err)` → `errorMessage(err) \|\| String(err)` (empty-string fallback preserved) |
| `src/commands/publish.ts`, `src/commands/audit.ts`, `src/commands/outdated-update.ts`, `src/commands/export-import.ts` | `err.message` → shared `errorMessage(err)` |
| `src/commands/activate.ts` | dropped `: any`; existing `instanceof Error` narrowing already safe |
| `src/commands/uninstall.ts` / `src/skill-state.ts` / `src/skill-tags.ts` / `src/utils/lock.ts` / `src/config.ts` | `err?.code === "ENOENT"` → `NodeJS.ErrnoException` cast |
| `src/eval/providers/skill-best-practice/v1/index.ts`, `src/security-auditor.ts`, `src/health.ts` | `err?.message`/`err.message` → `errorMessage(err)` |

## Test Results

- Unit tests: 2894 passed (94 files) — 2886 baseline + 8 new `errors.test.ts` tests
- Integration tests: covered by the same vitest suite (in-process CLI dispatch tests)
- E2e tests: skipped — `tests/e2e/` not in `npm test` scope (unchanged)
- Build: passed (`tsc --noEmit` exit 0; `eslint src/` exit 0)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `grep -rE ': any\|as any\|<any>' src/ --include='*.ts' --include='*.tsx' \| grep -v '.test.'` → 0 | pass | Verified red (51 matches) → fixed → 0 matches; broader `\bany\b` sweep also clean (only prose strings/comments remain) |
| `npm run typecheck` exits 0 | pass | `tsc --noEmit` exit 0 on final tree |
| `CI=true npm test` passes at 2793/2793 (baseline-green holds) | pass | 2894/2894 — baseline grew to 2886 via merged #673/#695/#697 work, +8 new helper tests; the literal 2793 figure in the plan is stale, intent (suite green at current baseline) holds |

<!-- gitissue:qa v1 head=f05480bfd96f2491d14425ea398d5dccec2f1c2a profile=full cycles=1 review=clean tests=2894@f05480bfd96f2491d14425ea398d5dccec2f1c2a ui=none -->
