### PR TITLE
feat(tui): honest empty-filter message, legend, config discard, exit label (#679)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -171,6 +171,11 @@ export function App({ initialConfig }: AppProps) {
     // config identity, so no manual rescan is required here.
   }, []);
 
+  const handleConfigDiscard = useCallback(() => {
+    // q in the config view: drop in-session toggles — nothing is persisted.
+    setView("dashboard");
+  }, []);
+
   const handleConfigEditor = useCallback(async () => {
     // Exit the ink app to hand the terminal to $EDITOR, then let the process
     // die so the user re-runs asm with the updated config.
@@ -382,6 +387,7 @@ export function App({ initialConfig }: AppProps) {
             visibleCount={visibleListRows}
             termWidth={termWidth}
             hasScanned={hasScanned}
+            searchQuery={searchQuery}
           />
           <DashboardFooter
             refreshFeedback={refreshFeedback}
@@ -405,6 +411,7 @@ export function App({ initialConfig }: AppProps) {
         <ConfigView
           config={config}
           onClose={handleConfigClose}
+          onDiscard={handleConfigDiscard}
           onOpenEditor={handleConfigEditor}
         />
       )}

--- a/src/views/config.test.tsx
+++ b/src/views/config.test.tsx
@@ -40,14 +40,22 @@ describe("ConfigView", () => {
   it("renders the configuration panel with each provider row and its status", () => {
     const config = makeConfig();
     const { lastFrame } = render(
-      <ConfigView config={config} onClose={vi.fn()} onOpenEditor={vi.fn()} />,
+      <ConfigView
+        config={config}
+        onClose={vi.fn()}
+        onDiscard={vi.fn()}
+        onOpenEditor={vi.fn()}
+      />,
     );
     const frame = lastFrame() ?? "";
     expect(frame).toContain("Configuration");
     expect(frame).toContain("Claude Code");
     expect(frame).toContain("Codex");
-    expect(frame).toContain("Tools (Enter to toggle, e to edit config file):");
-    expect(frame).toContain("Enter Toggle e Edit file Esc Save & close");
+    expect(frame).toContain("Tools (Enter to toggle, e to edit file & exit):");
+    // The footer can wrap at the 72-col box width — assert fragments.
+    expect(frame).toContain("Edit file & exit");
+    expect(frame).toContain("Discard");
+    expect(frame).toContain("Save");
     // First provider enabled, second disabled.
     expect(frame).toContain("✔ ON");
     expect(frame).toContain("✘ OFF");
@@ -58,6 +66,7 @@ describe("ConfigView", () => {
       <ConfigView
         config={makeConfig()}
         onClose={vi.fn()}
+        onDiscard={vi.fn()}
         onOpenEditor={vi.fn()}
       />,
     );
@@ -69,7 +78,12 @@ describe("ConfigView", () => {
       customPaths: [{ path: "/custom/x", label: "Custom X", scope: "global" }],
     });
     const { lastFrame } = render(
-      <ConfigView config={config} onClose={vi.fn()} onOpenEditor={vi.fn()} />,
+      <ConfigView
+        config={config}
+        onClose={vi.fn()}
+        onDiscard={vi.fn()}
+        onOpenEditor={vi.fn()}
+      />,
     );
     const frame = lastFrame() ?? "";
     expect(frame).toContain("Custom Paths:");
@@ -80,7 +94,12 @@ describe("ConfigView", () => {
     const onClose = vi.fn();
     const config = makeConfig();
     const { stdin, unmount } = render(
-      <ConfigView config={config} onClose={onClose} onOpenEditor={vi.fn()} />,
+      <ConfigView
+        config={config}
+        onClose={onClose}
+        onDiscard={vi.fn()}
+        onOpenEditor={vi.fn()}
+      />,
     );
     await tick();
     // First provider starts ON; Enter flips it OFF.
@@ -102,6 +121,7 @@ describe("ConfigView", () => {
       <ConfigView
         config={makeConfig()}
         onClose={onClose}
+        onDiscard={vi.fn()}
         onOpenEditor={vi.fn()}
       />,
     );
@@ -120,6 +140,7 @@ describe("ConfigView", () => {
       <ConfigView
         config={makeConfig()}
         onClose={vi.fn()}
+        onDiscard={vi.fn()}
         onOpenEditor={vi.fn()}
       />,
     );
@@ -137,6 +158,7 @@ describe("ConfigView", () => {
       <ConfigView
         config={makeConfig()}
         onClose={vi.fn()}
+        onDiscard={vi.fn()}
         onOpenEditor={onOpenEditor}
       />,
     );
@@ -147,12 +169,59 @@ describe("ConfigView", () => {
     unmount();
   });
 
+  it("q discards in-session toggles — onDiscard fires, onClose does not", async () => {
+    const onClose = vi.fn();
+    const onDiscard = vi.fn();
+    const { stdin, unmount } = render(
+      <ConfigView
+        config={makeConfig()}
+        onClose={onClose}
+        onDiscard={onDiscard}
+        onOpenEditor={vi.fn()}
+      />,
+    );
+    await tick();
+    // Flip the first provider OFF, then discard — the save path never runs.
+    stdin.write(ENTER);
+    await tick();
+    stdin.write("q");
+    await tick();
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+    expect(onDiscard).toHaveBeenCalledWith();
+    expect(onClose).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("Esc still saves after a toggle — onClose receives the edited config", async () => {
+    const onClose = vi.fn();
+    const onDiscard = vi.fn();
+    const { stdin, unmount } = render(
+      <ConfigView
+        config={makeConfig()}
+        onClose={onClose}
+        onDiscard={onDiscard}
+        onOpenEditor={vi.fn()}
+      />,
+    );
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    stdin.write(ESC);
+    await tick();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    const emitted = onClose.mock.calls[0][0] as AppConfig;
+    expect(emitted.providers[0].enabled).toBe(false);
+    expect(onDiscard).not.toHaveBeenCalled();
+    unmount();
+  });
+
   it("passes the current edit state to onClose on Esc", async () => {
     const onClose = vi.fn();
     const { stdin, unmount } = render(
       <ConfigView
         config={makeConfig()}
         onClose={onClose}
+        onDiscard={vi.fn()}
         onOpenEditor={vi.fn()}
       />,
     );

--- a/src/views/config.tsx
+++ b/src/views/config.tsx
@@ -17,10 +17,16 @@ function providerRow(
 export interface ConfigProps {
   config: AppConfig;
   onClose: (updatedConfig: AppConfig) => void;
+  onDiscard: () => void;
   onOpenEditor: () => void;
 }
 
-export function ConfigView({ config, onClose, onOpenEditor }: ConfigProps) {
+export function ConfigView({
+  config,
+  onClose,
+  onDiscard,
+  onOpenEditor,
+}: ConfigProps) {
   const [editConfig, setEditConfig] = useState<AppConfig>(() =>
     JSON.parse(JSON.stringify(config)),
   );
@@ -60,6 +66,10 @@ export function ConfigView({ config, onClose, onOpenEditor }: ConfigProps) {
       onOpenEditor();
       return;
     }
+    if (_input === "q") {
+      onDiscard();
+      return;
+    }
     if (key.escape) {
       onClose(editConfig);
       return;
@@ -79,7 +89,7 @@ export function ConfigView({ config, onClose, onOpenEditor }: ConfigProps) {
       </Box>
       <Text color={theme.fgDim}>Config: {getConfigPath()}</Text>
       <Text color={theme.yellow}>
-        Tools (Enter to toggle, e to edit config file):
+        Tools (Enter to toggle, e to edit file &amp; exit):
       </Text>
       {editConfig.providers.map((p, i) => {
         const row = providerRow(p.label, p.global, p.enabled);
@@ -121,7 +131,10 @@ export function ConfigView({ config, onClose, onOpenEditor }: ConfigProps) {
           {editConfig.preferences.defaultSort}
         </Text>
       </Box>
-      <Text color={theme.fgDim}>Enter Toggle e Edit file Esc Save & close</Text>
+      <Text color={theme.fgDim}>
+        Enter Toggle e Edit file &amp; exit q Discard &amp; close Esc Save &amp;
+        close
+      </Text>
     </Box>
   );
 }

--- a/src/views/help.test.tsx
+++ b/src/views/help.test.tsx
@@ -46,6 +46,25 @@ describe("HelpView", () => {
     expect(frame).toContain("Quit");
   });
 
+  it("renders the glyph/column legend", () => {
+    const { lastFrame } = render(<HelpView />);
+    const frame = lastFrame() ?? "";
+
+    expect(frame).toContain("Legend");
+    // `~` name prefix marks a symlinked install.
+    expect(frame).toContain("~");
+    expect(frame).toContain("symlinked skill");
+    // Type column values.
+    expect(frame).toContain("→link");
+    expect(frame).toContain("dir");
+    // Invoke column values.
+    expect(frame).toContain("Invoke");
+    expect(frame).toContain("both");
+    expect(frame).toContain("model");
+    expect(frame).toContain("user");
+    expect(frame).toContain("none");
+  });
+
   it("renders the version string from the version module", () => {
     const { lastFrame } = render(<HelpView />);
     expect(lastFrame()).toBeTruthy();

--- a/src/views/help.tsx
+++ b/src/views/help.tsx
@@ -19,6 +19,13 @@ const KEYBINDINGS: Array<[string, string]> = [
   ["q", "Quit"],
 ];
 
+const LEGEND: Array<[string, string]> = [
+  ["~", "symlinked skill"],
+  ["→link", "Type col: symlinked"],
+  ["dir", "Type col: real directory"],
+  ["Invoke", "both · model · user · none"],
+];
+
 export function HelpView() {
   return (
     <Box
@@ -38,6 +45,17 @@ export function HelpView() {
             <Text color={theme.cyan}>{key}</Text>
           </Box>
           <Text color={theme.fg}>{action}</Text>
+        </Box>
+      ))}
+      <Box marginTop={1} justifyContent="center">
+        <Text color={theme.accent}> Legend </Text>
+      </Box>
+      {LEGEND.map(([glyph, meaning]) => (
+        <Box key={glyph} flexDirection="row">
+          <Box width={14}>
+            <Text color={theme.cyan}>{glyph}</Text>
+          </Box>
+          <Text color={theme.fg}>{meaning}</Text>
         </Box>
       ))}
       <Box marginTop={1}>

--- a/src/views/skill-list.test.tsx
+++ b/src/views/skill-list.test.tsx
@@ -53,12 +53,43 @@ describe("SkillListView row width", () => {
         visibleCount={5}
         termWidth={200}
         hasScanned={true}
+        searchQuery=""
       />,
     );
     const frame = lastFrame() ?? "";
     expect(frame).toContain("Invoke");
     // formatInvocability("model", true, false) === "model".
     expect(frame).toContain("model");
+    unmount();
+  });
+});
+
+describe("SkillListView empty state", () => {
+  const renderEmpty = (searchQuery: string) =>
+    render(
+      <SkillListView
+        skills={[]}
+        selectedIndex={0}
+        visibleCount={5}
+        termWidth={200}
+        hasScanned={true}
+        searchQuery={searchQuery}
+      />,
+    );
+
+  it("names the query when a search filter emptied the list", () => {
+    const { lastFrame, unmount } = renderEmpty("foobar");
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain('no matches for "foobar"');
+    expect(frame).not.toContain("(no skills found)");
+    unmount();
+  });
+
+  it("keeps the empty-install message when no query is active", () => {
+    const { lastFrame, unmount } = renderEmpty("");
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("(no skills found)");
+    expect(frame).not.toContain("no matches for");
     unmount();
   });
 });

--- a/src/views/skill-list.tsx
+++ b/src/views/skill-list.tsx
@@ -62,6 +62,7 @@ export interface SkillListProps {
   visibleCount: number;
   termWidth: number;
   hasScanned: boolean;
+  searchQuery: string;
 }
 
 export function SkillListView({
@@ -70,6 +71,7 @@ export function SkillListView({
   visibleCount,
   termWidth,
   hasScanned,
+  searchQuery,
 }: SkillListProps) {
   const descWidth = calcDescWidth(termWidth);
   const descHeader = descWidth > 0 ? " Description" : "";
@@ -101,7 +103,12 @@ export function SkillListView({
       <Text color={theme.fgDim}> Skills ({total})</Text>
       <Text color={theme.fgDim}>{header}</Text>
       {total === 0 && hasScanned && (
-        <Text color={theme.fgDim}> (no skills found)</Text>
+        <Text color={theme.fgDim}>
+          {" "}
+          {searchQuery
+            ? `no matches for "${searchQuery}"`
+            : "(no skills found)"}
+        </Text>
       )}
       {showTopIndicator && <Text color={theme.fgDim}> ↑ more above</Text>}
       {visible.map((s, i) => {

--- a/tests/e2e/tui-smoke.test.tsx
+++ b/tests/e2e/tui-smoke.test.tsx
@@ -58,6 +58,7 @@ describe("TUI smoke test (issue #224)", () => {
         visibleCount={5}
         termWidth={120}
         hasScanned={true}
+        searchQuery=""
       />,
     );
     expect(emptyView.lastFrame() ?? "").toContain("(no skills found)");
@@ -70,6 +71,7 @@ describe("TUI smoke test (issue #224)", () => {
         visibleCount={5}
         termWidth={120}
         hasScanned={true}
+        searchQuery=""
       />,
     );
     expect(populatedView.lastFrame() ?? "").toContain("sample-skill");


### PR DESCRIPTION
Closes #679

## Summary

Four small message-honesty fixes in the ink/React TUI:

- **(a) Filtered-empty names the query** — `SkillListView` takes a `searchQuery` prop; when a search empties the list it renders `no matches for "<q>"` instead of the misleading `(no skills found)`, which now only appears for a genuinely empty install.
- **(b) Legend in the help view** — the `?` panel gains a Legend section explaining `~` (symlinked skill), the `Type` column values (`→link` = symlinked, `dir` = real directory), and the `Invoke` column values (`both · model · user · none`). Each row is sized to fit the 44-col panel without wrapping.
- **(c) Config discard path** — `q` in the config view calls a new `onDiscard` prop that returns to the dashboard **without** `saveConfig`, so in-session toggles are dropped; `Esc` remains save-and-close. The dashboard's global `q`-to-quit handler is already inactive in the config view (`isActive: view !== "config"`), so the binding is safe.
- **(d) Editor key labeled honestly** — `handleConfigEditor` ends in `process.exit(0)` by design (the process dies after the editor closes so the user re-runs `asm`). Relaunching the TUI in-process would require unmount/re-mount plus re-entering the alternate screen around an inherited-stdio child — not trivially safe. The label now says `Edit file & exit` (hint line + footer).

## Decision Record

- **Root cause:** Three user-facing strings understated reality (generic empty message, unexplained glyphs, `Esc`-only config close, `e` labeled as if it returned to the TUI).
- **Options considered:** (d) label change vs. TUI relaunch after editor close — relaunch rejected: the handler intentionally `process.exit(0)`s after `waitUntilExit` teardown and an inherited-stdio $EDITOR child; re-entering the alt screen + re-rendering App mid-lifecycle is not trivially safe with the existing spawn code.
- **Options rejected:** list-header legend (b) — help view is the canonical reference and already reachable via `?`; a header line would consume a list row permanently.
- **Selected option:** minimal honest-labeling + discard callback; no behavior changes beyond the four fixes.
- **Residual risk:** `q` in the config view now discards — a user who habitually pressed `q` to leave must now expect no persistence (that is the point); footer line may wrap on very narrow terminals (fragments still legible).
- **Design-confirm:** auto-selected (complexity: M, full profile).
- **Reproduction:** render `SkillListView` with `skills={[]} hasScanned searchQuery="x"` → previously showed `(no skills found)`; now `no matches for "x"`. Regression-locked by the three sibling test files.

Analyzed at: `feat/679-6-1-tui-message-honesty-four-small-fixes @ 4957ba4` (2026-09-12)

## Changes

| File | Change |
|------|--------|
| `src/views/skill-list.tsx` | `searchQuery` prop; query-naming empty state |
| `src/index.tsx` | pass `searchQuery`; `handleConfigDiscard` → no-persist close |
| `src/views/help.tsx` | Legend section (`~`, `→link`/`dir`, `Invoke` values) |
| `src/views/config.tsx` | `onDiscard` prop + `q` binding; honest `e`/footer labels |
| `src/views/skill-list.test.tsx` | +2 tests (query-named empty state, unchanged true-empty) |
| `src/views/help.test.tsx` | +1 test (legend strings) |
| `src/views/config.test.tsx` | +2 tests (q discards without onClose; Esc still saves) |
| `tests/e2e/tui-smoke.test.tsx` | prop update only |

## Test Results

- Unit tests: 2908 passed (95 files) — 2903 baseline + 5 new
- `tests/e2e/tui-smoke.test.tsx` run directly: 5/5 green
- Build: `tsc --noEmit` exit 0; `eslint src/` exit 0; prettier clean
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Filtered-to-empty renders a query-naming message | pass | `skill-list.tsx` empty state; test `names the query when a search filter emptied the list` |
| Three glyphs/columns explained somewhere reachable from `?` | pass | `help.tsx` Legend; test `renders the glyph/column legend` |
| Config closeable without persisting toggles; editor key labeled with exit | pass | `onDiscard` + `q` binding; tests `q discards in-session toggles`, `Esc still saves`; `e Edit file & exit` label |
| `CI=true npm test` passes at 2793/2793 (baseline-green holds) | pass | 2908/2908 — baseline grew to 2903 via merged P3 work; stale figure, intent holds |

<!-- gitissue:qa v1 head=4957ba4c082a63bfee238e78e44f1496f2cc7bed profile=full cycles=1 review=clean tests=2908@4957ba4c082a63bfee238e78e44f1496f2cc7bed ui=code:noted@4957ba4c082a63bfee238e78e44f1496f2cc7bed -->