### PR TITLE
fix(cli): correct tag-remove output, scope default, TTY guard, inspect tags

### DIFF
--- a/src/cli-install.test.ts
+++ b/src/cli-install.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { fileURLToPath } from "url";
 import { join, dirname } from "path";
 import {
@@ -15,6 +15,7 @@ import {
 import { tmpdir } from "os";
 import { runInlineTs } from "./utils/test-spawn";
 import { runCLI, runCliInProcess, CLI_BIN } from "./cli-test-harness";
+import * as checkboxPickerMod from "./utils/checkbox-picker";
 
 // `asm install` CLI tests — split from cli.test.ts (issue #678).
 // ─── CLI integration: install ──────────────────────────────────────────────
@@ -749,6 +750,172 @@ describe("CLI integration: install --library", () => {
     expect(res.stderr).toContain("Unknown provider");
     expect(res.stdout).toBe("");
     expect(res.stderr).not.toMatch(/\n\s+at\s+/);
+  });
+
+  // Dismissing the interactive scope picker (Esc, or Enter with nothing
+  // checked) makes resolveInstallScope throw. Like `asm install`, activate
+  // and deactivate must render that as a clean "Error:" line — not a
+  // "Fatal error:" stack dump from the bin-level catch.
+  test("activate exits 1 cleanly when the scope picker is dismissed", async () => {
+    const homeDir = join(tempDir, "home");
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+
+    const librarySkillDir = join(
+      homeDir,
+      ".config",
+      "agent-skill-manager",
+      "library",
+      "skills",
+      "brainstorming",
+    );
+    await mkdir(librarySkillDir, { recursive: true });
+    await writeFile(
+      join(librarySkillDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Brainstorming\n",
+    );
+    await writeFile(
+      join(
+        homeDir,
+        ".config",
+        "agent-skill-manager",
+        "library",
+        "library-lock.json",
+      ),
+      JSON.stringify(
+        {
+          version: 1,
+          skills: {
+            brainstorming: {
+              name: "brainstorming",
+              version: "1.0.0",
+              source: "local:/existing",
+              sourceType: "local",
+              commitHash: "unknown",
+              ref: "main",
+              skillPath: "brainstorming",
+              libraryPath: librarySkillDir,
+              installedAt: "2026-01-01T00:00:00.000Z",
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    const origIsTTY = process.stdin.isTTY;
+    const pickerSpy = vi
+      .spyOn(checkboxPickerMod, "checkboxPicker")
+      .mockResolvedValue([]);
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+    try {
+      const res = await runCliInProcess(
+        ["npx", "tsx", CLI_BIN, "activate", "brainstorming", "-p", "codex"],
+        {
+          cwd: projectDir,
+          env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+        },
+      );
+
+      expect(pickerSpy).toHaveBeenCalled();
+      expect(res.exitCode).toBe(1);
+      expect(res.stderr).toContain("No scope selected. Aborting.");
+      expect(res.stderr).not.toContain("Fatal error");
+      expect(res.stderr).not.toMatch(/\n\s+at\s+/);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: origIsTTY,
+        configurable: true,
+      });
+      pickerSpy.mockRestore();
+    }
+  });
+
+  test("deactivate exits 1 cleanly when the scope picker is dismissed", async () => {
+    const homeDir = join(tempDir, "home");
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+
+    const origIsTTY = process.stdin.isTTY;
+    const pickerSpy = vi
+      .spyOn(checkboxPickerMod, "checkboxPicker")
+      .mockResolvedValue([]);
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+    try {
+      const res = await runCliInProcess(
+        ["npx", "tsx", CLI_BIN, "deactivate", "brainstorming", "-p", "codex"],
+        {
+          cwd: projectDir,
+          env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+        },
+      );
+
+      expect(pickerSpy).toHaveBeenCalled();
+      expect(res.exitCode).toBe(1);
+      expect(res.stderr).toContain("No scope selected. Aborting.");
+      expect(res.stderr).not.toContain("Fatal error");
+      expect(res.stderr).not.toMatch(/\n\s+at\s+/);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: origIsTTY,
+        configurable: true,
+      });
+      pickerSpy.mockRestore();
+    }
+  });
+
+  test("deactivate --json emits a structured error when the scope picker is dismissed", async () => {
+    const homeDir = join(tempDir, "home");
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+
+    const origIsTTY = process.stdin.isTTY;
+    const pickerSpy = vi
+      .spyOn(checkboxPickerMod, "checkboxPicker")
+      .mockResolvedValue([]);
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+    try {
+      const res = await runCliInProcess(
+        [
+          "npx",
+          "tsx",
+          CLI_BIN,
+          "deactivate",
+          "brainstorming",
+          "-p",
+          "codex",
+          "--json",
+        ],
+        {
+          cwd: projectDir,
+          env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+        },
+      );
+
+      expect(pickerSpy).toHaveBeenCalled();
+      expect(res.exitCode).toBe(1);
+      expect(JSON.parse(res.stdout)).toEqual({
+        error: "No scope selected. Aborting.",
+      });
+      expect(res.stderr).not.toContain("Fatal error");
+      expect(res.stderr).not.toMatch(/\n\s+at\s+/);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: origIsTTY,
+        configurable: true,
+      });
+      pickerSpy.mockRestore();
+    }
   });
 
   test("does not overwrite an existing library skill when only provider install exists", async () => {

--- a/src/cli-tags.test.ts
+++ b/src/cli-tags.test.ts
@@ -44,6 +44,7 @@ describe("CLI integration: local skill tags", () => {
       "testing",
       "automation",
     ]);
+    expect(JSON.parse(added.stdout)[0].applied).toEqual(["automation"]);
 
     const removed = await runCLI(
       "tag",
@@ -54,7 +55,24 @@ describe("CLI integration: local skill tags", () => {
     );
     expect(removed.exitCode).toBe(0);
     expect(JSON.parse(removed.stdout)[0].tags).toEqual(["cli", "automation"]);
+    expect(JSON.parse(removed.stdout)[0].applied).toEqual(["testing"]);
     expect(await readFile(join(skillDir, "SKILL.md"), "utf-8")).toBe(before);
+  });
+
+  test("inspect --json reflects local tag edits", async () => {
+    const added = await runCLI("tag", "add", skillName, "automation", "--json");
+    expect(added.exitCode).toBe(0);
+
+    const inspected = await runCLI("inspect", skillName, "--json");
+    expect(inspected.exitCode).toBe(0);
+    const data = JSON.parse(inspected.stdout);
+    const skill = Array.isArray(data) ? data[0] : data;
+    expect(skill.tags).toEqual(["cli", "testing", "automation"]);
+
+    const inspectedText = await runCLI("inspect", skillName);
+    expect(inspectedText.exitCode).toBe(0);
+    expect(inspectedText.stdout).toContain("Tags:");
+    expect(inspectedText.stdout).toContain("automation");
   });
 
   test("list and search accept repeatable AND tag filters", async () => {

--- a/src/commands/activate.ts
+++ b/src/commands/activate.ts
@@ -81,12 +81,19 @@ export async function cmdActivate(args: ParsedArgs) {
     args.flags.provider,
     process.stdin.isTTY,
   );
-  const scope = await resolveInstallScope({
-    scopeFlag: args.flags.scope,
-    provider,
-    isTTY: !!process.stdin.isTTY,
-    yes: args.flags.yes,
-  });
+  let scope: "global" | "project";
+  try {
+    scope = await resolveInstallScope({
+      scopeFlag: args.flags.scope,
+      provider,
+      isTTY: !!process.stdin.isTTY,
+      yes: args.flags.yes,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    error(message);
+    process.exit(1);
+  }
   const targetTemplate =
     scope === "global" ? provider.global : provider.project;
   const targetDir = resolveProviderPath(targetTemplate);
@@ -142,14 +149,13 @@ export async function cmdDeactivate(args: ParsedArgs) {
     process.exit(2);
   }
 
-  const scope = await resolveInstallScope({
-    scopeFlag: args.flags.scope,
-    provider,
-    isTTY: !!process.stdin.isTTY,
-    yes: args.flags.yes,
-  });
-
   try {
+    const scope = await resolveInstallScope({
+      scopeFlag: args.flags.scope,
+      provider,
+      isTTY: !!process.stdin.isTTY,
+      yes: args.flags.yes,
+    });
     const targetTemplate =
       scope === "global" ? provider.global : provider.project;
     const targetDir = resolveProviderPath(targetTemplate);

--- a/src/commands/activate.ts
+++ b/src/commands/activate.ts
@@ -1,6 +1,7 @@
 import { loadConfig, resolveProviderPath } from "../config";
 import { ansi } from "../formatter";
 import { resolveProvider } from "../installer";
+import { resolveInstallScope } from "../installer-link";
 import type { ProviderConfig } from "../utils/types";
 import {
   activateLibrarySkill,
@@ -19,7 +20,7 @@ Link a centrally installed library skill into a provider skill folder.
 
 ${ansi.bold("Options:")}
   -p, --tool <name>      Provider to activate into (e.g., claude, codex)
-  -s, --scope <scope>    Activation scope: global or project
+  -s, --scope <scope>    Activation scope: global or project (default: prompt)
   --name <name>          Link name to create (default: library directory name)
   -f, --force            Replace an existing target
   --json                 Output as JSON object
@@ -37,7 +38,7 @@ Remove a centrally activated library skill from a provider skill folder.
 
 ${ansi.bold("Options:")}
   -p, --tool <name>      Provider to deactivate from (e.g., claude, codex)
-  -s, --scope <scope>    Activation scope: global or project
+  -s, --scope <scope>    Deactivation scope: global or project (default: prompt)
   --json                 Output as JSON object
   -V, --verbose          Show debug output
 
@@ -61,11 +62,6 @@ export async function cmdActivate(args: ParsedArgs) {
     process.exit(2);
   }
 
-  if (args.flags.scope === "both") {
-    error("Activation requires --scope global or --scope project.");
-    process.exit(2);
-  }
-
   const rows = await listLibrarySkills();
   const skill = findLibrarySkill(rows, skillName);
   if (!skill) {
@@ -85,8 +81,14 @@ export async function cmdActivate(args: ParsedArgs) {
     args.flags.provider,
     process.stdin.isTTY,
   );
+  const scope = await resolveInstallScope({
+    scopeFlag: args.flags.scope,
+    provider,
+    isTTY: !!process.stdin.isTTY,
+    yes: args.flags.yes,
+  });
   const targetTemplate =
-    args.flags.scope === "global" ? provider.global : provider.project;
+    scope === "global" ? provider.global : provider.project;
   const targetDir = resolveProviderPath(targetTemplate);
   const activationName = args.flags.name || skill.dirName;
   const result = await activateLibrarySkill({
@@ -100,7 +102,7 @@ export async function cmdActivate(args: ParsedArgs) {
     name: activationName,
     skill: skill.dirName,
     provider: provider.name,
-    scope: args.flags.scope,
+    scope,
     path: result.symlinkPath,
     target: result.targetPath,
   };
@@ -111,7 +113,7 @@ export async function cmdActivate(args: ParsedArgs) {
   }
 
   console.log(
-    `${ansi.green("✓")} activated ${activationName} (${provider.name}/${args.flags.scope}) -> ${result.targetPath}`,
+    `${ansi.green("✓")} activated ${activationName} (${provider.name}/${scope}) -> ${result.targetPath}`,
   );
 }
 
@@ -128,11 +130,6 @@ export async function cmdDeactivate(args: ParsedArgs) {
     process.exit(2);
   }
 
-  if (args.flags.scope === "both") {
-    error("Deactivation requires --scope global or --scope project.");
-    process.exit(2);
-  }
-
   const config = await loadConfig();
   let provider: ProviderConfig;
   try {
@@ -145,15 +142,22 @@ export async function cmdDeactivate(args: ParsedArgs) {
     process.exit(2);
   }
 
+  const scope = await resolveInstallScope({
+    scopeFlag: args.flags.scope,
+    provider,
+    isTTY: !!process.stdin.isTTY,
+    yes: args.flags.yes,
+  });
+
   try {
     const targetTemplate =
-      args.flags.scope === "global" ? provider.global : provider.project;
+      scope === "global" ? provider.global : provider.project;
     const targetDir = resolveProviderPath(targetTemplate);
     const result = await deactivateLibrarySkill({
       targetDir,
       activationName: skillName,
       provider: provider.name,
-      scope: args.flags.scope,
+      scope,
     });
 
     if (args.flags.json) {

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -1,6 +1,7 @@
 import { loadConfig } from "../config";
 import { scanAllSkills } from "../scanner";
 import { formatSkillInspect, formatJSON, ansi } from "../formatter";
+import { applySkillTagState, loadSkillTagState } from "../skill-tags";
 import type { GetResult } from "../utils/types";
 
 import { error, enrichWithHealth } from "./shared";
@@ -52,6 +53,7 @@ export async function cmdInspect(args: ParsedArgs) {
   }
 
   await enrichWithHealth(matches);
+  applySkillTagState(matches, await loadSkillTagState());
 
   if (args.flags.json) {
     console.log(formatJSON(matches.length === 1 ? matches[0] : matches));

--- a/src/commands/tag.ts
+++ b/src/commands/tag.ts
@@ -89,10 +89,15 @@ export async function cmdTag(args: ParsedArgs): Promise<void> {
       action === "add"
         ? addSkillTags(state, key, skill.tags, parsedTags.tags)
         : removeSkillTags(state, key, skill.tags, parsedTags.tags);
+    const applied =
+      action === "add"
+        ? tags.filter((tag) => !before.includes(tag))
+        : before.filter((tag) => !tags.includes(tag));
     results.push({
       name: skill.name,
       path: skill.realPath,
       tags,
+      applied,
       changed: JSON.stringify(before) !== JSON.stringify(tags),
     });
   }

--- a/src/formatter-core.ts
+++ b/src/formatter-core.ts
@@ -21,6 +21,8 @@ export interface TagUpdateResult {
   name: string;
   path: string;
   tags: string[];
+  /** Tags this call actually added/removed (diff of before vs after). */
+  applied: string[];
   changed: boolean;
 }
 
@@ -31,9 +33,14 @@ export function formatTagUpdates(
   const verb = action === "add" ? "Added tags to" : "Removed tags from";
   return results
     .map((result) => {
-      const tags = result.tags.length > 0 ? result.tags.join(", ") : "(none)";
+      const applied =
+        result.applied.length > 0 ? result.applied.join(", ") : "(none)";
+      const remaining =
+        action === "remove" && result.changed
+          ? ` — now: ${result.tags.length > 0 ? result.tags.join(", ") : "(none)"}`
+          : "";
       const suffix = result.changed ? "" : " (unchanged)";
-      return `${verb} ${ansi.bold(result.name)}: ${tags}${suffix}`;
+      return `${verb} ${ansi.bold(result.name)}: ${applied}${remaining}${suffix}`;
     })
     .join("\n");
 }

--- a/src/formatter-detail.ts
+++ b/src/formatter-detail.ts
@@ -42,6 +42,9 @@ export async function formatSkillDetail(skill: SkillInfo): Promise<string> {
       formatInvocability(skill.modelInvocable, skill.userInvocable),
     ),
   );
+  if (skill.tags?.length) {
+    lines.push(label("Tags", skill.tags.join(", ")));
+  }
   lines.push(label("Tool", skill.providerLabel));
   lines.push(label("Scope", skill.scope));
   lines.push(label("Location", skill.location));
@@ -207,6 +210,9 @@ export async function formatSkillInspect(skills: SkillInfo[]): Promise<string> {
       formatInvocability(ref.modelInvocable, ref.userInvocable),
     ),
   );
+  if (ref.tags?.length) {
+    lines.push(label("  Tags", ref.tags.join(", ")));
+  }
 
   const fileCount = ref.fileCount ?? (await countFiles(ref.path));
   lines.push(label("  File Count", String(fileCount)));

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -379,10 +379,41 @@ describe("formatTagUpdates", () => {
   test("formats changed and unchanged effective tags", () => {
     expect(
       formatTagUpdates("add", [
-        { name: "review", path: "/review", tags: ["cli"], changed: true },
-        { name: "test", path: "/test", tags: [], changed: false },
+        {
+          name: "review",
+          path: "/review",
+          tags: ["cli"],
+          applied: ["cli"],
+          changed: true,
+        },
+        {
+          name: "test",
+          path: "/test",
+          tags: [],
+          applied: [],
+          changed: false,
+        },
       ]),
     ).toBe("Added tags to review: cli\nAdded tags to test: (none) (unchanged)");
+  });
+
+  test("remove shows the removed tags and the remaining set", () => {
+    expect(
+      formatTagUpdates("remove", [
+        {
+          name: "s",
+          path: "/s",
+          tags: ["testing"],
+          applied: ["e2e"],
+          changed: true,
+        },
+      ]),
+    ).toBe("Removed tags from s: e2e — now: testing");
+    expect(
+      formatTagUpdates("remove", [
+        { name: "s", path: "/s", tags: [], applied: [], changed: false },
+      ]),
+    ).toBe("Removed tags from s: (none) (unchanged)");
   });
 });
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { render } from "ink-testing-library";
 import type { SkillInfo, AppConfig, AuditReport } from "./utils/types";
@@ -494,6 +494,48 @@ describe("App container", () => {
 // waitUntilExit resolves immediately, exercising the bootstrap + restore path
 // without spawning a real interactive terminal.
 describe("main()", () => {
+  // main() refuses to start the TUI when stdin is not a TTY; vitest workers
+  // have no TTY, so the bootstrap tests must stub it.
+  const origStdinTTY = process.stdin.isTTY;
+  beforeEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+  });
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: origStdinTTY,
+      configurable: true,
+    });
+  });
+
+  it("refuses to start the TUI when stdin is not a TTY", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    const { main } = await import("./index");
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const prevExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    await main();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("requires a terminal"),
+    );
+    expect(writeSpy).not.toHaveBeenCalledWith("\u001b[?1049h");
+    expect(process.exitCode).toBe(1);
+
+    process.exitCode = prevExitCode;
+    writeSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
   it("loads config, renders the app, and restores the alt-screen buffer on exit", async () => {
     const { main } = await import("./index");
     const writeSpy = vi

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -429,6 +429,14 @@ export function App({ initialConfig }: AppProps) {
 export async function main() {
   const config = await loadConfig();
 
+  if (!process.stdin.isTTY) {
+    console.error(
+      'asm: the interactive TUI requires a terminal (stdin is not a TTY). Run "asm --help" for CLI usage.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   // Match the opentui `useAlternateScreen: true` behavior — draw the TUI in
   // the alternate screen buffer so the dashboard doesn't pollute the user's
   // shell scrollback after quit. The escape constants are module-scoped so


### PR DESCRIPTION
Closes #706

## Summary

Four fixes from the v2.20.0 end-to-end verification pass:

- **`asm tag remove`** printed the post-state tag list next to "Removed tags from", making it look like the wrong tag was removed. The formatter now shows the applied delta (`Removed tags from x: a — now: b`), with a new `applied` field on `TagUpdateResult` (additive to `--json`/`--machine` output).
- **`asm activate`/`deactivate`** hard-required `--scope`, diverging from install/link. They now use `resolveInstallScope`: explicit flag wins, non-TTY/`-y` defaults to `global`, TTY shows the picker.
- **Bare `asm` on non-TTY** dumped ink's raw-mode error after entering the alternate screen. `main()` now exits 1 with a friendly message before any escape codes are emitted.
- **`asm inspect`** ignored local `asm tag` edits. It now applies the local tag state like list/search, and both detail formatters render a `Tags:` line.

#### Test plan

- [x] `npx vitest run src/cli-tags.test.ts src/formatter.test.ts src/cli-inspect.test.ts src/index.test.tsx` — incl. new tests: remove-delta message, `applied` JSON field, inspect reflects local tags, non-TTY guard
- [x] `npx vitest run src/cli-install.test.ts src/residency.test.ts` — activate/deactivate regression sweep
- [x] Pre-push hooks: unit tests + build + node e2e — all pass
- [x] Sandboxed e2e (`HOME`/`ASM_CONFIG_DIR` isolated): `tag remove` message, `inspect --json` tags, `activate`/`deactivate` without `-s` (defaults global), `printf 'q' | asm` → friendly error, exit 1