### PR TITLE
perf: O(1) realPath dedupe + 4-wide library update --all (#680)

### DIFF
--- a/src/auditor.test.ts
+++ b/src/auditor.test.ts
@@ -410,6 +410,86 @@ describe("detectDuplicates", () => {
     expect(report.totalDuplicateInstances).toBe(0);
   });
 
+  it("keeps the preferred winner at the first-seen slot across ≥3 same-realPath entries", () => {
+    // Regression guard for the O(1) dedupe map (#680): three skills share one
+    // realPath, interleaved with unique entries. The last preference-winner
+    // (global-scope, non-symlink) must win and stay at the first-seen slot.
+    const shared = "/home/user/.agents/skills/code-review";
+    const skills = [
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/home/user/.claude/skills/code-review",
+        realPath: shared,
+        location: "global-claude",
+        provider: "claude",
+        isSymlink: true,
+        symlinkTarget: "../../.agents/skills/code-review",
+      }),
+      makeSkill({
+        dirName: "uniq-one",
+        name: "uniq-one",
+        path: "/home/user/.agents/skills/uniq-one",
+        realPath: "/home/user/.agents/skills/uniq-one",
+        location: "global-agents",
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/home/user/.agents/skills/code-review",
+        realPath: shared,
+        location: "project-agents",
+        scope: "project",
+        provider: "agents",
+        isSymlink: false,
+      }),
+      makeSkill({
+        dirName: "uniq-two",
+        name: "uniq-two",
+        path: "/home/user/.agents/skills/uniq-two",
+        realPath: "/home/user/.agents/skills/uniq-two",
+        location: "global-agents",
+      }),
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: shared,
+        originalPath: shared,
+        realPath: shared,
+        location: "global-agents",
+        scope: "global",
+        provider: "agents",
+        isSymlink: false,
+      }),
+      // Same dirName but a different realPath — forces a Rule-1 group so the
+      // dedupe winner is observable in `instances`.
+      makeSkill({
+        dirName: "code-review",
+        name: "code-review",
+        path: "/work/repo/.agents/skills/code-review",
+        realPath: "/work/repo/.agents/skills/code-review",
+        location: "project-agents",
+        scope: "project",
+        provider: "agents",
+        isSymlink: false,
+      }),
+    ];
+    const report = detectDuplicates(skills);
+    const group = report.duplicateGroups.find(
+      (g) => g.key === "code-review" && g.reason === "same-dirName",
+    );
+    expect(group).toBeDefined();
+    // Winner is the global-scope non-symlink, holding the first-seen slot.
+    expect(group!.instances.map((i) => i.path)).toEqual([
+      "/home/user/.agents/skills/code-review",
+      "/work/repo/.agents/skills/code-review",
+    ]);
+    // The three same-realPath rows collapsed into one instance.
+    expect(group!.instances.filter((i) => i.realPath === shared)).toHaveLength(
+      1,
+    );
+  });
+
   it("still groups genuinely separate global and project copies", () => {
     const skills = [
       makeSkill({

--- a/src/auditor.ts
+++ b/src/auditor.ts
@@ -125,27 +125,26 @@ export function detectDuplicates(skills: SkillInfo[]): AuditReport {
 
   // Deduplicate skills that resolve to the same real path (e.g. symlinks).
   // Keep the non-symlink (real directory) when possible; otherwise keep the first.
-  const seenRealPaths = new Map<string, SkillInfo>();
+  const seenIndexByRealPath = new Map<string, number>();
   const deduped: SkillInfo[] = [];
   for (const s of skills) {
-    const existing = seenRealPaths.get(s.realPath);
-    if (existing) {
+    const existingIndex = seenIndexByRealPath.get(s.realPath);
+    if (existingIndex !== undefined) {
+      const existing = deduped[existingIndex];
       // Prefer the non-symlink entry
       if (s.isSymlink) continue;
       // Current is not a symlink but existing is — replace it
       if (existing.isSymlink) {
-        deduped[deduped.indexOf(existing)] = s;
-        seenRealPaths.set(s.realPath, s);
+        deduped[existingIndex] = s;
       }
       // Both non-symlinks with the same realPath — one physical install
       // (e.g. cwd === $HOME so ~/.agents/skills and ./.agents/skills collide).
       // Prefer global scope; otherwise keep the first seen instance.
       else if (s.scope === "global" && existing.scope !== "global") {
-        deduped[deduped.indexOf(existing)] = s;
-        seenRealPaths.set(s.realPath, s);
+        deduped[existingIndex] = s;
       }
     } else {
-      seenRealPaths.set(s.realPath, s);
+      seenIndexByRealPath.set(s.realPath, deduped.length);
       deduped.push(s);
     }
   }

--- a/src/library-update.ts
+++ b/src/library-update.ts
@@ -9,6 +9,7 @@ import { getLibraryLockPath, getLibrarySkillsDir } from "./config";
 
 import { parseFrontmatter } from "./utils/frontmatter";
 import { withFileMutationLock } from "./utils/atomic-file";
+import { poolAll } from "./updater-core";
 import type { LibrarySkillEntry } from "./utils/types";
 import {
   type LibraryPaths,
@@ -299,25 +300,36 @@ export async function updateLibrarySkill(
   }
 }
 
+// Each update may shell out to git / hit the GitHub remote; a small cap keeps
+// `--all` under rate limits while avoiding a fully serial pass.
+const LIBRARY_UPDATE_CONCURRENCY = 4;
+
 export async function updateLibrarySkills(
   names: string[] | null,
   paths: LibraryPaths = {},
+  _overrides?: {
+    updateLibrarySkillFn?: typeof updateLibrarySkill;
+  },
 ): Promise<LibraryUpdateSummary> {
   const lockPath = paths.lockPath ?? getLibraryLockPath();
   const lock = await readLibraryLock(lockPath);
   const selectedNames = names === null ? Object.keys(lock.skills) : names;
   const warnings: string[] = [];
-  const results: LibraryUpdateResult[] = [];
+  const updateFn = _overrides?.updateLibrarySkillFn ?? updateLibrarySkill;
 
-  for (const selectedName of selectedNames) {
-    const result = await updateLibrarySkill(selectedName, paths);
+  const results = await poolAll(
+    selectedNames,
+    LIBRARY_UPDATE_CONCURRENCY,
+    (selectedName) => updateFn(selectedName, paths),
+  );
+
+  for (const result of results) {
     if (
       result.status === "failed" &&
       result.reason?.includes('Run "asm library list"')
     ) {
       warnings.push(result.reason);
     }
-    results.push(result);
   }
 
   return {

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -74,6 +74,7 @@ import {
   updateLibrarySkill,
   updateLibrarySkills,
   writeLibraryLock,
+  type LibraryUpdateResult,
 } from "./library";
 
 function deferred<T = void>() {
@@ -1930,5 +1931,47 @@ describe("updateLibrarySkill", () => {
     ).resolves.toContain("# Old Source");
     const lock = await readLibraryLock(lockPath);
     expect(lock.skills.brainstorming.version).toBe("1.0.0");
+  });
+
+  test("update --all caps concurrency at 4 and preserves result order", async () => {
+    const names = Array.from({ length: 10 }, (_, i) => `lib-skill-${i}`);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const releaseQueue: Array<() => void> = [];
+    const stub = vi.fn(async (name: string): Promise<LibraryUpdateResult> => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      // Park the first wave until the test has observed it; later waves
+      // resolve immediately so the summary can settle.
+      if (releaseQueue.length < 4) {
+        const gate = deferred<void>();
+        releaseQueue.push(() => gate.resolve());
+        await gate.promise;
+      }
+      inFlight--;
+      return name === "lib-skill-3"
+        ? { name, status: "failed", reason: "boom" }
+        : { name, status: "skipped" };
+    });
+
+    const pending = updateLibrarySkills(
+      names,
+      { skillsDir, lockPath },
+      {
+        updateLibrarySkillFn: stub,
+      },
+    );
+    while (releaseQueue.length < 4) {
+      await new Promise((r) => setImmediate(r));
+    }
+    expect(maxInFlight).toBe(4);
+    releaseQueue.forEach((release) => release());
+    const summary = await pending;
+
+    expect(stub).toHaveBeenCalledTimes(10);
+    expect(maxInFlight).toBe(4);
+    expect(summary.results.map((r) => r.name)).toEqual(names);
+    expect(summary.failedCount).toBe(1);
+    expect(summary.skippedCount).toBe(9);
   });
 });


### PR DESCRIPTION
Closes #680

## Decision Record

- **(a) `src/auditor.ts` dedupe → index map.** The loop called `deduped.indexOf(existing)` on every realPath collision — O(n²) overall. `seenRealPaths` now maps `realPath → index` into `deduped`; lookup and in-place winner replacement are O(1). Winner semantics preserved exactly: non-symlink replaces symlink, global scope replaces non-global, and the winner occupies the first-seen slot (in-place replacement, so output order is first-seen order with preferred substitutions — same as before).
- **(b) `library update --all` → `poolAll(…, 4)`.** Reused the existing worker-pool helper `poolAll` from `src/updater-core.ts` (the same helper `asm update` uses at concurrency 5) rather than `runWithConcurrency` from `evaluator-batch.ts`, which aborts remaining work on first failure — wrong semantics here. `poolAll` preserves input-order results and lets every update complete; `updateLibrarySkill` reports failures as `status: "failed"` result objects, so per-skill failure reporting is unchanged. Cap of 4 documented in-code for git/GitHub rate-limit headroom. No new dependency.
- **Test seam.** `updateLibrarySkills` gained an optional `_overrides.updateLibrarySkillFn` parameter — the same injection pattern `updateLibrarySkill` already uses (`writeLibraryLockFn`) — because same-module lexical calls can't be spied via `vi.spyOn`.

## Acceptance criteria

| AC | Evidence |
|---|---|
| No `indexOf` inside the dedupe loop | `grep -n indexOf src/auditor.ts` → 0 matches in the file |
| Dedupe behavior unchanged | All 77 `src/auditor.test.ts` tests green; new regression test with 3 same-realPath rows interleaved with uniques asserts winner identity + first-seen slot order via group `instances` |
| `library update --all` ≤4 concurrent | New test injects a deferred-promise stub for `updateLibrarySkill`, launches 10 updates, observes in-flight max = 4 (first wave gated), all 10 complete, results in input order, 1 failure reported without aborting the rest |
| Suite green | `CI=true npm test`: **2910/2910** (2908 baseline + 2 new) across 116 files |

## Files changed

- `src/auditor.ts` — index-map dedupe (−7 lines)
- `src/library-update.ts` — `poolAll` at `LIBRARY_UPDATE_CONCURRENCY = 4` + `_overrides` seam
- `src/auditor.test.ts` — +1 regression test
- `src/library.test.ts` — +1 concurrency test

## Verification

- `npm run typecheck` clean · `npm run lint` clean (pre-commit hooks green)
- `CI=true npm test` — 2910/2910
- Branch secscan — `clean` (4 files, `policy_source: ref:origin/main`)

QA handoff marker: `review=clean tests=2910@1fb2205 ui=none`
