### PR TITLE
fix(ci): add patch-ts6 --check tripwire and removal tracking (#676)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Patch TS 6 for typescript-eslint
         run: node scripts/patch-ts6.cjs
 
+      - name: Verify TS 6 patch applied
+        run: node scripts/patch-ts6.cjs --check
+
       - name: Lint src/
         run: npm run lint
 
@@ -58,6 +61,9 @@ jobs:
       - name: Patch TS 6 for typescript-eslint
         run: node scripts/patch-ts6.cjs
 
+      - name: Verify TS 6 patch applied
+        run: node scripts/patch-ts6.cjs --check
+
       - name: Run unit tests
         run: npx vitest run src/
 
@@ -81,6 +87,9 @@ jobs:
 
       - name: Patch TS 6 for typescript-eslint
         run: node scripts/patch-ts6.cjs
+
+      - name: Verify TS 6 patch applied
+        run: node scripts/patch-ts6.cjs --check
 
       - name: Audit production dependencies
         timeout-minutes: 3
@@ -107,6 +116,9 @@ jobs:
 
       - name: Patch TS 6 for typescript-eslint
         run: node scripts/patch-ts6.cjs
+
+      - name: Verify TS 6 patch applied
+        run: node scripts/patch-ts6.cjs --check
 
       - name: Build
         run: npm run build

--- a/scripts/patch-ts6.cjs
+++ b/scripts/patch-ts6.cjs
@@ -8,26 +8,30 @@
  * This script creates a nested `node_modules/typescript` symlink inside each
  * package that does `require("typescript")`, pointing to
  * `@typescript/typescript6`. It is idempotent and safe to re-run.
+ *
+ * Tripwire: `--check` verifies the patch actually applied and exits 1 with an
+ * actionable message when a nested link is missing or points at the wrong
+ * target — CI runs it right after every patch step so a silently skipped
+ * patch fails loudly instead of surfacing as an opaque lint error.
+ *
+ * Tracked for removal: https://github.com/luongnv89/asm/issues/699
+ * Delete this file once typescript-eslint supports TypeScript 7 natively.
  */
-const { resolve, join } = require("node:path");
+const { resolve, join, relative } = require("node:path");
 const {
   symlinkSync,
   mkdirSync,
   existsSync,
   readlinkSync,
   lstatSync,
+  realpathSync,
+  readFileSync,
 } = require("node:fs");
 
-const root = resolve(__dirname, "..");
-const ts6Path = join(root, "node_modules/@typescript/typescript6");
-
-if (!existsSync(ts6Path)) {
-  console.log("patch-ts6: @typescript/typescript6 not found, skipping");
-  process.exit(0);
-}
+const TS6_PKG = "node_modules/@typescript/typescript6";
 
 // Packages that `require("typescript")` and need the TS 6 API.
-const targets = [
+const TARGETS = [
   "typescript-eslint",
   "@typescript-eslint/eslint-plugin",
   "@typescript-eslint/parser",
@@ -37,51 +41,145 @@ const targets = [
   "ts-api-utils",
 ];
 
-let patched = 0;
-for (const target of targets) {
-  const targetDir = join(root, "node_modules", target);
-  if (!existsSync(targetDir)) continue;
-
-  const nestedMods = join(targetDir, "node_modules");
-  const linkPath = join(nestedMods, "typescript");
-
-  // Skip if already a correct symlink
-  if (existsSync(linkPath)) {
-    try {
-      const existing = readlinkSync(linkPath);
-      if (existing === ts6Path || existing === "@typescript/typescript6") {
-        patched++;
-        continue;
-      }
-    } catch {
-      // Not a symlink — fall through to replace
-    }
-  }
-
-  mkdirSync(nestedMods, { recursive: true });
-  // Remove existing file/dir/symlink
-  if (existsSync(linkPath)) {
-    try {
-      const fs = require("node:fs");
-      let isDir = false;
-      try {
-        isDir = lstatSync(linkPath).isDirectory() && !readlinkSync(linkPath);
-      } catch {
-        isDir = lstatSync(linkPath).isDirectory();
-      }
-      if (isDir) {
-        fs.rmSync(linkPath, { recursive: true });
-      } else {
-        fs.unlinkSync(linkPath);
-      }
-    } catch {
-      // best effort
-    }
-  }
-  symlinkSync(ts6Path, linkPath, "dir");
-  patched++;
+// Nested `node_modules/typescript` paths for the targets actually installed
+// under `root` — mirrors the apply loop's `existsSync(targetDir)` filter.
+function expectedLinks(root) {
+  return TARGETS.filter((target) =>
+    existsSync(join(root, "node_modules", target)),
+  ).map((target) =>
+    join(root, "node_modules", target, "node_modules", "typescript"),
+  );
 }
 
-console.log(
-  `patch-ts6: patched ${patched}/${targets.length} packages to use @typescript/typescript6`,
-);
+/**
+ * Verify the patch applied under `root`: every expected nested link must
+ * resolve to @typescript/typescript6. A real directory containing a
+ * typescript@6 install (npm `overrides` materializing the alias) also counts.
+ * Returns a list of human-readable failures; empty means the patch is good.
+ */
+function checkPatch(root) {
+  const ts6Path = join(root, TS6_PKG);
+  if (!existsSync(ts6Path)) {
+    return [`${TS6_PKG} is not installed under ${root}`];
+  }
+  const ts6Real = realpathSync(ts6Path);
+  const failures = [];
+  for (const linkPath of expectedLinks(root)) {
+    const rel = relative(root, linkPath);
+    if (!existsSync(linkPath)) {
+      failures.push(`${rel}: missing`);
+      continue;
+    }
+    try {
+      if (realpathSync(linkPath) === ts6Real) continue;
+    } catch {
+      // unreadable — fall through to the version probe
+    }
+    try {
+      const version = JSON.parse(
+        readFileSync(join(linkPath, "package.json"), "utf8"),
+      ).version;
+      if (typeof version === "string" && version.split(".")[0] === "6")
+        continue;
+      failures.push(`${rel}: points at typescript@${version}`);
+    } catch {
+      failures.push(`${rel}: not a symlink to @typescript/typescript6`);
+    }
+  }
+  return failures;
+}
+
+function applyPatch(root) {
+  const ts6Path = join(root, TS6_PKG);
+
+  if (!existsSync(ts6Path)) {
+    console.log("patch-ts6: @typescript/typescript6 not found, skipping");
+    return 0;
+  }
+
+  let patched = 0;
+  for (const target of TARGETS) {
+    const targetDir = join(root, "node_modules", target);
+    if (!existsSync(targetDir)) continue;
+
+    const nestedMods = join(targetDir, "node_modules");
+    const linkPath = join(nestedMods, "typescript");
+
+    // Skip if already a correct symlink
+    if (existsSync(linkPath)) {
+      try {
+        const existing = readlinkSync(linkPath);
+        if (existing === ts6Path || existing === "@typescript/typescript6") {
+          patched++;
+          continue;
+        }
+      } catch {
+        // Not a symlink — fall through to replace
+      }
+    }
+
+    mkdirSync(nestedMods, { recursive: true });
+    // Remove existing file/dir/symlink
+    if (existsSync(linkPath)) {
+      try {
+        const fs = require("node:fs");
+        let isDir = false;
+        try {
+          isDir = lstatSync(linkPath).isDirectory() && !readlinkSync(linkPath);
+        } catch {
+          isDir = lstatSync(linkPath).isDirectory();
+        }
+        if (isDir) {
+          fs.rmSync(linkPath, { recursive: true });
+        } else {
+          fs.unlinkSync(linkPath);
+        }
+      } catch {
+        // best effort
+      }
+    }
+    symlinkSync(ts6Path, linkPath, "dir");
+    patched++;
+  }
+
+  console.log(
+    `patch-ts6: patched ${patched}/${TARGETS.length} packages to use @typescript/typescript6`,
+  );
+  return patched;
+}
+
+function main(argv) {
+  const check = argv.includes("--check");
+  const rootIdx = argv.indexOf("--root");
+  const root =
+    rootIdx !== -1 && argv[rootIdx + 1]
+      ? resolve(argv[rootIdx + 1])
+      : resolve(__dirname, "..");
+
+  if (check) {
+    const failures = checkPatch(root);
+    if (failures.length > 0) {
+      console.error("patch-ts6 --check: TS 6 patch did not apply:");
+      for (const failure of failures) {
+        console.error(`  - ${failure}`);
+      }
+      console.error(
+        "Repair with `node scripts/patch-ts6.cjs` after `npm ci`/`npm install`." +
+          " Removal tracked in https://github.com/luongnv89/asm/issues/699",
+      );
+      process.exit(1);
+    }
+    console.log(
+      `patch-ts6 --check: ${expectedLinks(root).length} nested typescript link(s) resolve to @typescript/typescript6`,
+    );
+    process.exit(0);
+  }
+
+  applyPatch(root);
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}
+
+module.exports = { checkPatch, applyPatch, expectedLinks, TARGETS };

--- a/src/patch-ts6.test.ts
+++ b/src/patch-ts6.test.ts
@@ -1,0 +1,157 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { createRequire } from "module";
+import { execFileSync } from "child_process";
+
+const SCRIPT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../scripts/patch-ts6.cjs",
+);
+
+const { checkPatch, applyPatch, TARGETS } = createRequire(import.meta.url)(
+  SCRIPT,
+) as {
+  checkPatch: (root: string) => string[];
+  applyPatch: (root: string) => number;
+  expectedLinks: (root: string) => string[];
+  TARGETS: string[];
+};
+
+let root: string;
+let ts6Dir: string;
+
+function installTs6(version = "6.0.2") {
+  mkdirSync(ts6Dir, { recursive: true });
+  writeFileSync(join(ts6Dir, "package.json"), JSON.stringify({ version }));
+}
+
+function installTarget(
+  name: string,
+  link: "symlink" | "missing" | "wrong" | "realdir",
+) {
+  const nested = join(root, "node_modules", name, "node_modules");
+  mkdirSync(nested, { recursive: true });
+  if (link === "missing") return;
+  if (link === "symlink") {
+    symlinkSync(ts6Dir, join(nested, "typescript"), "dir");
+    return;
+  }
+  const other = join(root, "node_modules", `${name}-other-ts`);
+  mkdirSync(other, { recursive: true });
+  writeFileSync(
+    join(other, "package.json"),
+    JSON.stringify({ version: link === "wrong" ? "7.0.0" : "6.0.2" }),
+  );
+  if (link === "wrong") {
+    symlinkSync(other, join(nested, "typescript"), "dir");
+  } else {
+    symlinkSync(other, join(nested, "typescript"), "dir");
+    // realdir: replace the link with a real directory holding the ts6 manifest
+    rmSync(join(nested, "typescript"));
+    mkdirSync(join(nested, "typescript"));
+    writeFileSync(
+      join(nested, "typescript", "package.json"),
+      JSON.stringify({ version: "6.0.2" }),
+    );
+  }
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "patch-ts6-"));
+  ts6Dir = join(root, "node_modules", "@typescript", "typescript6");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("patch-ts6 --check", () => {
+  test("passes when every installed target links to @typescript/typescript6", () => {
+    installTs6();
+    installTarget("typescript-eslint", "symlink");
+    installTarget("ts-api-utils", "symlink");
+    expect(checkPatch(root)).toEqual([]);
+  });
+
+  test("fails when @typescript/typescript6 is not installed", () => {
+    installTarget("typescript-eslint", "missing");
+    expect(checkPatch(root)).toEqual([
+      expect.stringContaining("typescript6 is not installed"),
+    ]);
+  });
+
+  test("fails when an expected nested link is missing", () => {
+    installTs6();
+    installTarget("typescript-eslint", "missing");
+    const failures = checkPatch(root);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("node_modules/typescript: missing");
+  });
+
+  test("fails when a nested link points at typescript@7", () => {
+    installTs6();
+    installTarget("typescript-eslint", "wrong");
+    const failures = checkPatch(root);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("typescript@7.0.0");
+  });
+
+  test("accepts a real directory containing typescript@6 (materialized override)", () => {
+    installTs6();
+    installTarget("typescript-eslint", "realdir");
+    expect(checkPatch(root)).toEqual([]);
+  });
+
+  test("ignores target packages that are not installed", () => {
+    installTs6();
+    installTarget("typescript-eslint", "symlink");
+    // every other entry in TARGETS is absent — nothing to verify for them
+    expect(checkPatch(root)).toEqual([]);
+    expect(TARGETS.length).toBeGreaterThan(2);
+  });
+});
+
+describe("patch-ts6 apply + check round-trip", () => {
+  test("applyPatch then checkPatch yields zero failures", () => {
+    installTs6();
+    mkdirSync(join(root, "node_modules", "typescript-eslint"), {
+      recursive: true,
+    });
+    expect(applyPatch(root)).toBe(1);
+    expect(checkPatch(root)).toEqual([]);
+  });
+});
+
+describe("patch-ts6 CLI", () => {
+  test("--check --root exits 0 on a patched tree", () => {
+    installTs6();
+    installTarget("typescript-eslint", "symlink");
+    const out = execFileSync("node", [SCRIPT, "--check", "--root", root], {
+      encoding: "utf-8",
+    });
+    expect(out).toContain("--check:");
+  });
+
+  test("--check --root exits 1 with an actionable message on a broken tree", () => {
+    installTs6();
+    installTarget("typescript-eslint", "missing");
+    let code = 0;
+    let stderr = "";
+    try {
+      execFileSync("node", [SCRIPT, "--check", "--root", root], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      code = (err as { status?: number }).status ?? -1;
+      stderr = String((err as { stderr?: unknown }).stderr);
+    }
+    expect(code).toBe(1);
+    expect(stderr).toContain("TS 6 patch did not apply");
+    expect(stderr).toContain("node scripts/patch-ts6.cjs");
+    expect(stderr).toContain("missing");
+  });
+});


### PR DESCRIPTION
Closes #676

## Summary

`scripts/patch-ts6.cjs` is load-bearing (4 CI call sites — the issue's `postinstall` mention is stale: `scripts/postinstall.cjs` only does PATH-shadowing and never invokes it), and its silent failure mode — `@typescript/typescript6` absent → `skipping` exit 0 — surfaces only as an opaque typescript-eslint crash in a later lint step. This PR makes the failure loud and tracks the workaround's removal:

- **Tracking issue #699**: "Remove scripts/patch-ts6.cjs once typescript-eslint supports TypeScript 7 natively" — https://github.com/luongnv89/asm/issues/699 (label `improvement`; `dim:dep` does not exist in this repo). Linked from the script's header comment. Body covers what the patch does, the typescript-eslint@8.69.0 TS7 guard, the removal checklist (script, overrides entries, `@typescript/typescript6` devDep, all 8 CI steps, test file), and the trigger (typescript-eslint release notes announcing TS7 support).
- **`--check` mode**: `node scripts/patch-ts6.cjs --check` verifies every expected nested `node_modules/typescript` link resolves to `@typescript/typescript6` (a materialized `typescript@6` directory also counts — npm `overrides` can produce that shape). Exit 1 lists each missing/mis-pointed link plus the repair command.
- **CI tripwire**: a `Verify TS 6 patch applied` step now follows each of the 4 patch steps in `.github/workflows/ci.yml` (lint, unit-tests, audit, build).
- **`--root <dir>`** for testability; `checkPatch`/`applyPatch` exported behind a `require.main` guard so the new suite exercises them without touching real `node_modules`.
- **Doctor check rejected**: `asm doctor` runs on end-user machines where the dev-repo's `node_modules` layout isn't meaningful — detecting "am I in the asm repo" is not a trivial fit for the CheckResult pattern. CI-only satisfies the AC's "CI (or asm doctor)".

## Decision Record

- **Root cause:** The patch's only failure signal was a later lint crash; nothing verified the symlinks it was created to install.
- **Options considered:** Option 1 — CI check step only (script unchanged, e.g. a workflow shell loop); Option 2 — `--check` mode in the script + CI steps; Option 3 — Option 2 plus an `asm doctor` check.
- **Options rejected:** Option 1 — duplicating the target list in YAML drifts from the script; Option 3 — doctor runs on user machines, not dev checkouts.
- **Selected option:** Option 2 — single source of truth for the expected-links list, unit-testable, loud CI failure.
- **Residual risk:** `--check` trusts `realpathSync`/package.json probing on the runner's filesystem; a half-written nested `node_modules` could still fool it — same exposure as the patch itself.
- **Design-confirm:** auto-selected Option 2 (complexity: S, light profile).
- **Reproduction:** `node scripts/patch-ts6.cjs --check --root $(mktemp -d)` exits 1 naming the missing `typescript6` install; on this repo it exits 0 (7 links verified). Regression-locked by `src/patch-ts6.test.ts` (9 tests) and the new CI steps.

Analyzed at: `fix/676-4-4-track-the-patch-ts6-workaround-for @ 9d2a950` (2026-09-12)

## Changes

| File | Change |
|------|--------|
| `scripts/patch-ts6.cjs` | `--check`/`--root` modes, `checkPatch`/`applyPatch`/`expectedLinks` exports behind `require.main` guard, header links #699 |
| `.github/workflows/ci.yml` | `Verify TS 6 patch applied` step after each of the 4 patch calls |
| `src/patch-ts6.test.ts` | new — 9 tests: happy path, missing ts6, missing link, wrong target, materialized-override dir, absent targets, apply→check round-trip, CLI exit 0/1 + message |
| Issue #699 | tracking issue for removal (label `improvement`) |

## Test Results

- Unit tests: 2903 passed (95 files) — 2894 baseline + 9 new
- Tripwire verified by unit tests against temp-dir fixture trees; also run manually on the real repo: `patch-ts6 --check: 7 nested typescript link(s) resolve to @typescript/typescript6`
- Build: `tsc --noEmit` exit 0; `eslint src/` exit 0; prettier clean
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Tracking issue exists and is linked from `patch-ts6.cjs`'s header comment | pass | https://github.com/luongnv89/asm/issues/699 — linked in header lines 17-18 of `scripts/patch-ts6.cjs` |
| CI (or `asm doctor`) fails with a clear message when the patch is missing | pass | `--check` exits 1 naming each missing/wrong link + repair command; `Verify TS 6 patch applied` steps wired in all 4 patch-calling jobs; proven by CLI tests (exit 1 + stderr assertions) |
| `CI=true npm test` passes at 2793/2793 (baseline-green holds) | pass | 2903/2903 — baseline grew to 2894 via merged #673-#675 work; literal 2793 figure is stale, intent (suite green at current baseline) holds |

<!-- gitissue:qa v1 head=9d2a95036512db6e64b0a3650f3c01667a4c0b56 profile=light cycles=1 review=clean tests=2903@9d2a95036512db6e64b0a3650f3c01667a4c0b56 ui=none -->